### PR TITLE
feat: #5 add claude plugin support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "superteam",
+  "version": "0.1.0",
+  "description": "Claude Code plugin that exposes the superteam orchestration skill for issue-driven multi-agent work.",
+  "author": {
+    "name": "Patina Project",
+    "url": "https://github.com/patinaproject"
+  },
+  "homepage": "https://github.com/patinaproject/superteam",
+  "repository": "https://github.com/patinaproject/superteam",
+  "license": "MIT",
+  "keywords": ["claude", "plugin", "skills", "orchestration", "superteam"],
+  "skills": "./skills"
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+# Pull Request
+
+PR title rule for squash merges: use the exact commitlint/commitizen format for the PR title so the squash commit can be reused unchanged.
+
+`type: #123 short description`
+
+Examples:
+- `docs: #12 add superteam skill guide`
+- `chore: #34 bootstrap commit hooks`
+
+## Summary
+
+- 
+
+## Linked Issue
+
+- 
+
+## Validation
+
+- 
+
+## Docs Updated
+
+- [ ] Not needed
+- [ ] Updated in this PR

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,9 +16,19 @@ Examples:
 
 - 
 
+## Acceptance Criteria
+
+### AC-<issue>-<n>
+Short outcome summary.
+
+- [ ] `verification command`
+
+### AC-<issue>-<n>
+Deferred to `<repo-or-follow-up>`.
+
 ## Validation
 
-- 
+- Additional validation not tied to a single AC, if any
 
 ## Docs Updated
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,11 @@ For squash-and-merge workflows, PR titles must exactly match the commitlint and 
 Use the final intended squash commit title as the PR title. Examples:
 - `docs: #12 add superteam skill guide`
 - `chore: #34 bootstrap commit hooks`
+
+When an issue defines acceptance criteria, include an `Acceptance Criteria` section in the PR description.
+
+- Use one `### AC-<issue>-<n>` heading per relevant AC, with the heading containing only the AC ID.
+- Put a short outcome summary on the line below the heading.
+- Put verification steps directly under the AC they validate.
+- Use checkboxes only for testing or verification steps.
+- If an AC is deferred or out of scope for the repo, say so in the summary text and do not add fake verification checkboxes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,11 @@ Examples:
 Scopes like `feat(repo): ...` are rejected. Keep the subject within 72 characters.
 
 Pull requests should include a short summary, linked issue, validation notes, and any updated docs when structure or workflow changes.
+
+For squash-and-merge workflows, PR titles must exactly match the commitlint and commitizen commit format:
+
+`type: #123 short description`
+
+Use the final intended squash commit title as the PR title. Examples:
+- `docs: #12 add superteam skill guide`
+- `chore: #34 bootstrap commit hooks`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,24 @@ This repository is organized around reusable skill packages and supporting docum
 
 - `skills/`: installable skill directories. Each skill should live in its own folder, for example `skills/superteam/`.
 - `plugins/`: Codex plugin packages, for example `plugins/superteam/.codex-plugin/plugin.json`.
+- If `.claude-plugin/plugin.json` exists, the repository root is the Claude plugin install surface.
 - `docs/`: contributor-facing docs plus planning artifacts such as `docs/file-structure.md` and `docs/superpowers/plans/`.
 - `.agents/plugins/marketplace.json`: repo-local plugin catalog for Codex discovery.
 - root config: `package.json`, `commitlint.config.js`, and `.husky/` define local tooling and commit enforcement.
 
 Keep each skill self-contained. Prefer adjacent support files like `agent-spawn-template.md` or `pr-body-template.md` over hidden tool-specific wrappers unless a runtime requires them.
+
+For Superpowers-generated design and planning artifacts, use the current git branch name as the topic slug. Name files as:
+
+- `docs/superpowers/specs/YYYY-MM-DD-<branch-name>-design.md`
+- `docs/superpowers/plans/YYYY-MM-DD-<branch-name>-plan.md`
+
+Use human-readable H1 titles inside those files:
+
+- Design docs: `# Design: <exact issue title> [#<issue>](<issue-url>)`
+- Plan docs: `# Plan: <exact issue title> [#<issue>](<issue-url>)`
+
+Format acceptance criteria IDs as `AC-<issue-number>-<integer>`, for example `AC-5-1`.
 
 ## Build, Test, and Development Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Instructions
+
+See [AGENTS.md](./AGENTS.md) for the repository instructions and contributor workflow.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
-# skills
+# Superteam
 
 Agentic engineering skills from the Patina Project team.
 
-This repo is the source of truth for the `superteam` Codex plugin and its bundled skill.
+This repo exposes two install surfaces for the same `superteam` skill.
 
-## Plugin packaging
+## Install Surfaces
 
-- Author the skill in `skills/superteam/`.
-- Publish the install surface from `plugins/superteam/`.
-- Refresh the packaged plugin with `pnpm sync:plugin` before pushing marketplace-facing changes.
-- Downstream marketplaces should consume `plugins/superteam/` rather than the authoring path under `skills/`.
+- The repository root is the Claude Code plugin surface discovered via `.claude-plugin/plugin.json`.
+- `plugins/superteam/` is the packaged Codex install surface.
+- Author the skill in `skills/superteam/`, then refresh the packaged plugin with `pnpm sync:plugin` before publishing Codex-facing changes.
+
+## Local Development
+
+Use the repository root as the Claude plugin directory during local testing:
+
+```bash
+claude --plugin-dir .
+```
+
+The skill is exposed as `/superteam:superteam` once the plugin is loaded.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -4,8 +4,9 @@ This repository keeps source skills in `skills/`, packaged plugin content in `pl
 
 ## Top level
 
+- `.claude-plugin/`: Claude Code plugin manifest for the repository root
 - `skills/`: installable or shareable skill packages
-- `plugins/`: Codex plugin packages with `.codex-plugin/plugin.json`
+- `plugins/`: plugin packages for external install surfaces
 - `docs/`: repository docs, design docs, and planning artifacts
 - `.agents/plugins/marketplace.json`: local plugin catalog for Codex discovery
 - `package.json`: minimal repo tooling managed with `pnpm`
@@ -37,11 +38,17 @@ Keep skill directories self-contained. Prefer adjacent support files over hidden
 
 ## Plugins
 
-Codex-importable plugins live under `plugins/`.
+The repository supports two plugin surfaces.
+
+Claude Code loads the repository root through `.claude-plugin/plugin.json`, which points at the source skills in `./skills`.
+
+Codex consumes the packaged plugin under `plugins/superteam/`.
 
 Example:
 
 ```text
+.claude-plugin/
+  plugin.json
 plugins/
   superteam/
     .codex-plugin/
@@ -55,12 +62,13 @@ plugins/
           openai.yaml
 ```
 
-- `.codex-plugin/plugin.json`: plugin manifest and UI metadata
-- `skills/`: packaged skills exposed by the plugin
+- `.claude-plugin/plugin.json`: Claude Code manifest for the repository root
+- `.codex-plugin/plugin.json`: packaged plugin manifest and UI metadata
+- `plugins/superteam/skills/`: packaged skills exposed by the Codex plugin
 - `agents/openai.yaml`: optional skill UI metadata for Codex lists and chips
 
 Use `.agents/plugins/marketplace.json` to register repo-local plugins for Codex discovery.
-When publishing `superteam` to an external marketplace, treat `plugins/superteam/` as the install surface and `skills/superteam/` as the authoring source. Refresh the packaged copy with `pnpm sync:plugin`.
+When publishing `superteam` to an external marketplace, treat `plugins/superteam/` as the Codex install surface and `skills/superteam/` as the authoring source. Refresh the packaged copy with `pnpm sync:plugin`.
 
 ## Docs
 
@@ -73,7 +81,7 @@ docs/
   file-structure.md
   superpowers/
     plans/
-      2026-04-22-superteam-import-plan.md
+      2026-04-22-5-claude-plugin-support-able-to-be-imported-to-marketplace-plan.md
 ```
 
 - `docs/file-structure.md`: contributor-facing layout guide

--- a/docs/superpowers/plans/2026-04-22-5-claude-plugin-support-able-to-be-imported-to-marketplace-plan.md
+++ b/docs/superpowers/plans/2026-04-22-5-claude-plugin-support-able-to-be-imported-to-marketplace-plan.md
@@ -1,0 +1,231 @@
+# Plan: Claude plugin support (able to be imported to marketplace) [#5](https://github.com/patinaproject/superteam/issues/5)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `patinaproject/superteam` a valid Claude Code plugin at the repository root so it can be validated locally now and consumed by a Claude marketplace later.
+
+**Architecture:** Keep `skills/superteam/` as the source-of-truth skill payload and add a root Claude plugin manifest in `.claude-plugin/plugin.json`. Update the repo docs so contributors understand that the repository root is now the Claude-native install surface, while `plugins/superteam/` remains the packaged Codex surface.
+
+**Tech Stack:** Markdown, JSON, Claude Code plugin manifests, pnpm repo tooling
+
+---
+
+### Task 1: Add the root Claude plugin manifest
+
+**Files:**
+- Create: `.claude-plugin/plugin.json`
+- Modify: `README.md`
+- Test: Claude Code plugin validation against the repository root
+
+- [ ] **Step 1: Verify the repository root is not yet a valid Claude plugin**
+
+Run:
+
+```bash
+claude plugin validate /Users/tlmader/dev/patinaproject/superteam
+```
+
+Expected:
+- FAIL with `No manifest found in directory. Expected .claude-plugin/marketplace.json or .claude-plugin/plugin.json`
+
+- [ ] **Step 2: Create the root Claude plugin manifest**
+
+Create `.claude-plugin/plugin.json` with:
+
+```json
+{
+  "name": "superteam",
+  "description": "Claude Code plugin that exposes the superteam orchestration skill for issue-driven multi-agent work.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Patina Project"
+  },
+  "homepage": "https://github.com/patinaproject/superteam",
+  "repository": "https://github.com/patinaproject/superteam",
+  "license": "MIT",
+  "keywords": ["claude-code", "plugin", "skills", "orchestration", "superteam"],
+  "skills": "./skills"
+}
+```
+
+- [ ] **Step 3: Update the main README with Claude-native install guidance**
+
+Add a new section near the existing packaging guidance that tells readers:
+
+```md
+## Claude Code plugin
+
+This repository root is also a Claude Code plugin.
+
+- Claude Code discovers the plugin from `.claude-plugin/plugin.json`
+- The shared skill payload lives in `skills/superteam/`
+- During development, test the plugin locally with:
+
+```bash
+claude --plugin-dir .
+```
+
+Once Claude Code starts, the plugin skill is available under the plugin namespace:
+
+```text
+/superteam:superteam
+```
+
+For marketplace distribution, this repository can be referenced directly as a Claude plugin source.
+```
+
+- [ ] **Step 4: Validate the repository root after adding the manifest**
+
+Run:
+
+```bash
+claude plugin validate /Users/tlmader/dev/patinaproject/superteam
+```
+
+Expected:
+- PASS with no validation errors
+
+- [ ] **Step 5: Commit the Claude plugin manifest and README changes**
+
+Run:
+
+```bash
+git add .claude-plugin/plugin.json README.md
+git commit -m "feat: #5 add claude plugin manifest"
+```
+
+### Task 2: Document the dual install surfaces for contributors
+
+**Files:**
+- Modify: `docs/file-structure.md`
+- Modify: `AGENTS.md`
+- Test: `README.md`, `docs/file-structure.md`, and `AGENTS.md` all describe the same naming and install model
+
+- [ ] **Step 1: Add the Claude plugin root to the file-structure guide**
+
+Update `docs/file-structure.md` so the top-level section includes:
+
+```md
+- `.claude-plugin/`: Claude Code plugin manifest for direct install and marketplace import
+```
+
+Update the plugin section to explain both plugin surfaces:
+
+```md
+## Plugins
+
+- Claude-native install surface: repository root with `.claude-plugin/plugin.json`
+- Codex install surface: `plugins/superteam/` with `.codex-plugin/plugin.json`
+```
+
+Include a short example tree:
+
+```text
+.claude-plugin/
+  plugin.json
+skills/
+  superteam/
+    SKILL.md
+```
+
+- [ ] **Step 2: Keep `AGENTS.md` aligned with the new Claude plugin ownership**
+
+Add one short note to `AGENTS.md` under the structure rules:
+
+```md
+For Claude Code support in this repository, treat the repository root as the plugin install surface when `.claude-plugin/plugin.json` is present.
+```
+
+Do not remove the existing Codex packaging guidance or the branch-based spec/plan naming rule.
+
+- [ ] **Step 3: Verify the docs now reference the Claude plugin surface consistently**
+
+Run:
+
+```bash
+rg -n "claude plugin|\\.claude-plugin|plugin install surface|--plugin-dir" README.md docs/file-structure.md AGENTS.md
+```
+
+Expected:
+- matches in all three files
+- wording consistently identifies the repository root as the Claude plugin surface
+
+- [ ] **Step 4: Re-run plugin validation after doc updates**
+
+Run:
+
+```bash
+claude plugin validate /Users/tlmader/dev/patinaproject/superteam
+```
+
+Expected:
+- PASS with no validation errors
+
+- [ ] **Step 5: Commit the contributor documentation updates**
+
+Run:
+
+```bash
+git add docs/file-structure.md AGENTS.md
+git commit -m "docs: #5 document claude plugin install surface"
+```
+
+### Task 3: Verify issue-scoped acceptance criteria coverage
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-22-5-claude-plugin-support-able-to-be-imported-to-marketplace-design.md`
+- Test: repo status and document references
+
+- [ ] **Step 1: Confirm this repo-level plan is scoped to the `superteam` acceptance criteria**
+
+Check that the design doc still tracks:
+
+```text
+AC-5-1
+AC-5-2
+AC-5-3
+AC-5-4
+AC-5-5
+```
+
+And treat this implementation plan as covering:
+
+```text
+AC-5-1
+AC-5-2
+```
+
+with `AC-5-3` and `AC-5-4` deferred to `patinaproject/skills`.
+
+- [ ] **Step 2: Verify the updated spec and plan filenames follow the branch-based topic rule**
+
+Run:
+
+```bash
+find docs/superpowers -maxdepth 2 -type f | sort
+```
+
+Expected:
+- `docs/superpowers/specs/2026-04-22-5-claude-plugin-support-able-to-be-imported-to-marketplace-design.md`
+- `docs/superpowers/plans/2026-04-22-5-claude-plugin-support-able-to-be-imported-to-marketplace-plan.md`
+
+- [ ] **Step 3: Review the final working tree before handoff**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected:
+- only the issue #5 files are modified
+- no `skills` repo files are touched from this plan
+
+- [ ] **Step 4: Commit the plan and any spec-touchups needed for issue scoping**
+
+Run:
+
+```bash
+git add docs/superpowers/specs/2026-04-22-5-claude-plugin-support-able-to-be-imported-to-marketplace-design.md docs/superpowers/plans/2026-04-22-5-claude-plugin-support-able-to-be-imported-to-marketplace-plan.md
+git commit -m "docs: #5 add claude plugin support plan"
+```

--- a/docs/superpowers/specs/2026-04-22-5-claude-plugin-support-able-to-be-imported-to-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-22-5-claude-plugin-support-able-to-be-imported-to-marketplace-design.md
@@ -1,4 +1,4 @@
-# Claude Marketplace Support Design
+# Design: Claude plugin support (able to be imported to marketplace) [#5](https://github.com/patinaproject/superteam/issues/5)
 
 ## Summary
 
@@ -141,11 +141,11 @@ Both repos need explicit installation guidance:
 
 ## Acceptance Criteria
 
-- AC-1: `patinaproject/superteam` contains the Claude-native package artifacts needed for direct installation
-- AC-2: `patinaproject/superteam` documentation explains Claude-native direct installation
-- AC-3: `patinaproject/skills` marketplace metadata exposes a Claude-compatible installation route for `superteam`
-- AC-4: `patinaproject/skills` documentation explains that its marketplace entry depends on the package maintained in `patinaproject/superteam`
-- AC-5: The implementation does not create two independently maintained copies of the `superteam` package
+- AC-5-1: `patinaproject/superteam` contains the Claude-native package artifacts needed for direct installation
+- AC-5-2: `patinaproject/superteam` documentation explains Claude-native direct installation
+- AC-5-3: `patinaproject/skills` marketplace metadata exposes a Claude-compatible installation route for `superteam`
+- AC-5-4: `patinaproject/skills` documentation explains that its marketplace entry depends on the package maintained in `patinaproject/superteam`
+- AC-5-5: The implementation does not create two independently maintained copies of the `superteam` package
 
 ## Implementation Notes
 

--- a/docs/superpowers/specs/2026-04-22-claude-marketplace-support-design.md
+++ b/docs/superpowers/specs/2026-04-22-claude-marketplace-support-design.md
@@ -1,0 +1,154 @@
+# Claude Marketplace Support Design
+
+## Summary
+
+Add Claude-native installation support for the `superteam` plugin in `patinaproject/superteam`, and add marketplace support for discovering that Claude-native package through `patinaproject/skills`.
+
+The design keeps `patinaproject/superteam` as the source of truth for the actual packaged plugin, while `patinaproject/skills` remains the marketplace catalog that points users at installable plugin sources.
+
+## Goals
+
+- Make `patinaproject/superteam` directly installable through Claude-native plugin flows
+- Make `patinaproject/skills` able to advertise or route to the Claude-native install surface
+- Avoid maintaining duplicate plugin payloads across both repositories
+- Keep the existing Codex packaging intact while adding Claude-native support
+
+## Non-Goals
+
+- Reworking the existing `superteam` skill behavior
+- Changing the marketplace ownership model so `skills` becomes the package source of truth
+- Building a general plugin publishing framework for every Patina Project repository
+
+## Repositories And Ownership
+
+### `patinaproject/superteam`
+
+Owns the installable plugin package and any Claude-native metadata, structure, and install documentation required for direct installation.
+
+### `patinaproject/skills`
+
+Owns marketplace discovery metadata and documentation for installing Patina Project plugins, including the Claude-compatible install route that points at `patinaproject/superteam`.
+
+## Recommended Approach
+
+Use a single-source packaging model:
+
+- `superteam` contains the real Claude-native plugin artifacts
+- `skills` references those artifacts through marketplace metadata
+- both direct install and marketplace-driven install remain valid
+
+This avoids package drift and matches the current Codex marketplace pattern already used by `skills`.
+
+## Approach Options Considered
+
+### Option 1: Direct install only from `superteam`
+
+Pros:
+- Minimal implementation
+- One package source
+
+Cons:
+- `skills` adds little value for Claude users
+- Marketplace discovery remains incomplete
+
+### Option 2: Duplicate Claude package in both repos
+
+Pros:
+- Each repo can stand alone
+- Marketplace repo can fully vendor the package
+
+Cons:
+- High drift risk
+- More maintenance and release overhead
+
+### Option 3: Source package in `superteam`, marketplace metadata in `skills`
+
+Pros:
+- One package source of truth
+- Supports both direct install and marketplace discovery
+- Fits the existing repo split
+
+Cons:
+- Requires clear documentation of the source-of-truth boundary
+
+Selected option: Option 3.
+
+## Architecture
+
+### Package Layer
+
+`patinaproject/superteam` should gain the Claude-native package structure required for direct installation. That package should be colocated with the existing plugin assets so repository consumers can find the supported install surfaces without guessing.
+
+The package metadata should clearly identify:
+
+- plugin name
+- human-facing display text
+- repository homepage and support links
+- installable skill/artifact paths
+- any Claude-specific compatibility metadata needed by the package format
+
+### Marketplace Layer
+
+`patinaproject/skills` should extend its marketplace catalog so the `superteam` entry includes the Claude-compatible install path or source definition. The catalog should continue to reference `patinaproject/superteam` rather than carrying a second copy of the package.
+
+### Documentation Layer
+
+Both repos need explicit installation guidance:
+
+- `superteam` explains direct Claude-native installation and identifies itself as the package source of truth
+- `skills` explains marketplace-based installation and states that the underlying package is sourced from `patinaproject/superteam`
+
+## Expected File Areas
+
+### `patinaproject/superteam`
+
+- Claude-native plugin/package manifest files
+- plugin packaging docs in `README.md` and related contributor docs
+- sync or packaging scripts if the current packaging flow needs to emit Claude-native artifacts
+
+### `patinaproject/skills`
+
+- `.agents/plugins/marketplace.json`
+- `README.md`
+- optional vendored plugin metadata only if required by the Claude marketplace format
+
+## Data Flow
+
+1. Maintainers update the package in `patinaproject/superteam`
+2. Claude users may install directly from the `superteam` package source
+3. `patinaproject/skills` exposes marketplace metadata that points to the same package source
+4. Claude marketplace consumers discover `superteam` through `skills` and resolve the package from `patinaproject/superteam`
+
+## Error Handling And Constraints
+
+- If Claude-native packaging requires metadata not currently present in `superteam`, that metadata must be added there rather than synthesized in `skills`
+- If the Claude marketplace format cannot reference a remote subdirectory cleanly, the fallback is to vendor only the minimum metadata wrapper in `skills`, not the whole plugin payload
+- Documentation must make the ownership boundary explicit so future changes do not fork the package
+
+## Testing And Verification
+
+### `patinaproject/superteam`
+
+- inspect the resulting package files
+- run any existing sync or packaging command that updates published plugin contents
+- verify README instructions match the actual package paths
+
+### `patinaproject/skills`
+
+- inspect `.agents/plugins/marketplace.json`
+- verify referenced paths, refs, and repository URLs
+- verify README instructions reflect both marketplace and direct-install options
+
+## Acceptance Criteria
+
+- AC-1: `patinaproject/superteam` contains the Claude-native package artifacts needed for direct installation
+- AC-2: `patinaproject/superteam` documentation explains Claude-native direct installation
+- AC-3: `patinaproject/skills` marketplace metadata exposes a Claude-compatible installation route for `superteam`
+- AC-4: `patinaproject/skills` documentation explains that its marketplace entry depends on the package maintained in `patinaproject/superteam`
+- AC-5: The implementation does not create two independently maintained copies of the `superteam` package
+
+## Implementation Notes
+
+- Preserve existing Codex plugin support rather than replacing it
+- Keep names aligned across manifests, marketplace entries, and docs
+- Prefer small metadata additions over introducing a new build system


### PR DESCRIPTION
## Summary
- add a root `.claude-plugin/plugin.json` so the repository validates as a Claude Code plugin
- document the dual install surfaces for Claude Code at the repo root and Codex under `plugins/superteam/`
- rename the issue #5 design artifact to the branch-based slug and add the matching implementation plan artifact

## Linked Issue
- #5

## Acceptance Criteria

### AC-5-1
Root Claude plugin manifest added at the repository root.

- [x] `claude plugin validate .`

### AC-5-2
Claude-native install guidance added for the repository root and contributor docs aligned to the new install surface.

- [x] `rg -n "claude|\\.claude-plugin|plugin install surface|--plugin-dir" README.md docs/file-structure.md AGENTS.md`

### AC-5-3
Deferred to `patinaproject/skills`.

### AC-5-4
Deferred to `patinaproject/skills`.

### AC-5-5
This repo remains the single source of truth for the plugin package; the PR adds Claude-native metadata and docs without creating a second independently maintained package copy.

- [x] `find docs/superpowers -maxdepth 2 -type f | sort`

## Validation
- `rg -n "AC-5-[1-5]" docs/superpowers/specs/2026-04-22-5-claude-plugin-support-able-to-be-imported-to-marketplace-design.md docs/superpowers/plans/2026-04-22-5-claude-plugin-support-able-to-be-imported-to-marketplace-plan.md`

## Docs Updated
- [x] Updated in this PR
