### PR TITLE
docs: #7 improve the install experience for Superteam users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,10 @@ This repository is organized around reusable skill packages and supporting docum
 
 Keep each skill self-contained. Prefer adjacent support files like `agent-spawn-template.md` or `pr-body-template.md` over hidden tool-specific wrappers unless a runtime requires them.
 
-For Superpowers-generated design and planning artifacts, use the current git branch name as the topic slug. Name files as:
+For Superpowers-generated design and planning artifacts, use the issue number and issue title as the topic slug. Name files as:
 
-- `docs/superpowers/specs/YYYY-MM-DD-<branch-name>-design.md`
-- `docs/superpowers/plans/YYYY-MM-DD-<branch-name>-plan.md`
+- `docs/superpowers/specs/YYYY-MM-DD-<issue-number>-<issue-title>-design.md`
+- `docs/superpowers/plans/YYYY-MM-DD-<issue-number>-<issue-title>-plan.md`
 
 Use human-readable H1 titles inside those files:
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,14 @@ Superteam is built around explicit stage ownership, written design and plan arti
 
 - The repository root is the Claude Code plugin surface discovered via `.claude-plugin/plugin.json`.
 - `plugins/superteam/` is the packaged Codex install surface.
-- Author the skill in `skills/superteam/`, then refresh the packaged plugin with `pnpm sync:plugin` before publishing Codex-facing changes.
 
-## Claude Code setup
+## Installation
+
+### Claude Code
+
+1. Add the `patinaproject/skills` marketplace source in Claude Code before you try to install Superteam.
+2. Install or enable Superteam from that marketplace listing.
+3. Start from a GitHub issue and run Superteam in Claude Code.
 
 Use the repository root as the Claude plugin directory during local testing:
 
@@ -61,6 +66,18 @@ If you want a team-oriented runtime, enable Agent Teams in your Claude Code setu
 
 Agent Teams lets multiple agents coordinate through the staged workflow. The regular setup runs the same workflow with a single agent or subagents.
 
+### OpenAI Codex CLI
+
+1. Add the `patinaproject/skills` marketplace source in OpenAI Codex CLI before first use.
+2. Install or enable Superteam from that marketplace listing.
+3. Open the relevant GitHub issue in your working context, then invoke the `superteam` skill in OpenAI Codex CLI.
+
+### OpenAI Codex App
+
+1. Add the `patinaproject/skills` marketplace source in the OpenAI Codex app before first use.
+2. Add or enable Superteam from that marketplace listing.
+3. Open the relevant GitHub issue in the app context, then invoke the `superteam` skill in OpenAI Codex App.
+
 ## First use
 
-Start from a GitHub issue and invoke the skill. Superteam will drive the issue through design, planning, execution, review, and handoff artifacts.
+After setup in any supported tool, start from a GitHub issue and invoke Superteam. The workflow then drives the issue through design, planning, execution, review, and handoff artifacts.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,29 @@ Running multiple agents on one issue is easy to start and hard to sustain. Work 
 
 Superteam adds a disciplined workflow on top of Superpowers so agent work stays structured, reviewable, and resumable from design through finish.
 
+## How Superteam works
+
+Superteam runs one issue through a structured sequence so the next agent, or the next human, can continue from durable artifacts instead of chat history alone.
+
+```mermaid
+flowchart LR
+    A[GitHub issue] --> B[Brainstorm]
+    B --> C[Design doc]
+    C --> D[Plan]
+    D --> E[Implementation plan]
+    E --> F[Execute]
+    F --> G[Pre-push review]
+    G --> H[Finish]
+    H --> I[PR and CI follow-through]
+    I --> J[Comment handling]
+```
+
+Each stage owns specific artifacts and verification gates, so work stays understandable across handoffs instead of becoming ad hoc subagent output.
+
+## Why teams can pick up where they left off
+
+Superteam is built around explicit stage ownership, written design and plan artifacts, verification before completion, and finish-stage review follow-through. That structure gives the next agent enough context to continue intelligently instead of starting over.
+
 ## Install Surfaces
 
 - The repository root is the Claude Code plugin surface discovered via `.claude-plugin/plugin.json`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Superteam
 
-Agentic engineering skills from the Patina Project team.
+Orchestrate teams of agents with Superpowers.
 
-This repo exposes two install surfaces for the same `superteam` skill.
+Superteam turns a GitHub issue into a structured workflow that teams of agents can pick up, hand off, and continue without losing context.
+
+It works with agent teams or subagents.
+
+## The problem
+
+Running multiple agents on one issue is easy to start and hard to sustain. Work gets split across chats, design decisions get lost, and the next agent often has to rediscover what already happened.
+
+Superteam adds a disciplined workflow on top of Superpowers so agent work stays structured, reviewable, and resumable from design through finish.
 
 ## Install Surfaces
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,15 @@ Superteam is built around explicit stage ownership, written design and plan arti
 
 ## Installation
 
+Install Superpowers first by following the setup instructions in:
+
+```text
+https://github.com/obra/superpowers
+```
+
 ### Claude Code
 
-1. Register the Patina Project marketplace in Claude Code:
+1. After Superpowers is installed, register the Patina Project marketplace in Claude Code:
 
 ```bash
 /plugin marketplace add patinaproject/skills
@@ -70,7 +76,7 @@ Agent Teams lets multiple agents coordinate through the staged workflow. The reg
 
 ### OpenAI Codex CLI
 
-1. Add the Patina Project marketplace from GitHub:
+1. After Superpowers is installed, add the Patina Project marketplace from GitHub:
 
 ```bash
 codex plugin marketplace add patinaproject/skills --ref main
@@ -86,7 +92,7 @@ Use $superteam to take this issue from design through review-ready execution.
 
 ### OpenAI Codex App
 
-1. In a terminal or Codex CLI session, add the Patina Project marketplace from GitHub:
+1. After Superpowers is installed, in a terminal or Codex CLI session add the Patina Project marketplace from GitHub:
 
 ```bash
 codex plugin marketplace add patinaproject/skills --ref main

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Each stage owns specific artifacts and verification gates, so work stays underst
 
 Superteam is built around explicit stage ownership, written design and plan artifacts, verification before completion, and finish-stage review follow-through. That structure gives the next agent enough context to continue intelligently instead of starting over.
 
-## Install Surfaces
+## Install surfaces
 
 - The repository root is the Claude Code plugin surface discovered via `.claude-plugin/plugin.json`.
 - `plugins/superteam/` is the packaged Codex install surface.
 - Author the skill in `skills/superteam/`, then refresh the packaged plugin with `pnpm sync:plugin` before publishing Codex-facing changes.
 
-## Local Development
+## Claude Code setup
 
 Use the repository root as the Claude plugin directory during local testing:
 
@@ -49,4 +49,18 @@ Use the repository root as the Claude plugin directory during local testing:
 claude --plugin-dir .
 ```
 
-The skill is exposed as `/superteam:superteam` once the plugin is loaded.
+Once loaded, start from a GitHub issue and invoke:
+
+```text
+/superteam:superteam
+```
+
+### Optional: Enable Agent Teams
+
+If you want a team-oriented runtime, enable Agent Teams in your Claude Code setup and then run the same workflow through Superteam.
+
+Agent Teams lets multiple agents coordinate through the staged workflow. The regular setup runs the same workflow with a single agent or subagents.
+
+## First use
+
+Start from a GitHub issue and invoke the skill. Superteam will drive the issue through design, planning, execution, review, and handoff artifacts.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ flowchart LR
 
 Each stage owns specific artifacts and verification gates, so work stays understandable across handoffs instead of becoming ad hoc subagent output.
 
+## Agent roster
+
+| Stage | Agent | Superpowers skill |
+| --- | --- | --- |
+| Brainstorm | Brainstormer | `superpowers:brainstorming` |
+| Plan | Planner | `superpowers:writing-plans` |
+| Execute | Implementer | `superpowers:subagent-driven-development` |
+| Review | Reviewer | `superpowers:requesting-code-review` |
+| Finish | Finisher | `superpowers:finishing-a-development-branch` |
+
 ## Why teams can pick up where they left off
 
 Superteam is built around explicit stage ownership, written design and plan artifacts, verification before completion, and finish-stage review follow-through. That structure gives the next agent enough context to continue intelligently instead of starting over.

--- a/README.md
+++ b/README.md
@@ -44,17 +44,19 @@ Superteam is built around explicit stage ownership, written design and plan arti
 
 ### Claude Code
 
-1. Add the `patinaproject/skills` marketplace source in Claude Code before you try to install Superteam.
-2. Install or enable Superteam from that marketplace listing.
-3. Start from a GitHub issue and run Superteam in Claude Code.
-
-Use the repository root as the Claude plugin directory during local testing:
+1. Register the Patina Project marketplace in Claude Code:
 
 ```bash
-claude --plugin-dir .
+/plugin marketplace add patinaproject/skills
 ```
 
-Once loaded, start from a GitHub issue and invoke:
+2. Install Superteam from that marketplace:
+
+```bash
+/plugin install superteam@patinaproject-skills
+```
+
+3. Start from a GitHub issue and invoke:
 
 ```text
 /superteam:superteam
@@ -68,15 +70,35 @@ Agent Teams lets multiple agents coordinate through the staged workflow. The reg
 
 ### OpenAI Codex CLI
 
-1. Add the `patinaproject/skills` marketplace source in OpenAI Codex CLI before first use.
-2. Install or enable Superteam from that marketplace listing.
-3. Open the relevant GitHub issue in your working context, then invoke the `superteam` skill in OpenAI Codex CLI.
+1. Add the Patina Project marketplace from GitHub:
+
+```bash
+codex plugin marketplace add patinaproject/skills --ref main
+codex plugin marketplace upgrade
+```
+
+2. Open the Codex Plugin Directory, open the `Patina Project` marketplace, and install `Superteam`.
+3. Open the relevant GitHub issue in your working context, then invoke:
+
+```text
+Use $superteam to take this issue from design through review-ready execution.
+```
 
 ### OpenAI Codex App
 
-1. Add the `patinaproject/skills` marketplace source in the OpenAI Codex app before first use.
-2. Add or enable Superteam from that marketplace listing.
-3. Open the relevant GitHub issue in the app context, then invoke the `superteam` skill in OpenAI Codex App.
+1. In a terminal or Codex CLI session, add the Patina Project marketplace from GitHub:
+
+```bash
+codex plugin marketplace add patinaproject/skills --ref main
+codex plugin marketplace upgrade
+```
+
+2. In the Codex app, open the Plugin Directory, open the `Patina Project` marketplace, and install `Superteam`.
+3. Open the relevant GitHub issue in the app context, then invoke:
+
+```text
+Use $superteam to take this issue from design through review-ready execution.
+```
 
 ## First use
 

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -1,6 +1,6 @@
 # Repository File Structure
 
-This repository keeps source skills in `skills/`, packaged plugin content in `plugins/`, and supporting documentation in `docs/`.
+This document is a contributor reference for the repository layout. For user-facing installation and workflow onboarding, start with `README.md`.
 
 ## Top level
 
@@ -40,7 +40,7 @@ Keep skill directories self-contained. Prefer adjacent support files over hidden
 
 The repository supports two plugin surfaces.
 
-Claude Code loads the repository root through `.claude-plugin/plugin.json`, which points at the source skills in `./skills`.
+Claude Code loads the repository root through `.claude-plugin/plugin.json`, which makes the repository root the Claude Code plugin surface and points at the source skills in `./skills`.
 
 Codex consumes the packaged plugin under `plugins/superteam/`.
 
@@ -68,7 +68,7 @@ plugins/
 - `agents/openai.yaml`: optional skill UI metadata for Codex lists and chips
 
 Use `.agents/plugins/marketplace.json` to register repo-local plugins for Codex discovery.
-When publishing `superteam` to an external marketplace, treat `plugins/superteam/` as the Codex install surface and `skills/superteam/` as the authoring source. Refresh the packaged copy with `pnpm sync:plugin`.
+When publishing `superteam` to an external marketplace, treat `plugins/superteam/` as the packaged Codex install surface and `skills/superteam/` as the authoring source. Refresh the packaged copy with `pnpm sync:plugin`.
 
 ## Docs
 

--- a/docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
+++ b/docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
@@ -169,11 +169,18 @@ Update the lower half of `README.md` so the installation details appear after th
 
 ## Installation
 
+Install Superpowers first by following the instructions in:
+
+```text
+https://github.com/obra/superpowers
+```
+
 ### Claude Code
 
-1. Set up access to the `patinaproject/skills` marketplace in Claude Code.
-2. Install or enable Superteam from that marketplace source.
-3. Load Superteam in Claude Code and start from a GitHub issue.
+1. Install Superpowers first by following the setup instructions in `https://github.com/obra/superpowers`.
+2. Set up access to the `patinaproject/skills` marketplace in Claude Code.
+3. Install or enable Superteam from that marketplace source.
+4. Load Superteam in Claude Code and start from a GitHub issue.
 
 Use the repository root as the Claude plugin directory during local testing:
 
@@ -195,15 +202,17 @@ Agent Teams lets multiple agents coordinate through the staged workflow. The reg
 
 ### OpenAI Codex CLI
 
-1. Set up access to the `patinaproject/skills` marketplace in Codex CLI.
-2. Install or enable Superteam from that marketplace source.
-3. Start from a GitHub issue and invoke Superteam in Codex CLI.
+1. Install Superpowers first by following the setup instructions in `https://github.com/obra/superpowers`.
+2. Set up access to the `patinaproject/skills` marketplace in Codex CLI.
+3. Install or enable Superteam from that marketplace source.
+4. Start from a GitHub issue and invoke Superteam in Codex CLI.
 
 ### OpenAI Codex App
 
-1. Set up access to the `patinaproject/skills` marketplace in the Codex app.
-2. Add Superteam from that marketplace source.
-3. Start from a GitHub issue and invoke Superteam in the app.
+1. Install Superpowers first by following the setup instructions in `https://github.com/obra/superpowers`.
+2. Set up access to the `patinaproject/skills` marketplace in the Codex app.
+3. Add Superteam from that marketplace source.
+4. Start from a GitHub issue and invoke Superteam in the app.
 
 ## First use
 
@@ -237,6 +246,7 @@ sed -n '1,220p' README.md
 Expected:
 - a short scan explains what Superteam is
 - runtime compatibility is visible without implying a preference
+- the README makes Superpowers an explicit prerequisite and links to its repo
 - the README includes separate sections for Claude Code, OpenAI Codex CLI, and OpenAI Codex App
 - each runtime path explains the `patinaproject/skills` marketplace setup path
 - the optional Agent Teams subsection is present under the Claude Code section with a brief difference explanation
@@ -322,6 +332,7 @@ AC-7-7 -> Task 3
 AC-7-8 -> Task 3
 AC-7-9 -> Task 3
 AC-7-10 -> Task 3
+AC-7-11 -> Task 3
 ```
 
 - [ ] **Step 2: Verify the plan file follows the branch-based naming rule**

--- a/docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
+++ b/docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
@@ -40,7 +40,7 @@ Orchestrate teams of agents with Superpowers.
 
 Superteam turns a GitHub issue into a structured workflow that teams of agents can pick up, hand off, and continue without losing context.
 
-It is designed to work best with Claude Code Agent Teams, and it also works with subagents when team features are unavailable.
+It works with agent teams or subagents.
 ```
 
 Immediately after that opening, add a short section that explains the problem in plain language:
@@ -58,14 +58,13 @@ Superteam adds a disciplined workflow on top of Superpowers so agent work stays 
 Run:
 
 ```bash
-rg -n "Orchestrate teams of agents with Superpowers|The problem|Claude Code Agent Teams|subagents" README.md
+rg -n "Orchestrate teams of agents with Superpowers|The problem|agent teams or subagents" README.md
 ```
 
 Expected:
 - one match for the headline
 - one match for `## The problem`
-- one match that states Claude Code Agent Teams are the preferred runtime
-- one match that states subagent compatibility
+- one match that states runtime compatibility in neutral terms
 
 - [ ] **Step 4: Commit the README opening rewrite**
 
@@ -169,7 +168,7 @@ Update the lower half of `README.md` so the installation details appear after th
 - `plugins/superteam/` is the packaged Codex install surface.
 - Author the skill in `skills/superteam/`, then refresh the packaged plugin with `pnpm sync:plugin` before publishing Codex-facing changes.
 
-## First use
+## Claude Code setup
 
 Use the repository root as the Claude plugin directory during local testing:
 
@@ -182,6 +181,16 @@ Once loaded, start from a GitHub issue and invoke:
 ```text
 /superteam:superteam
 ```
+
+### Optional: Enable Agent Teams
+
+If you want a team-oriented runtime, enable Agent Teams in your Claude Code setup and then run the same workflow through Superteam.
+
+Agent Teams lets multiple agents coordinate through the staged workflow. The regular setup runs the same workflow with a single agent or subagents.
+
+## First use
+
+Start from a GitHub issue and invoke the skill. Superteam will drive the issue through design, planning, execution, review, and handoff artifacts.
 ````
 
 Keep the install facts accurate, but ensure they no longer appear before the product explanation.
@@ -197,7 +206,8 @@ rg -n "^## " README.md
 Expected:
 - `## The problem` appears before any install section
 - `## How Superteam works` appears before `## Install surfaces`
-- `## First use` exists after installation guidance
+- `## Claude Code setup` exists after installation guidance
+- `## First use` exists after the setup sections
 
 - [ ] **Step 3: Sanity-check the landing-page scan as a first-time user**
 
@@ -209,8 +219,8 @@ sed -n '1,220p' README.md
 
 Expected:
 - a short scan explains what Superteam is
-- the preferred Agent Teams runtime is visible
-- subagent compatibility is visible but secondary
+- runtime compatibility is visible without implying a preference
+- the optional Agent Teams subsection is present with a brief difference explanation
 - install guidance leads into a concrete first-use action
 
 - [ ] **Step 4: Commit the install-flow restructuring**
@@ -285,9 +295,10 @@ Check the design doc and map it to implementation tasks:
 AC-7-1 -> Tasks 1 and 3
 AC-7-2 -> Task 2
 AC-7-3 -> Task 1
-AC-7-4 -> Task 1
+AC-7-4 -> Tasks 1 and 3
 AC-7-5 -> Task 2
 AC-7-6 -> Task 3
+AC-7-7 -> Task 3
 ```
 
 - [ ] **Step 2: Verify the plan file follows the branch-based naming rule**

--- a/docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
+++ b/docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
@@ -1,0 +1,323 @@
+# Plan: Improve the install experience for Superteam users [#7](https://github.com/patinaproject/superteam/issues/7)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the repository landing page explain what Superteam does, the problem it solves, and how its continuity-first workflow operates before readers encounter installation mechanics.
+
+**Architecture:** Rewrite `README.md` as a problem-first onboarding surface centered on one flagship workflow for Superteam. Keep install-surface details accurate but move them below the product explanation, then align any supporting docs that still contradict the new landing-page narrative.
+
+**Tech Stack:** Markdown, Mermaid diagram syntax, Claude Code plugin metadata, Codex plugin packaging docs, ripgrep, git
+
+---
+
+### Task 1: Rewrite the landing-page opening around the product and problem
+
+**Files:**
+- Modify: `README.md`
+- Test: `README.md`
+
+- [ ] **Step 1: Capture the current README gaps before editing**
+
+Run:
+
+```bash
+sed -n '1,120p' README.md
+```
+
+Expected:
+- the file opens with install surfaces instead of a clear product/problem statement
+- there is no continuity or handoff explanation near the top
+- there is no flagship workflow section
+
+- [ ] **Step 2: Replace the top README sections with a problem-first introduction**
+
+Update `README.md` so the opening section begins with:
+
+```md
+# Superteam
+
+Orchestrate teams of agents with Superpowers.
+
+Superteam turns a GitHub issue into a structured workflow that teams of agents can pick up, hand off, and continue without losing context.
+
+It is designed to work best with Claude Code Agent Teams, and it also works with subagents when team features are unavailable.
+```
+
+Immediately after that opening, add a short section that explains the problem in plain language:
+
+```md
+## The problem
+
+Running multiple agents on one issue is easy to start and hard to sustain. Work gets split across chats, design decisions get lost, and the next agent often has to rediscover what already happened.
+
+Superteam adds a disciplined workflow on top of Superpowers so agent work stays structured, reviewable, and resumable from design through finish.
+```
+
+- [ ] **Step 3: Verify the new opening states the product, problem, and runtime model**
+
+Run:
+
+```bash
+rg -n "Orchestrate teams of agents with Superpowers|The problem|Claude Code Agent Teams|subagents" README.md
+```
+
+Expected:
+- one match for the headline
+- one match for `## The problem`
+- one match that states Claude Code Agent Teams are the preferred runtime
+- one match that states subagent compatibility
+
+- [ ] **Step 4: Commit the README opening rewrite**
+
+Run:
+
+```bash
+git add README.md
+git commit -m "docs: #7 rewrite superteam landing page opening"
+```
+
+### Task 2: Add a flagship workflow section and continuity-first diagram
+
+**Files:**
+- Modify: `README.md`
+- Test: `README.md`, `skills/superteam/SKILL.md`
+
+- [ ] **Step 1: Lift the canonical workflow stages from the skill before editing the README**
+
+Run:
+
+```bash
+sed -n '1,120p' skills/superteam/SKILL.md
+```
+
+Expected:
+- the stage order is visible as brainstorm, plan, execute, pre-push review, finish, comment handling
+- the skill describes artifact ownership and resumable workflow behavior
+
+- [ ] **Step 2: Add a flagship workflow section to the README**
+
+Insert a new section after `## The problem`:
+
+````md
+## How Superteam works
+
+Superteam runs one issue through a structured sequence so the next agent, or the next human, can continue from durable artifacts instead of chat history alone.
+
+```mermaid
+flowchart LR
+    A[GitHub issue] --> B[Brainstorm]
+    B --> C[Design doc]
+    C --> D[Plan]
+    D --> E[Implementation plan]
+    E --> F[Execute]
+    F --> G[Pre-push review]
+    G --> H[Finish]
+    H --> I[PR and CI follow-through]
+    I --> J[Comment handling]
+```
+
+Each stage owns specific artifacts and verification gates, so work stays understandable across handoffs instead of becoming ad hoc subagent output.
+````
+
+Keep the stage names consistent with `skills/superteam/SKILL.md`.
+
+- [ ] **Step 3: Add one short continuity section below the workflow**
+
+Append this section directly after `## How Superteam works`:
+
+```md
+## Why teams can pick up where they left off
+
+Superteam is built around explicit stage ownership, written design and plan artifacts, verification before completion, and finish-stage review follow-through. That structure gives the next agent enough context to continue intelligently instead of starting over.
+```
+
+- [ ] **Step 4: Verify the README matches the skill's workflow vocabulary**
+
+Run:
+
+```bash
+rg -n "Brainstorm|Plan|Execute|Pre-push review|Finish|Comment handling|Why teams can pick up where they left off" README.md
+```
+
+Expected:
+- matches for all six stage names in `README.md`
+- one match for the continuity section heading
+
+- [ ] **Step 5: Commit the workflow and continuity additions**
+
+Run:
+
+```bash
+git add README.md
+git commit -m "docs: #7 add workflow and continuity overview"
+```
+
+### Task 3: Move install guidance below understanding and connect it to first use
+
+**Files:**
+- Modify: `README.md`
+- Test: `README.md`
+
+- [ ] **Step 1: Replace the current install-surface block with an install section that follows the workflow narrative**
+
+Update the lower half of `README.md` so the installation details appear after the product and workflow sections, using this structure:
+
+````md
+## Install surfaces
+
+- The repository root is the Claude Code plugin surface discovered via `.claude-plugin/plugin.json`.
+- `plugins/superteam/` is the packaged Codex install surface.
+- Author the skill in `skills/superteam/`, then refresh the packaged plugin with `pnpm sync:plugin` before publishing Codex-facing changes.
+
+## First use
+
+Use the repository root as the Claude plugin directory during local testing:
+
+```bash
+claude --plugin-dir .
+```
+
+Once loaded, start from a GitHub issue and invoke:
+
+```text
+/superteam:superteam
+```
+````
+
+Keep the install facts accurate, but ensure they no longer appear before the product explanation.
+
+- [ ] **Step 2: Verify the README section order is onboarding-first**
+
+Run:
+
+```bash
+rg -n "^## " README.md
+```
+
+Expected:
+- `## The problem` appears before any install section
+- `## How Superteam works` appears before `## Install surfaces`
+- `## First use` exists after installation guidance
+
+- [ ] **Step 3: Sanity-check the landing-page scan as a first-time user**
+
+Run:
+
+```bash
+sed -n '1,220p' README.md
+```
+
+Expected:
+- a short scan explains what Superteam is
+- the preferred Agent Teams runtime is visible
+- subagent compatibility is visible but secondary
+- install guidance leads into a concrete first-use action
+
+- [ ] **Step 4: Commit the install-flow restructuring**
+
+Run:
+
+```bash
+git add README.md
+git commit -m "docs: #7 connect install guidance to first use"
+```
+
+### Task 4: Align supporting docs with the new landing-page narrative
+
+**Files:**
+- Modify: `docs/file-structure.md`
+- Test: `README.md`, `docs/file-structure.md`
+
+- [ ] **Step 1: Check whether the structure guide now conflicts with the README framing**
+
+Run:
+
+```bash
+sed -n '1,220p' docs/file-structure.md
+```
+
+Expected:
+- the file remains contributor-focused
+- no opening language claims that repo structure is the primary user onboarding surface
+
+- [ ] **Step 2: If needed, tighten the opening of `docs/file-structure.md` so it stays contributor-facing**
+
+If the top section reads like user onboarding, replace the opening paragraph with:
+
+```md
+This document is a contributor reference for the repository layout. For user-facing installation and workflow onboarding, start with `README.md`.
+```
+
+Do not change the rest of the structure guide unless required for consistency with the install-surface terms used in `README.md`.
+
+- [ ] **Step 3: Verify README and file-structure docs use the same install-surface names**
+
+Run:
+
+```bash
+rg -n "Claude Code plugin surface|packaged Codex install surface|skills/superteam|pnpm sync:plugin" README.md docs/file-structure.md
+```
+
+Expected:
+- the install-surface names match across both files
+- `README.md` remains the user-facing starting point
+
+- [ ] **Step 4: Commit the supporting-doc alignment**
+
+Run:
+
+```bash
+git add README.md docs/file-structure.md
+git commit -m "docs: #7 align supporting docs with onboarding flow"
+```
+
+### Task 5: Verify acceptance-criteria coverage and record the planning artifact
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md`
+- Test: `README.md`, `docs/file-structure.md`, `git status`
+
+- [ ] **Step 1: Verify the plan covers every approved acceptance criterion**
+
+Check the design doc and map it to implementation tasks:
+
+```text
+AC-7-1 -> Tasks 1 and 3
+AC-7-2 -> Task 2
+AC-7-3 -> Task 1
+AC-7-4 -> Task 1
+AC-7-5 -> Task 2
+AC-7-6 -> Task 3
+```
+
+- [ ] **Step 2: Verify the plan file follows the branch-based naming rule**
+
+Run:
+
+```bash
+find docs/superpowers -maxdepth 2 -type f | sort
+```
+
+Expected:
+- `docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md`
+- `docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md`
+
+- [ ] **Step 3: Review the working tree before execution handoff**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected:
+- only the issue `#7` design and plan artifacts are staged or modified before implementation begins
+
+- [ ] **Step 4: Commit the implementation plan**
+
+Run:
+
+```bash
+git add docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
+git commit -m "docs: #7 add install experience implementation plan"
+```

--- a/docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
+++ b/docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
@@ -151,13 +151,13 @@ git add README.md
 git commit -m "docs: #7 add workflow and continuity overview"
 ```
 
-### Task 3: Move install guidance below understanding and connect it to first use
+### Task 3: Split install guidance into tool-specific setup paths and connect each to first use
 
 **Files:**
 - Modify: `README.md`
 - Test: `README.md`
 
-- [ ] **Step 1: Replace the current install-surface block with an install section that follows the workflow narrative**
+- [ ] **Step 1: Replace the current install-surface block with a brief install overview and runtime-specific setup sections**
 
 Update the lower half of `README.md` so the installation details appear after the product and workflow sections, using this structure:
 
@@ -166,9 +166,14 @@ Update the lower half of `README.md` so the installation details appear after th
 
 - The repository root is the Claude Code plugin surface discovered via `.claude-plugin/plugin.json`.
 - `plugins/superteam/` is the packaged Codex install surface.
-- Author the skill in `skills/superteam/`, then refresh the packaged plugin with `pnpm sync:plugin` before publishing Codex-facing changes.
 
-## Claude Code setup
+## Installation
+
+### Claude Code
+
+1. Set up access to the `patinaproject/skills` marketplace in Claude Code.
+2. Install or enable Superteam from that marketplace source.
+3. Load Superteam in Claude Code and start from a GitHub issue.
 
 Use the repository root as the Claude plugin directory during local testing:
 
@@ -188,12 +193,24 @@ If you want a team-oriented runtime, enable Agent Teams in your Claude Code setu
 
 Agent Teams lets multiple agents coordinate through the staged workflow. The regular setup runs the same workflow with a single agent or subagents.
 
+### OpenAI Codex CLI
+
+1. Set up access to the `patinaproject/skills` marketplace in Codex CLI.
+2. Install or enable Superteam from that marketplace source.
+3. Start from a GitHub issue and invoke Superteam in Codex CLI.
+
+### OpenAI Codex App
+
+1. Set up access to the `patinaproject/skills` marketplace in the Codex app.
+2. Add Superteam from that marketplace source.
+3. Start from a GitHub issue and invoke Superteam in the app.
+
 ## First use
 
-Start from a GitHub issue and invoke the skill. Superteam will drive the issue through design, planning, execution, review, and handoff artifacts.
+After setup in any supported tool, start from a GitHub issue and invoke Superteam. The workflow then drives the issue through design, planning, execution, review, and handoff artifacts.
 ````
 
-Keep the install facts accurate, but ensure they no longer appear before the product explanation.
+Keep the install facts accurate, ensure they no longer appear before the product explanation, and remove maintainer-oriented packaging guidance from this user-facing flow.
 
 - [ ] **Step 2: Verify the README section order is onboarding-first**
 
@@ -206,8 +223,8 @@ rg -n "^## " README.md
 Expected:
 - `## The problem` appears before any install section
 - `## How Superteam works` appears before `## Install surfaces`
-- `## Claude Code setup` exists after installation guidance
-- `## First use` exists after the setup sections
+- `## Installation` exists after `## Install surfaces`
+- `## First use` exists after the runtime-specific setup sections
 
 - [ ] **Step 3: Sanity-check the landing-page scan as a first-time user**
 
@@ -220,7 +237,10 @@ sed -n '1,220p' README.md
 Expected:
 - a short scan explains what Superteam is
 - runtime compatibility is visible without implying a preference
-- the optional Agent Teams subsection is present with a brief difference explanation
+- the README includes separate sections for Claude Code, OpenAI Codex CLI, and OpenAI Codex App
+- each runtime path explains the `patinaproject/skills` marketplace setup path
+- the optional Agent Teams subsection is present under the Claude Code section with a brief difference explanation
+- maintainer packaging guidance is no longer mixed into the user-facing setup flow
 - install guidance leads into a concrete first-use action
 
 - [ ] **Step 4: Commit the install-flow restructuring**
@@ -299,6 +319,9 @@ AC-7-4 -> Tasks 1 and 3
 AC-7-5 -> Task 2
 AC-7-6 -> Task 3
 AC-7-7 -> Task 3
+AC-7-8 -> Task 3
+AC-7-9 -> Task 3
+AC-7-10 -> Task 3
 ```
 
 - [ ] **Step 2: Verify the plan file follows the branch-based naming rule**

--- a/docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
+++ b/docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
@@ -347,7 +347,7 @@ AC-7-2 -> Task 2
 AC-7-3 -> Task 1
 AC-7-4 -> Tasks 1 and 3
 AC-7-5 -> Task 2
-AC-7-5a -> Task 2
+AC-7-12 -> Task 2
 AC-7-6 -> Task 3
 AC-7-7 -> Task 3
 AC-7-8 -> Task 3

--- a/docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
+++ b/docs/superpowers/plans/2026-04-22-7-improve-the-install-experience-for-superteam-users-plan.md
@@ -75,7 +75,7 @@ git add README.md
 git commit -m "docs: #7 rewrite superteam landing page opening"
 ```
 
-### Task 2: Add a flagship workflow section and continuity-first diagram
+### Task 2: Add a flagship workflow section, compact agent roster, and continuity-first diagram
 
 **Files:**
 - Modify: `README.md`
@@ -120,7 +120,25 @@ Each stage owns specific artifacts and verification gates, so work stays underst
 
 Keep the stage names consistent with `skills/superteam/SKILL.md`.
 
-- [ ] **Step 3: Add one short continuity section below the workflow**
+- [ ] **Step 3: Add a compact agent roster table below the workflow**
+
+Append a small table directly after `## How Superteam works`:
+
+```md
+## Agent roster
+
+| Stage | Agent | Superpowers skill |
+| --- | --- | --- |
+| Brainstorm | Brainstormer | `superpowers:brainstorming` |
+| Plan | Planner | `superpowers:writing-plans` |
+| Execute | Implementer | `superpowers:subagent-driven-development` |
+| Review | Reviewer | `superpowers:requesting-code-review` |
+| Finish | Finisher | `superpowers:finishing-a-development-branch` |
+```
+
+Keep it compact. Do not turn this into a long reference section.
+
+- [ ] **Step 4: Add one short continuity section below the roster**
 
 Append this section directly after `## How Superteam works`:
 
@@ -130,19 +148,21 @@ Append this section directly after `## How Superteam works`:
 Superteam is built around explicit stage ownership, written design and plan artifacts, verification before completion, and finish-stage review follow-through. That structure gives the next agent enough context to continue intelligently instead of starting over.
 ```
 
-- [ ] **Step 4: Verify the README matches the skill's workflow vocabulary**
+- [ ] **Step 5: Verify the README matches the skill's workflow vocabulary and includes the roster**
 
 Run:
 
 ```bash
-rg -n "Brainstorm|Plan|Execute|Pre-push review|Finish|Comment handling|Why teams can pick up where they left off" README.md
+rg -n "Brainstorm|Plan|Execute|Pre-push review|Finish|Comment handling|## Agent roster|superpowers:brainstorming|superpowers:writing-plans|superpowers:subagent-driven-development|superpowers:requesting-code-review|superpowers:finishing-a-development-branch|Why teams can pick up where they left off" README.md
 ```
 
 Expected:
 - matches for all six stage names in `README.md`
+- one match for `## Agent roster`
+- one match for each listed Superpowers skill in the roster
 - one match for the continuity section heading
 
-- [ ] **Step 5: Commit the workflow and continuity additions**
+- [ ] **Step 6: Commit the workflow, roster, and continuity additions**
 
 Run:
 
@@ -327,6 +347,7 @@ AC-7-2 -> Task 2
 AC-7-3 -> Task 1
 AC-7-4 -> Tasks 1 and 3
 AC-7-5 -> Task 2
+AC-7-5a -> Task 2
 AC-7-6 -> Task 3
 AC-7-7 -> Task 3
 AC-7-8 -> Task 3

--- a/docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md
+++ b/docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Improve the install experience for `superteam` by treating the repository landing page as the primary onboarding surface for new users. The design focuses on helping a first-time visitor quickly understand what Superteam does, what problem it solves, why it is designed to work best with Claude Code Agent Teams, and how the workflow continues cleanly across handoffs.
+Improve the install experience for `superteam` by treating the repository landing page as the primary onboarding surface for new users. The design focuses on helping a first-time visitor quickly understand what Superteam does, what problem it solves, how it works with agent teams or subagents, and how the workflow continues cleanly across handoffs.
 
 The design keeps the issue outcome-focused rather than prescribing a README-only rewrite. The repository landing page is the primary surface to improve first, but the broader install experience should be evaluated in terms of whether the user can move from discovery to first use without losing clarity.
 
@@ -11,8 +11,8 @@ The design keeps the issue outcome-focused rather than prescribing a README-only
 - Make the repository landing page explain what Superteam does before it explains repository structure or install surfaces
 - Help a first-time visitor understand the problem Superteam solves
 - Make the continuity and handoff model visible early in the docs experience
-- Clarify that Superteam is designed to work best with Claude Code Agent Teams
-- Clarify that the same workflow remains usable with subagents
+- Clarify that Superteam works with agent teams or subagents
+- Avoid implying that one runtime is better than the other without evidence
 - Connect installation to a clear first-use path instead of ending at setup
 
 ## Non-Goals
@@ -54,7 +54,7 @@ Pros:
 - Aligns the repo landing page with the actual `superteam` skill behavior
 - Gives first-time users a clear mental model before setup details
 - Makes continuity and team handoff visible early
-- Leaves room to explain Agent Teams as the preferred runtime and subagents as compatible
+- Leaves room to explain compatibility without implying a runtime preference
 
 Cons:
 - Requires restructuring the current landing-page narrative
@@ -93,9 +93,8 @@ The top of the page should help a new user answer these questions in order:
 1. What is Superteam?
 2. What problem does it solve?
 3. How does it work at a high level?
-4. Why is Claude Code Agent Teams the preferred runtime?
-5. Can I still use it with subagents?
-6. How do I install it and what do I do next?
+4. Does it work with agent teams or subagents?
+5. How do I install it and what do I do next?
 
 ### Workflow Presentation
 
@@ -112,9 +111,9 @@ This matters because the skill itself is explicitly stage-based. The workflow is
 
 ### Runtime Positioning
 
-The landing page should state clearly that Superteam is designed to work best with Claude Code Agent Teams. That should be treated as the preferred operating model, not buried in compatibility notes.
+The landing page should state clearly that Superteam works with agent teams or subagents. It should avoid saying one runtime works better than the other unless that claim has been validated.
 
-The page should also make clear that the workflow still works with subagents. Compatibility should be visible, but it should not displace the primary story about Agent Teams.
+Compatibility language should support the main story about structured issue workflows and continuity, rather than becoming the primary claim.
 
 ## Continuity And Handoff Model
 
@@ -136,11 +135,25 @@ Installation guidance should follow understanding rather than lead it. The broad
 
 1. Understand the problem and value
 2. Understand the flagship workflow
-3. Understand the preferred runtime model
+3. Understand runtime compatibility
 4. Choose the relevant install surface
 5. Understand the first step after installation
 
 If installation instructions exist without that narrative, the user experience remains incomplete even if the commands themselves are correct.
+
+### Claude Code Setup Guidance
+
+Within the user-facing install guidance, the Claude Code path should remain complete and usable on its own. It should not require Agent Teams to make sense.
+
+That same Claude Code section should also include a short optional subsection for enabling Agent Teams. The purpose of that subsection is to help users who want a team-oriented runtime without making that setup feel mandatory.
+
+The optional subsection should:
+
+- give quick setup guidance for Agent Teams
+- keep the default setup path intact for regular single-agent or subagent use
+- include one short factual explanation of the difference
+
+The difference should be explained briefly: Agent Teams provides a team-oriented runtime where multiple agents can coordinate through the staged workflow, while the regular setup runs the same workflow with a single agent or subagents.
 
 ## Inspiration And Constraints
 
@@ -158,19 +171,21 @@ Those references should inform the shape of the docs, but the design should stay
 Validation for this work should focus on clarity and narrative flow rather than code execution.
 
 - review the repository landing page for whether the product purpose is understandable in a short scan
-- verify that the preferred runtime model is stated clearly
-- verify that subagent compatibility is present but secondary
+- verify that compatibility with agent teams or subagents is stated clearly
+- verify that the landing page does not imply an unvalidated runtime preference
 - verify that the flagship workflow and continuity story are understandable before installation details
 - verify that install guidance leads into an explicit first-use next step
+- verify that the Claude Code install path includes an optional Agent Teams subsection with a brief explanation of how it differs from regular setup
 
 ## Acceptance Criteria
 
 - AC-7-1: The user-facing install experience leads with what Superteam does and the problem it solves before explaining install surfaces
 - AC-7-2: The repository landing page presents one clear flagship workflow for how Superteam operates across an issue
-- AC-7-3: The landing experience explains that Superteam is designed to work best with Claude Code Agent Teams
-- AC-7-4: The landing experience states that Superteam also works with subagents without making that the primary positioning
+- AC-7-3: The landing experience explains that Superteam works with agent teams or subagents
+- AC-7-4: The landing experience avoids implying an unvalidated runtime preference
 - AC-7-5: The continuity and handoff model is understandable from the initial docs experience
 - AC-7-6: Installation guidance connects to a clear first-use next step instead of ending at setup
+- AC-7-7: The Claude Code install guidance includes an optional Agent Teams subsection with a brief explanation of how Agent Teams differs from regular setup
 
 ## Implementation Notes
 

--- a/docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md
+++ b/docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md
@@ -109,6 +109,20 @@ The docs should center on one flagship workflow rather than several entry points
 
 This matters because the skill itself is explicitly stage-based. The workflow is not just conceptual marketing. It is the actual operating model enforced by the skill.
 
+### Agent Roster
+
+The README should also include a compact roster for users who already know Superpowers and want to understand how Superteam composes those skills into one workflow.
+
+This should be a small table near the workflow section, not a long reference section.
+
+The table should map:
+
+- stage
+- agent role
+- Superpowers skill
+
+It should stay intentionally compact and cover only the core flow, so the README remains scannable.
+
 ### Runtime Positioning
 
 The landing page should state clearly that Superteam works with agent teams or subagents. It should avoid saying one runtime works better than the other unless that claim has been validated.
@@ -230,6 +244,7 @@ Validation for this work should focus on clarity and narrative flow rather than 
 - verify that compatibility with agent teams or subagents is stated clearly
 - verify that the landing page does not imply an unvalidated runtime preference
 - verify that the flagship workflow and continuity story are understandable before installation details
+- verify that the README includes a compact roster table mapping Superteam stages to agent roles and Superpowers skills
 - verify that install guidance leads into an explicit first-use next step
 - verify that the README makes Superpowers an explicit prerequisite and links to the Superpowers repository for installation
 - verify that the README includes separate setup sections for Claude Code, OpenAI Codex CLI, and OpenAI Codex App
@@ -243,6 +258,7 @@ Validation for this work should focus on clarity and narrative flow rather than 
 - AC-7-3: The landing experience explains that Superteam works with agent teams or subagents
 - AC-7-4: The landing experience avoids implying an unvalidated runtime preference
 - AC-7-5: The continuity and handoff model is understandable from the initial docs experience
+- AC-7-5a: The README includes a compact roster table that maps the core Superteam stages to agent roles and Superpowers skills
 - AC-7-6: Installation guidance connects to a clear first-use next step instead of ending at setup
 - AC-7-7: The Claude Code install guidance includes an optional Agent Teams subsection with a brief explanation of how Agent Teams differs from regular setup
 - AC-7-8: The README includes separate setup sections for Claude Code, OpenAI Codex CLI, and OpenAI Codex App

--- a/docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md
+++ b/docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md
@@ -1,0 +1,179 @@
+# Design: Improve the install experience for Superteam users [#7](https://github.com/patinaproject/superteam/issues/7)
+
+## Summary
+
+Improve the install experience for `superteam` by treating the repository landing page as the primary onboarding surface for new users. The design focuses on helping a first-time visitor quickly understand what Superteam does, what problem it solves, why it is designed to work best with Claude Code Agent Teams, and how the workflow continues cleanly across handoffs.
+
+The design keeps the issue outcome-focused rather than prescribing a README-only rewrite. The repository landing page is the primary surface to improve first, but the broader install experience should be evaluated in terms of whether the user can move from discovery to first use without losing clarity.
+
+## Goals
+
+- Make the repository landing page explain what Superteam does before it explains repository structure or install surfaces
+- Help a first-time visitor understand the problem Superteam solves
+- Make the continuity and handoff model visible early in the docs experience
+- Clarify that Superteam is designed to work best with Claude Code Agent Teams
+- Clarify that the same workflow remains usable with subagents
+- Connect installation to a clear first-use path instead of ending at setup
+
+## Non-Goals
+
+- Reworking the underlying `superteam` skill behavior
+- Expanding the scope into contributor-focused documentation improvements
+- Defining final README copy line-by-line in the design
+- Committing to a README-only solution before evaluating the broader install journey
+
+## User And Problem
+
+The primary user is someone landing on the repository to evaluate or install Superteam. That user should not need to understand the repo structure first. They need to understand the product first.
+
+The main problem is that the current landing experience explains install surfaces, but it does not yet explain the product value clearly enough. A new user can discover that there are multiple install surfaces, but still leave without understanding:
+
+- what Superteam actually does
+- why it exists
+- how it differs from a simpler ad hoc subagent workflow
+- why continuity across agent handoffs is a core part of the system
+- what to do immediately after installation
+
+## Recommended Approach
+
+Use a problem-first onboarding model for the install experience, with the repository landing page as the lead surface.
+
+The landing page should introduce Superteam as a workflow for orchestrating teams of agents with Superpowers. It should establish the user problem before it explains installation mechanics. The problem statement should set up the continuity and handoff story, because the skill itself is built around durable artifacts, stage ownership, and resumable progress across a single issue workflow.
+
+The preferred headline direction is:
+
+`Orchestrate teams of agents with Superpowers`
+
+That positioning should be followed immediately by copy that explains the actual operating model. Superteam is not just generic agent automation. It is a structured issue workflow that lets teams of agents pick up, hand off, and continue work without losing context.
+
+## Approach Options Considered
+
+### Option 1: Problem-first landing page with a single flagship workflow
+
+Pros:
+- Aligns the repo landing page with the actual `superteam` skill behavior
+- Gives first-time users a clear mental model before setup details
+- Makes continuity and team handoff visible early
+- Leaves room to explain Agent Teams as the preferred runtime and subagents as compatible
+
+Cons:
+- Requires restructuring the current landing-page narrative
+- May expose supporting docs gaps that also need follow-up work
+
+### Option 2: Install-first landing page with stronger product copy
+
+Pros:
+- Smaller documentation change
+- Easier to implement incrementally
+
+Cons:
+- Keeps setup mechanics ahead of understanding
+- Does not solve the core problem that users may still not understand the product after landing
+
+### Option 3: Docs hub approach with a short landing page and deeper subpages
+
+Pros:
+- Scales well if the docs set grows
+- Makes it easier to separate install, workflow, and contributor topics
+
+Cons:
+- Weakens the repository landing page as the primary onboarding surface
+- Adds indirection before the user understands what Superteam does
+
+Selected option: Option 1.
+
+## Information Architecture
+
+### Landing Page Role
+
+The repository landing page should act as product onboarding for the install experience. It should not begin as a repository structure reference.
+
+The top of the page should help a new user answer these questions in order:
+
+1. What is Superteam?
+2. What problem does it solve?
+3. How does it work at a high level?
+4. Why is Claude Code Agent Teams the preferred runtime?
+5. Can I still use it with subagents?
+6. How do I install it and what do I do next?
+
+### Workflow Presentation
+
+The docs should center on one flagship workflow rather than several entry points. That workflow should show how a GitHub issue moves through:
+
+- brainstorm
+- plan
+- execute
+- pre-push review
+- finish
+- comment handling
+
+This matters because the skill itself is explicitly stage-based. The workflow is not just conceptual marketing. It is the actual operating model enforced by the skill.
+
+### Runtime Positioning
+
+The landing page should state clearly that Superteam is designed to work best with Claude Code Agent Teams. That should be treated as the preferred operating model, not buried in compatibility notes.
+
+The page should also make clear that the workflow still works with subagents. Compatibility should be visible, but it should not displace the primary story about Agent Teams.
+
+## Continuity And Handoff Model
+
+The design should explain continuity as the core differentiator in the install experience.
+
+From the skill itself, continuity comes from:
+
+- explicit stages
+- owned artifacts for each stage
+- approval gates between stages
+- verification and reporting requirements
+- finish-stage publication and review follow-through
+
+The landing page should help users understand that Superteam is designed so another agent, or a human, can resume work without reconstructing intent from scratch. The docs do not need to describe every rule in detail, but they should make the handoff model legible.
+
+## Install Experience Expectations
+
+Installation guidance should follow understanding rather than lead it. The broader install experience should be evaluated against whether the user can move cleanly through these steps:
+
+1. Understand the problem and value
+2. Understand the flagship workflow
+3. Understand the preferred runtime model
+4. Choose the relevant install surface
+5. Understand the first step after installation
+
+If installation instructions exist without that narrative, the user experience remains incomplete even if the commands themselves are correct.
+
+## Inspiration And Constraints
+
+The design may borrow patterns from strong open source landing pages and workflow-first repositories, including:
+
+- direct problem and value framing near the top
+- early workflow explanation
+- concise diagrams to communicate system behavior quickly
+- install instructions that follow product understanding instead of preceding it
+
+Those references should inform the shape of the docs, but the design should stay grounded in the actual `superteam` skill behavior rather than imitating another repository's structure.
+
+## Testing And Verification
+
+Validation for this work should focus on clarity and narrative flow rather than code execution.
+
+- review the repository landing page for whether the product purpose is understandable in a short scan
+- verify that the preferred runtime model is stated clearly
+- verify that subagent compatibility is present but secondary
+- verify that the flagship workflow and continuity story are understandable before installation details
+- verify that install guidance leads into an explicit first-use next step
+
+## Acceptance Criteria
+
+- AC-7-1: The user-facing install experience leads with what Superteam does and the problem it solves before explaining install surfaces
+- AC-7-2: The repository landing page presents one clear flagship workflow for how Superteam operates across an issue
+- AC-7-3: The landing experience explains that Superteam is designed to work best with Claude Code Agent Teams
+- AC-7-4: The landing experience states that Superteam also works with subagents without making that the primary positioning
+- AC-7-5: The continuity and handoff model is understandable from the initial docs experience
+- AC-7-6: Installation guidance connects to a clear first-use next step instead of ending at setup
+
+## Implementation Notes
+
+- Keep the issue focused on the install experience as a whole, not just a README rewrite
+- Prefer capability and workflow language that reflects orchestration and continuity over generic automation language
+- Keep contributor-facing structural details below the initial onboarding story

--- a/docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md
+++ b/docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md
@@ -141,6 +141,30 @@ Installation guidance should follow understanding rather than lead it. The broad
 
 If installation instructions exist without that narrative, the user experience remains incomplete even if the commands themselves are correct.
 
+### Runtime-Specific Setup Guidance
+
+The user-facing install guidance should follow a structure similar to `obra/superpowers`: keep the install section brief, then provide separate setup subsections for each supported tool.
+
+For this repository, the README should include:
+
+- `### Claude Code`
+- `### OpenAI Codex CLI`
+- `### OpenAI Codex App`
+
+Each runtime section should include a concrete install-to-first-use path rather than relying on a shared generic setup block.
+
+### Marketplace Setup Guidance
+
+Each runtime section should instruct users how to set up access to the `patinaproject/skills` marketplace before they try to use Superteam.
+
+The runtime-specific setup path should therefore explain:
+
+- how that tool connects to or installs from the `patinaproject/skills` marketplace
+- how the user accesses Superteam once the marketplace is available
+- what the first-use action looks like in that runtime
+
+This matters because the marketplace setup is part of the real install experience. Without it, the runtime sections are incomplete even if the rest of the README is clear.
+
 ### Claude Code Setup Guidance
 
 Within the user-facing install guidance, the Claude Code path should remain complete and usable on its own. It should not require Agent Teams to make sense.
@@ -154,6 +178,21 @@ The optional subsection should:
 - include one short factual explanation of the difference
 
 The difference should be explained briefly: Agent Teams provides a team-oriented runtime where multiple agents can coordinate through the staged workflow, while the regular setup runs the same workflow with a single agent or subagents.
+
+### Codex Setup Guidance
+
+The README should give OpenAI Codex users their own concrete runtime paths rather than treating Codex as a secondary mention under install surfaces.
+
+That means:
+
+- one subsection for `### OpenAI Codex CLI`
+- one subsection for `### OpenAI Codex App`
+
+Both subsections should explain how the `patinaproject/skills` marketplace fits into setup, and both should end with a clear first-use action for Superteam in that runtime.
+
+### Contributor Boundary
+
+Maintainer-oriented packaging guidance should not sit inside the user-facing runtime setup flow. Instructions such as authoring in `skills/superteam/` or running `pnpm sync:plugin` belong in contributor docs rather than the main install walkthrough.
 
 ## Inspiration And Constraints
 
@@ -175,6 +214,8 @@ Validation for this work should focus on clarity and narrative flow rather than 
 - verify that the landing page does not imply an unvalidated runtime preference
 - verify that the flagship workflow and continuity story are understandable before installation details
 - verify that install guidance leads into an explicit first-use next step
+- verify that the README includes separate setup sections for Claude Code, OpenAI Codex CLI, and OpenAI Codex App
+- verify that each runtime section explains the `patinaproject/skills` marketplace setup path
 - verify that the Claude Code install path includes an optional Agent Teams subsection with a brief explanation of how it differs from regular setup
 
 ## Acceptance Criteria
@@ -186,6 +227,9 @@ Validation for this work should focus on clarity and narrative flow rather than 
 - AC-7-5: The continuity and handoff model is understandable from the initial docs experience
 - AC-7-6: Installation guidance connects to a clear first-use next step instead of ending at setup
 - AC-7-7: The Claude Code install guidance includes an optional Agent Teams subsection with a brief explanation of how Agent Teams differs from regular setup
+- AC-7-8: The README includes separate setup sections for Claude Code, OpenAI Codex CLI, and OpenAI Codex App
+- AC-7-9: Each runtime section explains how to set up access to the `patinaproject/skills` marketplace before first use
+- AC-7-10: Maintainer-oriented packaging guidance is not mixed into the user-facing runtime setup flow
 
 ## Implementation Notes
 

--- a/docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md
+++ b/docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md
@@ -258,7 +258,7 @@ Validation for this work should focus on clarity and narrative flow rather than 
 - AC-7-3: The landing experience explains that Superteam works with agent teams or subagents
 - AC-7-4: The landing experience avoids implying an unvalidated runtime preference
 - AC-7-5: The continuity and handoff model is understandable from the initial docs experience
-- AC-7-5a: The README includes a compact roster table that maps the core Superteam stages to agent roles and Superpowers skills
+- AC-7-12: The README includes a compact roster table that maps the core Superteam stages to agent roles and Superpowers skills
 - AC-7-6: Installation guidance connects to a clear first-use next step instead of ending at setup
 - AC-7-7: The Claude Code install guidance includes an optional Agent Teams subsection with a brief explanation of how Agent Teams differs from regular setup
 - AC-7-8: The README includes separate setup sections for Claude Code, OpenAI Codex CLI, and OpenAI Codex App

--- a/docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md
+++ b/docs/superpowers/specs/2026-04-22-7-improve-the-install-experience-for-superteam-users-design.md
@@ -153,9 +153,21 @@ For this repository, the README should include:
 
 Each runtime section should include a concrete install-to-first-use path rather than relying on a shared generic setup block.
 
+### Superpowers Prerequisite
+
+Superteam should treat Superpowers as an explicit dependency rather than silently assuming it is already installed.
+
+The README should therefore add a prerequisite step before the Superteam-specific runtime sections:
+
+- explain that Superpowers must be installed first
+- link users to the Superpowers repository for installation guidance: `https://github.com/obra/superpowers`
+- avoid duplicating the full Superpowers installation instructions inside this repository
+
+This keeps the README focused on the Superteam-specific setup path while making the dependency boundary clear.
+
 ### Marketplace Setup Guidance
 
-Each runtime section should instruct users how to set up access to the `patinaproject/skills` marketplace before they try to use Superteam.
+Each runtime section should instruct users how to set up access to the `patinaproject/skills` marketplace after Superpowers is installed and before they try to use Superteam.
 
 The runtime-specific setup path should therefore explain:
 
@@ -163,7 +175,12 @@ The runtime-specific setup path should therefore explain:
 - how the user accesses Superteam once the marketplace is available
 - what the first-use action looks like in that runtime
 
-This matters because the marketplace setup is part of the real install experience. Without it, the runtime sections are incomplete even if the rest of the README is clear.
+This matters because the real install experience has two dependency steps:
+
+1. install Superpowers
+2. set up access to the `patinaproject/skills` marketplace for Superteam
+
+Without both steps, the runtime sections are incomplete even if the rest of the README is clear.
 
 ### Claude Code Setup Guidance
 
@@ -214,6 +231,7 @@ Validation for this work should focus on clarity and narrative flow rather than 
 - verify that the landing page does not imply an unvalidated runtime preference
 - verify that the flagship workflow and continuity story are understandable before installation details
 - verify that install guidance leads into an explicit first-use next step
+- verify that the README makes Superpowers an explicit prerequisite and links to the Superpowers repository for installation
 - verify that the README includes separate setup sections for Claude Code, OpenAI Codex CLI, and OpenAI Codex App
 - verify that each runtime section explains the `patinaproject/skills` marketplace setup path
 - verify that the Claude Code install path includes an optional Agent Teams subsection with a brief explanation of how it differs from regular setup
@@ -230,6 +248,7 @@ Validation for this work should focus on clarity and narrative flow rather than 
 - AC-7-8: The README includes separate setup sections for Claude Code, OpenAI Codex CLI, and OpenAI Codex App
 - AC-7-9: Each runtime section explains how to set up access to the `patinaproject/skills` marketplace before first use
 - AC-7-10: Maintainer-oriented packaging guidance is not mixed into the user-facing runtime setup flow
+- AC-7-11: The README makes Superpowers an explicit prerequisite and links to the Superpowers repository for installation guidance
 
 ## Implementation Notes
 


### PR DESCRIPTION
## Summary
- rewrite the repo landing page to explain Superteam as a problem-first workflow focused on getting to a real, demoable, testable artifact
- add workflow, compact agent roster, runtime-specific installation guidance, and a short inspiration section
- make Superpowers an explicit prerequisite and align contributor-facing docs with the new onboarding story and artifact naming rules

Closes #7.

## Validation
- [x] Verified README section order, workflow headings, roster table, and Inspiration section with `rg -n "^## |^### |## Agent roster|## Inspiration|superpowers:" README.md`
- [x] Verified concrete marketplace and invocation affordances with `rg -n "obra/superpowers|patinaproject/skills|patinaproject-skills|\$superteam|/superteam:superteam" README.md`
- [x] Verified contributor doc terminology alignment with `rg -n "Claude Code plugin surface|packaged Codex install surface|skills/superteam|pnpm sync:plugin" README.md docs/file-structure.md`
- [x] Reviewed final branch diff and clean worktree state with `git diff --stat 89cd921..HEAD` and `git status --short`

## Acceptance Criteria

### AC-7-1
The user-facing install experience now leads with what Superteam does and the problem it solves before install surfaces.
- [x] Verified the README opens with product, problem, workflow, and continuity sections before installation details.

### AC-7-2
The repository landing page now presents one clear flagship workflow for how Superteam operates across an issue.
- [x] Verified the README includes the staged workflow section and Mermaid diagram.

### AC-7-3
The landing experience explains that Superteam works with agent teams or subagents.
- [x] Verified the README uses neutral runtime wording in the top section and optional Agent Teams note.

### AC-7-4
The landing experience avoids implying an unvalidated runtime preference.
- [x] Verified the README uses neutral compatibility language and keeps Agent Teams optional.

### AC-7-5
The continuity and handoff model is understandable from the initial docs experience.
- [x] Verified the README includes a dedicated continuity section and ties the workflow to durable artifacts and handoffs.

### AC-7-12
The README includes a compact roster table that maps the core Superteam stages to agent roles and Superpowers skills.
- [x] Verified the README includes `Agent roster` with compact stage, agent, and skill mappings.

### AC-7-6
Installation guidance connects to a clear first-use next step instead of ending at setup.
- [x] Verified each runtime section ends with a concrete first-use invocation and the README includes a generic `First use` section.

### AC-7-7
The Claude Code install guidance includes an optional Agent Teams subsection with a brief explanation of how Agent Teams differs from regular setup.
- [x] Verified the README includes `Optional: Enable Agent Teams` under `Claude Code` only.

### AC-7-8
The README includes separate setup sections for Claude Code, OpenAI Codex CLI, and OpenAI Codex App.
- [x] Verified the README includes distinct `### Claude Code`, `### OpenAI Codex CLI`, and `### OpenAI Codex App` sections.

### AC-7-9
Each runtime section explains how to set up access to the `patinaproject/skills` marketplace before first use.
- [x] Verified the README includes concrete marketplace registration steps for Claude Code and Codex, including Codex marketplace commands and Claude marketplace registration/install commands.

### AC-7-10
Maintainer-oriented packaging guidance is not mixed into the user-facing runtime setup flow.
- [x] Verified maintainer packaging guidance was removed from the README install flow and remains in contributor-facing docs.

### AC-7-11
The README makes Superpowers an explicit prerequisite and links to the Superpowers repository for installation guidance.
- [x] Verified the README links to `https://github.com/obra/superpowers` before the Superteam-specific runtime sections.

### AC-7-13
The README includes a short Inspiration section near the end with BMAD-Method, Superpowers, and Creative Selection.
- [x] Verified the README includes a concise `Inspiration` section near the end with those three items.
