### PR TITLE
docs: #12 add Superteam plugin descriptions

### DIFF
--- a/docs/superpowers/plans/2026-04-22-12-plugin-card-is-missing-the-superteam-description-in-codex-plan.md
+++ b/docs/superpowers/plans/2026-04-22-12-plugin-card-is-missing-the-superteam-description-in-codex-plan.md
@@ -1,0 +1,114 @@
+# Plan: Plugin card is missing the Superteam description in Codex [#12](https://github.com/patinaproject/superteam/issues/12)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Superteam plugin ship explicit plugin-card description text and aligned skill UI metadata for Codex.
+
+**Architecture:** Keep plugin-card copy in `plugins/superteam/.codex-plugin/plugin.json`, keep source skill UI copy in `skills/superteam/agents/openai.yaml`, and rely on `pnpm sync:plugin` to refresh the packaged skill metadata copy. Verification is file-level because this repository does not include a runnable Codex UI test harness.
+
+**Tech Stack:** JSON manifests, YAML skill metadata, pnpm repo scripts, git
+
+---
+
+## File structure
+
+- Modify: `plugins/superteam/.codex-plugin/plugin.json`
+- Modify: `skills/superteam/agents/openai.yaml`
+- Sync output: `plugins/superteam/skills/superteam/agents/openai.yaml`
+- Create: `docs/superpowers/specs/2026-04-22-12-plugin-card-is-missing-the-superteam-description-in-codex-design.md`
+- Create: `docs/superpowers/plans/2026-04-22-12-plugin-card-is-missing-the-superteam-description-in-codex-plan.md`
+
+### Task 1: Align the shipped plugin card metadata
+
+**Files:**
+- Modify: `plugins/superteam/.codex-plugin/plugin.json`
+
+- [ ] **Step 1: Update the plugin manifest copy**
+
+Set the manifest values to:
+
+```json
+{
+  "description": "Build with a team of agents using Superpowers",
+  "interface": {
+    "shortDescription": "Build with a team of agents using Superpowers",
+    "longDescription": "Move a GitHub issue to a testable, demoable outcome as quickly as possible through brainstorm, plan, execute, review, and CI follow-through."
+  }
+}
+```
+
+- [ ] **Step 2: Verify the manifest content**
+
+Run: `sed -n '1,40p' plugins/superteam/.codex-plugin/plugin.json`
+Expected: `description`, `shortDescription`, and `longDescription` match the approved copy for issue `#12`.
+
+### Task 2: Align the source and packaged skill UI metadata
+
+**Files:**
+- Modify: `skills/superteam/agents/openai.yaml`
+- Modify: `plugins/superteam/skills/superteam/agents/openai.yaml`
+
+- [ ] **Step 1: Update the source skill UI metadata**
+
+Set the source file content to:
+
+```yaml
+interface:
+  display_name: "Superteam"
+  short_description: "Build with a team of agents using Superpowers"
+  default_prompt: "Use $superteam to take this issue from design through review-ready execution."
+
+policy:
+  allow_implicit_invocation: true
+```
+
+- [ ] **Step 2: Sync the packaged skill copy**
+
+Run: `pnpm sync:plugin`
+Expected: the packaged copy under `plugins/superteam/skills/superteam/agents/openai.yaml` is refreshed from the source skill directory with no script errors.
+
+- [ ] **Step 3: Verify both skill metadata files**
+
+Run: `sed -n '1,20p' skills/superteam/agents/openai.yaml`
+Expected: `short_description` is `Build with a team of agents using Superpowers`.
+
+Run: `sed -n '1,20p' plugins/superteam/skills/superteam/agents/openai.yaml`
+Expected: the packaged skill copy shows the same `short_description` value.
+
+### Task 3: Prepare the repository for publish
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-22-12-plugin-card-is-missing-the-superteam-description-in-codex-design.md`
+- Modify: `docs/superpowers/plans/2026-04-22-12-plugin-card-is-missing-the-superteam-description-in-codex-plan.md`
+- Stage: `plugins/superteam/.codex-plugin/plugin.json`
+- Stage: `skills/superteam/agents/openai.yaml`
+- Stage: `plugins/superteam/skills/superteam/agents/openai.yaml`
+
+- [ ] **Step 1: Confirm the working tree only contains intended issue-12 changes**
+
+Run: `git diff -- plugins/superteam/.codex-plugin/plugin.json skills/superteam/agents/openai.yaml plugins/superteam/skills/superteam/agents/openai.yaml`
+Expected: diff contains only the description-copy updates for issue `#12`.
+
+- [ ] **Step 2: Stage the implementation changes**
+
+Run:
+
+```bash
+git add plugins/superteam/.codex-plugin/plugin.json \
+  skills/superteam/agents/openai.yaml \
+  plugins/superteam/skills/superteam/agents/openai.yaml
+```
+
+Expected: `git status --short` shows those three files staged.
+
+- [ ] **Step 3: Commit with the required issue-tagged message**
+
+Run: `git commit -m "docs: #12 add Superteam plugin descriptions"`
+Expected: commitlint and Husky accept the message and create a commit.
+
+## Self-review
+
+- AC-12-1 maps to Task 1 and Task 3 verification.
+- AC-12-2 maps to Task 2 verification.
+- AC-12-3 maps to Task 2 verification after `pnpm sync:plugin`.
+- No placeholders remain; all edited files and commands are explicit.

--- a/docs/superpowers/specs/2026-04-22-12-plugin-card-is-missing-the-superteam-description-in-codex-design.md
+++ b/docs/superpowers/specs/2026-04-22-12-plugin-card-is-missing-the-superteam-description-in-codex-design.md
@@ -1,0 +1,48 @@
+# Design: Plugin card is missing the Superteam description in Codex [#12](https://github.com/patinaproject/superteam/issues/12)
+
+## Intent
+
+Make the Superteam plugin render meaningful description text in Codex by aligning the user-facing metadata we ship in the packaged plugin and the source skill metadata we maintain in-repo.
+
+## Problem
+
+The Codex plugin card for Superteam shows the plugin name and action button but no description text. The repository already contains description metadata, which suggests the problem is either the wrong metadata copy, stale copy, or metadata that is not aligned across the source skill and packaged plugin.
+
+## Recommended approach
+
+Treat the repository as owning two metadata surfaces that should stay aligned:
+
+- `plugins/superteam/.codex-plugin/plugin.json` for plugin-card presentation
+- `skills/superteam/agents/openai.yaml` as the authoring source for Codex skill UI metadata
+
+After editing the source skill metadata, run `pnpm sync:plugin` so the packaged skill copy under `plugins/superteam/skills/superteam/` matches the source tree.
+
+For this issue, update the shipped plugin descriptions to match the wording selected during this thread and keep the source and packaged skill `short_description` values in sync with that same positioning.
+
+## Alternatives considered
+
+### Update only the marketplace metadata
+
+Rejected because the observed bug is in the installed plugin card, not just marketplace discovery. The packaged plugin manifest remains the most direct fix surface.
+
+### Update only `SKILL.md`
+
+Rejected because the missing description appears in the plugin card UI rather than the skill trigger description shown in the skill body frontmatter.
+
+## Acceptance criteria
+
+- AC-12-1: The packaged plugin manifest exposes a non-empty `description`, `interface.shortDescription`, and `interface.longDescription` for Superteam.
+- AC-12-2: The source skill and packaged skill `agents/openai.yaml` files expose the same `short_description` value.
+- AC-12-3: Verification shows the updated text in the manifest and both skill metadata files after `pnpm sync:plugin`.
+
+## Verification
+
+- `pnpm sync:plugin`
+- `sed -n '1,40p' plugins/superteam/.codex-plugin/plugin.json`
+- `sed -n '1,20p' skills/superteam/agents/openai.yaml`
+- `sed -n '1,20p' plugins/superteam/skills/superteam/agents/openai.yaml`
+
+## Out of scope
+
+- Fixing a Codex application bug if the UI still ignores the manifest after the packaged metadata is correct
+- Broader marketplace catalog changes in `patinaproject/skills`

--- a/plugins/superteam/.codex-plugin/plugin.json
+++ b/plugins/superteam/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superteam",
   "version": "0.1.0",
-  "description": "Codex plugin that exposes the superteam orchestration skill for issue-driven multi-agent work.",
+  "description": "Build with a team of agents using Superpowers",
   "author": {
     "name": "Patina Project",
     "url": "https://github.com/patinaproject"
@@ -13,8 +13,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Superteam",
-    "shortDescription": "Run issue-driven multi-agent delivery workflows.",
-    "longDescription": "Install the Superteam plugin to make the superteam skill importable in Codex as a packaged workflow for design, planning, execution, review, and finish stages.",
+    "shortDescription": "Build with a team of agents using Superpowers",
+    "longDescription": "Move a GitHub issue to a testable, demoable outcome as quickly as possible through brainstorm, plan, execute, review, and CI follow-through.",
     "developerName": "Patina Project",
     "category": "Productivity",
     "capabilities": ["Write", "Interactive"],

--- a/plugins/superteam/skills/superteam/agents/openai.yaml
+++ b/plugins/superteam/skills/superteam/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Superteam"
-  short_description: "Run issue-driven multi-agent delivery workflows"
+  short_description: "Build with a team of agents using Superpowers"
   default_prompt: "Use $superteam to take this issue from design through review-ready execution."
 
 policy:

--- a/skills/superteam/agents/openai.yaml
+++ b/skills/superteam/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Superteam"
-  short_description: "Run issue-driven multi-agent delivery workflows"
+  short_description: "Build with a team of agents using Superpowers"
   default_prompt: "Use $superteam to take this issue from design through review-ready execution."
 
 policy:


### PR DESCRIPTION
## Summary
- add issue-12 design and plan artifacts for the missing Superteam plugin card description
- update the packaged Codex plugin manifest with explicit description, short description, and long description copy
- align the source and packaged skill UI metadata on the same Superteam short description

Closes #12.

## Validation Notes
- Ran `pnpm sync:plugin`
- Verified `plugins/superteam/.codex-plugin/plugin.json`
- Verified `skills/superteam/agents/openai.yaml`
- Verified `plugins/superteam/skills/superteam/agents/openai.yaml`

## Acceptance Criteria

### AC-12-1
The packaged plugin manifest now exposes non-empty `description`, `interface.shortDescription`, and `interface.longDescription` fields for Superteam.
- [x] Verified in `plugins/superteam/.codex-plugin/plugin.json`

### AC-12-2
The source skill and packaged skill `agents/openai.yaml` files now expose the same `short_description` value.
- [x] Verified in `skills/superteam/agents/openai.yaml`
- [x] Verified in `plugins/superteam/skills/superteam/agents/openai.yaml`

### AC-12-3
Verification shows the updated text in the manifest and both skill metadata files after `pnpm sync:plugin`.
- [x] Ran `pnpm sync:plugin`
- [x] Re-read the manifest and both YAML files after the sync
