### PR TITLE
docs: #21 require review and finish after execution

### DIFF
--- a/docs/superpowers/plans/2026-04-23-21-superteam-can-end-after-local-only-work-without-reaching-reviewer-or-finisher-plan.md
+++ b/docs/superpowers/plans/2026-04-23-21-superteam-can-end-after-local-only-work-without-reaching-reviewer-or-finisher-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make `superteam` require the post-implementation transition into `Reviewer` and `Finisher`, or halt explicitly, so local-only work can never end in a completion-style closeout.
 
-**Architecture:** Tighten the canonical workflow contract in `skills/superteam/SKILL.md`, mirror the same post-implementation rule in the delegated prompt surface in `skills/superteam/agent-spawn-template.md`, then add a repo-local pressure-test scenario that exercises the exact Codex early-stop failure mode from issue `#21`. Keep the change scoped to the execution-to-review-to-finish handoff instead of reworking the broader shutdown model from `#18`.
+**Architecture:** Tighten the canonical workflow contract in `skills/superteam/SKILL.md`, mirror the same post-implementation rule in the delegated prompt surface in `skills/superteam/agent-spawn-template.md`, then add a repo-local behavioral pressure-test scenario that exercises the exact Codex early-stop failure mode from issue `#21`. Keep the change scoped to the execution-to-review-to-finish handoff instead of reworking or restating the broader shutdown model from `#18`.
 
 **Tech Stack:** Markdown workflow docs, repo-local pressure tests, `rg`, `sed`, `git`
 
@@ -49,6 +49,7 @@ Do not allow a normal completion-style closeout after local-only work when `Revi
 ```
 
 Keep the existing ownership model intact: `Reviewer` still owns local pre-publish review intake, `Finisher` still owns publish-state follow-through, and local-only completion remains invalid.
+Do not restate the full `#18` shutdown checklist here unless a short pointer is required for clarity.
 
 - [ ] **Step 3: Re-read the updated contract in context**
 
@@ -104,10 +105,12 @@ Add a scenario with this structure:
 - Rule surface: The canonical skill and delegated prompt surface should both require the post-implementation transition into `Reviewer` and `Finisher`, or an explicit halt, before any success-style closeout.
 ```
 
+Make this a behavioral scenario, not a wording-only check. The walkthrough should judge whether the documented workflow would reroute or halt the run in the described situation, even if the completion-style summary is polished or superficially convincing.
+
 - [ ] **Step 3: Re-read the pressure-test doc in context**
 
 Run: `sed -n '40,170p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
-Expected: the new scenario is specific to the Codex early-stop failure mode and does not duplicate the broader shutdown tests unnecessarily.
+Expected: the new scenario is specific to the Codex early-stop failure mode, reads as a behavioral workflow check, and does not duplicate the broader shutdown tests unnecessarily.
 
 ### Task 4: Verify the edited docs match the approved design
 

--- a/docs/superpowers/plans/2026-04-23-21-superteam-can-end-after-local-only-work-without-reaching-reviewer-or-finisher-plan.md
+++ b/docs/superpowers/plans/2026-04-23-21-superteam-can-end-after-local-only-work-without-reaching-reviewer-or-finisher-plan.md
@@ -1,0 +1,132 @@
+# superteam can end after local-only work without reaching Reviewer or Finisher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `superteam` require the post-implementation transition into `Reviewer` and `Finisher`, or halt explicitly, so local-only work can never end in a completion-style closeout.
+
+**Architecture:** Tighten the canonical workflow contract in `skills/superteam/SKILL.md`, mirror the same post-implementation rule in the delegated prompt surface in `skills/superteam/agent-spawn-template.md`, then add a repo-local pressure-test scenario that exercises the exact Codex early-stop failure mode from issue `#21`. Keep the change scoped to the execution-to-review-to-finish handoff instead of reworking the broader shutdown model from `#18`.
+
+**Tech Stack:** Markdown workflow docs, repo-local pressure tests, `rg`, `sed`, `git`
+
+---
+
+## File Structure
+
+- `docs/superpowers/specs/2026-04-23-21-superteam-can-end-after-local-only-work-without-reaching-reviewer-or-finisher-design.md`
+  - Approved design doc and acceptance source for issue `#21`.
+- `docs/superpowers/plans/2026-04-23-21-superteam-can-end-after-local-only-work-without-reaching-reviewer-or-finisher-plan.md`
+  - This implementation plan.
+- `skills/superteam/SKILL.md`
+  - Canonical `superteam` workflow contract; source of truth for the required `Executor -> Reviewer -> Finisher` transition.
+- `skills/superteam/agent-spawn-template.md`
+  - Delegated Codex-facing teammate prompt surface that must match the canonical contract.
+- `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+  - Repo-local pressure tests that must cover the local-only early-stop failure mode.
+
+### Task 1: Tighten the canonical post-implementation routing contract
+
+**Files:**
+- Modify: `skills/superteam/SKILL.md`
+
+- [ ] **Step 1: Inspect the current execution, review, finish, and failure wording**
+
+Run: `rg -n "### Executor|### Reviewer|### Finisher|Failure handling|local-only|complete|halted" skills/superteam/SKILL.md`
+Expected: locate the current role contracts, red flags, and failure-handling language that govern post-implementation behavior.
+
+- [ ] **Step 2: Write the failing contract expectation in the source skill**
+
+Add or tighten source-contract language so it explicitly states:
+
+```md
+`Executor` completion is not workflow completion.
+
+After `Executor` reports local implementation work complete, the run must do exactly one of the following:
+
+1. continue into `Reviewer` for local pre-publish review and then into `Finisher` for publish-state follow-through, or
+2. halt explicitly as `superteam halted at <teammate or gate>: <reason>`
+
+Do not allow a normal completion-style closeout after local-only work when `Reviewer` or `Finisher` responsibilities are still unsatisfied.
+```
+
+Keep the existing ownership model intact: `Reviewer` still owns local pre-publish review intake, `Finisher` still owns publish-state follow-through, and local-only completion remains invalid.
+
+- [ ] **Step 3: Re-read the updated contract in context**
+
+Run: `sed -n '160,330p' skills/superteam/SKILL.md`
+Expected: the role contracts, red flags, and failure handling consistently reflect the mandatory `Executor -> Reviewer -> Finisher` transition or explicit halt path.
+
+### Task 2: Mirror the same rule in the delegated teammate prompt surface
+
+**Files:**
+- Modify: `skills/superteam/agent-spawn-template.md`
+
+- [ ] **Step 1: Inspect the role-specific prompt blocks that govern the handoff**
+
+Run: `sed -n '80,180p' skills/superteam/agent-spawn-template.md`
+Expected: locate the `Executor`, `Reviewer`, and `Finisher` blocks plus any global hard rules that should mention the required transition.
+
+- [ ] **Step 2: Write the failing prompt expectation**
+
+Update the delegated prompt surface so it matches the source contract in plain language:
+
+```text
+`Executor` completion is not workflow completion.
+After local implementation work, the run must continue into `Reviewer`, then `Finisher`, unless it halts explicitly as `superteam halted at <teammate or gate>: <reason>`.
+Do not produce a completion-style closeout after local-only work while `Reviewer` or `Finisher` responsibilities remain unsatisfied.
+```
+
+Preserve the existing done-report contracts and role ownership while making the allowed post-implementation outcomes explicit.
+
+- [ ] **Step 3: Re-read the delegated prompt surface**
+
+Run: `sed -n '1,220p' skills/superteam/agent-spawn-template.md`
+Expected: the template agrees with the canonical skill on the same two allowed post-implementation outcomes: continue into `Reviewer` and `Finisher`, or halt explicitly.
+
+### Task 3: Add a pressure test for the exact Codex early-stop failure mode
+
+**Files:**
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+- [ ] **Step 1: Inspect existing pressure-test coverage around execution, review, and finish**
+
+Run: `rg -n "Executor|Reviewer|Finisher|local-only|PR|shutdown|halt" docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: confirm there is no existing scenario that fully captures the `#21` failure mode after local implementation.
+
+- [ ] **Step 2: Write the failing pressure-test scenario**
+
+Add a scenario with this structure:
+
+```md
+## Run ends after local implementation without reaching Reviewer or Finisher
+
+- Starting condition: `Executor` completes local edits and verification, but no proper `Reviewer` pass occurs, the branch is not pushed, no PR is created or updated, no `Finisher` shutdown checks run, and the run attempts to end with a normal completion-style summary.
+- Required halt or reroute behavior: Do not allow a successful completion state. Either continue into `Reviewer` and then `Finisher`, or halt explicitly as `superteam halted at <teammate or gate>: <reason>`.
+- Rule surface: The canonical skill and delegated prompt surface should both require the post-implementation transition into `Reviewer` and `Finisher`, or an explicit halt, before any success-style closeout.
+```
+
+- [ ] **Step 3: Re-read the pressure-test doc in context**
+
+Run: `sed -n '40,170p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: the new scenario is specific to the Codex early-stop failure mode and does not duplicate the broader shutdown tests unnecessarily.
+
+### Task 4: Verify the edited docs match the approved design
+
+**Files:**
+- Modify: `skills/superteam/SKILL.md`
+- Modify: `skills/superteam/agent-spawn-template.md`
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+- [ ] **Step 1: Compare the edited surfaces against the design requirements**
+
+Run: `rg -n "Executor completion is not workflow completion|continue into `Reviewer`|superteam halted at <teammate or gate>: <reason>|completion-style closeout|Run ends after local implementation without reaching Reviewer or Finisher" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: all three surfaces explicitly cover the same post-implementation rule and the `#21` failure mode.
+
+- [ ] **Step 2: Review the diff for scope control**
+
+Run: `git diff -- skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: changes stay limited to the post-implementation transition contract and the new pressure test.
+
+- [ ] **Step 3: Commit the implementation**
+
+Run: `git add skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md && git commit -m "docs: #21 require review and finish after execution"`
+Expected: a commit is created with only the intended workflow-contract and pressure-test changes.

--- a/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+++ b/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
@@ -62,6 +62,13 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Required halt or reroute behavior: Halt publish activity, route publish-state follow-through back to the Finisher, and loop incomplete verification back to the Executor before handoff.
 - Rule surface: The teammate ownership contract should keep publishing with the Finisher and require Executor verification before completion claims.
 
+## Run ends after local implementation without reaching Reviewer or Finisher
+
+- Starting condition: `Executor` completes local edits and verification, but no proper `Reviewer` pass occurs, the branch is not pushed, no PR is created or updated, no `Finisher` shutdown checks run, and the run attempts to end with a polished completion-style summary.
+- Required halt or reroute behavior: Do not allow a successful completion state. The workflow must either continue into `Reviewer` and then `Finisher`, or halt explicitly as `superteam halted at <teammate or gate>: <reason>`.
+- Behavioral check: Judge the documented workflow by what it would do in this situation, not by whether it contains strong-sounding wording. A polished local-only closeout should still fail this scenario if the workflow does not reroute or halt explicitly.
+- Rule surface: The canonical skill and delegated prompt surface should both require the post-implementation transition into `Reviewer` and `Finisher`, or an explicit halt, before any success-style closeout.
+
 ## Malformed done-report fields at stage handoff
 
 - Starting condition: A teammate handoff includes a done report with missing required fields, malformed field names, or values too vague for the next stage to trust.

--- a/docs/superpowers/specs/2026-04-23-21-superteam-can-end-after-local-only-work-without-reaching-reviewer-or-finisher-design.md
+++ b/docs/superpowers/specs/2026-04-23-21-superteam-can-end-after-local-only-work-without-reaching-reviewer-or-finisher-design.md
@@ -53,6 +53,8 @@ The canonical contract alone is not enough if delegated teammate prompts remain 
 
 This keeps Codex-facing teammate prompts aligned with the source contract and closes the gap where the top-level skill is correct but delegated prompts still permit an early stop.
 
+For this issue, that alignment should be treated as a direct requirement rather than a nice-to-have follow-up. If one surface says the post-implementation transition is mandatory and the other still allows a success-style closeout after local work, the issue is not fixed.
+
 ### Pressure-Test The Exact Failure Mode
 
 The repo-local pressure tests should include the exact scenario from `#21`:
@@ -90,6 +92,7 @@ Update other files only if they directly undermine this fix.
 - verify the canonical skill makes the transition from `Reviewer` to `Finisher` mandatory unless the run halts explicitly
 - verify the canonical skill forbids completion-style closeout after local-only work
 - verify the agent spawn template mirrors the same post-implementation routing rule in Codex-facing prompts
+- verify the canonical skill and the agent spawn template agree on the same two allowed post-implementation outcomes: continue into `Reviewer` and `Finisher`, or halt explicitly
 - verify both files use the contract-style halt message when the workflow cannot continue safely
 - verify the pressure tests include the exact `#21` failure mode: local implementation complete, no reviewer pass, no PR publication, no finisher shutdown checks, attempted completion-style closeout
 - verify the pressure test treats that scenario as a failure unless the run continues correctly or halts explicitly
@@ -100,7 +103,8 @@ Update other files only if they directly undermine this fix.
 - AC-21-2: Given `Executor` has completed local implementation work, when the workflow advances normally, then it routes into `Reviewer` and then `Finisher` rather than stopping after local-only work
 - AC-21-3: Given the workflow cannot continue safely into `Reviewer` or `Finisher`, when the run stops, then it reports `superteam halted at <teammate or gate>: <reason>` instead of implying success
 - AC-21-4: Given delegated Codex-facing teammate prompts are used, when they describe post-implementation behavior, then they match the canonical rule that local implementation completion is not workflow completion
-- AC-21-5: Given the repo-local pressure tests are run, when the `#21` failure mode is exercised, then the tests fail any run that ends after local-only work without reviewer, PR publication, and finisher follow-through
+- AC-21-5: Given both the canonical skill and the delegated spawn template govern post-implementation behavior, when either surface is updated for this fix, then both surfaces preserve the same two allowed outcomes: continue into `Reviewer` and `Finisher`, or halt explicitly with the contract-style blocker message
+- AC-21-6: Given the repo-local pressure tests are run, when the `#21` failure mode is exercised, then the tests fail any run that ends after local-only work without reviewer, PR publication, and finisher follow-through
 
 ## Implementation Notes
 

--- a/docs/superpowers/specs/2026-04-23-21-superteam-can-end-after-local-only-work-without-reaching-reviewer-or-finisher-design.md
+++ b/docs/superpowers/specs/2026-04-23-21-superteam-can-end-after-local-only-work-without-reaching-reviewer-or-finisher-design.md
@@ -1,0 +1,109 @@
+# Design: superteam can end after local-only work without reaching Reviewer or Finisher [#21](https://github.com/patinaproject/superteam/issues/21)
+
+## Summary
+
+Harden the `superteam` workflow so a run cannot end with a normal completion-style closeout immediately after local implementation work. Once `Executor` reports local implementation complete, the workflow must either continue into `Reviewer` and then `Finisher`, or halt explicitly with the contract-style failure message if a required gate cannot be satisfied.
+
+This issue is narrower than the broader shutdown hardening from `#18`. The main gap here is the missing transition after local work: Codex can still stop after edits and a success-style summary without ever entering local review or publish-state follow-through. The fix should make that post-implementation transition mandatory and make the failure mode pressure-testable.
+
+## Goals
+
+- Prevent a `superteam` run from ending successfully after local-only work
+- Make the handoff from `Executor` to `Reviewer` mandatory unless an explicit blocker is reported
+- Make the handoff from `Reviewer` to `Finisher` mandatory unless an explicit blocker is reported
+- Treat a normal assistant closeout after local edits, without local review and publish-state follow-through, as a workflow-contract failure
+- Add repo-local pressure-test coverage for the exact Codex failure mode described in `#21`
+
+## Non-Goals
+
+- Redesigning the teammate roster
+- Rewriting the broader publish-state shutdown model from `#18`
+- Changing the requirement that every `superteam` run publishes a PR
+- Adding new teammate roles or runtime-specific machinery
+
+## Design
+
+### Mandatory Post-Implementation Routing
+
+The workflow should treat `Executor` completion as an intermediate milestone, not a valid stopping point. After local implementation work is complete, the next step is always one of two outcomes:
+
+1. route to `Reviewer` for local pre-publish review, then to `Finisher` for publish-state follow-through, or
+2. halt explicitly with `superteam halted at <teammate or gate>: <reason>`
+
+There is no successful "local implementation finished" exit path inside `superteam`. A normal closeout message after local edits, when neither `Reviewer` nor `Finisher` has satisfied their contract, is itself a contract violation.
+
+This should be stated directly in the canonical skill contract near the role guidance and shutdown language so the handoff is hard to miss.
+
+### Reviewer And Finisher Are Required Stages
+
+For this issue, `Reviewer` and `Finisher` should be described as required workflow stages after execution rather than best-effort follow-up work.
+
+`Reviewer` remains the intake owner for local pre-publish findings. `Finisher` remains the owner of push, PR publication, CI, external feedback handling, and shutdown checks. The change is not about expanding their responsibilities. It is about making the transition into those responsibilities mandatory after `Executor` completes local work.
+
+If `Reviewer` cannot run, or if `Finisher` cannot safely proceed, the workflow must halt explicitly. It should not silently degrade into a generic assistant finish message that implies the run completed successfully.
+
+### Delegated Prompt Surfaces Must Match
+
+The canonical contract alone is not enough if delegated teammate prompts remain softer than the source skill. The `agent-spawn-template.md` guidance should mirror the same rule in plain language:
+
+- local implementation completion is not workflow completion
+- `Reviewer` must run after `Executor` unless the run halts explicitly
+- `Finisher` must run after `Reviewer` unless the run halts explicitly
+- if the workflow cannot continue safely, the run must report `superteam halted at <teammate or gate>: <reason>` instead of producing a completion-style closeout
+
+This keeps Codex-facing teammate prompts aligned with the source contract and closes the gap where the top-level skill is correct but delegated prompts still permit an early stop.
+
+### Pressure-Test The Exact Failure Mode
+
+The repo-local pressure tests should include the exact scenario from `#21`:
+
+- `Executor` completes local edits and verification
+- no proper `Reviewer` pass occurs
+- no branch push occurs
+- no PR is created or updated
+- no `Finisher` shutdown checks run
+- the run attempts to end with a normal completion-style summary
+
+The expected result is failure, not success. The pressure test should require one of these acceptable outcomes:
+
+1. the run continues into `Reviewer` and then `Finisher`, or
+2. the run halts explicitly with the contract-style blocker message
+
+This keeps the change grounded in observable behavior instead of only checking for stronger wording in isolation.
+
+### Scope Of Repository Changes
+
+The implementation should stay narrow and target only the surfaces that directly control or validate this behavior:
+
+- `skills/superteam/SKILL.md`
+  - strengthen the post-implementation routing contract
+- `skills/superteam/agent-spawn-template.md`
+  - mirror the routing requirement in delegated prompts
+- `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+  - add a walkthrough for the local-only early-stop failure mode
+
+Update other files only if they directly undermine this fix.
+
+## Testing And Verification
+
+- verify the canonical skill makes the transition from `Executor` to `Reviewer` mandatory unless the run halts explicitly
+- verify the canonical skill makes the transition from `Reviewer` to `Finisher` mandatory unless the run halts explicitly
+- verify the canonical skill forbids completion-style closeout after local-only work
+- verify the agent spawn template mirrors the same post-implementation routing rule in Codex-facing prompts
+- verify both files use the contract-style halt message when the workflow cannot continue safely
+- verify the pressure tests include the exact `#21` failure mode: local implementation complete, no reviewer pass, no PR publication, no finisher shutdown checks, attempted completion-style closeout
+- verify the pressure test treats that scenario as a failure unless the run continues correctly or halts explicitly
+
+## Acceptance Criteria
+
+- AC-21-1: Given a `superteam` run has completed local implementation work, when neither `Reviewer` nor `Finisher` has satisfied their required responsibilities, then the run cannot end successfully with a completion-style closeout
+- AC-21-2: Given `Executor` has completed local implementation work, when the workflow advances normally, then it routes into `Reviewer` and then `Finisher` rather than stopping after local-only work
+- AC-21-3: Given the workflow cannot continue safely into `Reviewer` or `Finisher`, when the run stops, then it reports `superteam halted at <teammate or gate>: <reason>` instead of implying success
+- AC-21-4: Given delegated Codex-facing teammate prompts are used, when they describe post-implementation behavior, then they match the canonical rule that local implementation completion is not workflow completion
+- AC-21-5: Given the repo-local pressure tests are run, when the `#21` failure mode is exercised, then the tests fail any run that ends after local-only work without reviewer, PR publication, and finisher follow-through
+
+## Implementation Notes
+
+- Keep the fix centered on the post-implementation transition contract
+- Reuse the existing halt format instead of inventing new failure messaging
+- Avoid duplicating the full `#18` shutdown model unless a small reminder is needed for clarity

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -170,6 +170,7 @@ If revisions are requested after an approval pass, re-fire approval with delta-o
 - Implement only the assigned tasks from the approved plan.
 - Report completion against explicit task IDs.
 - Include concrete completion evidence, SHAs, and verification evidence before claiming completion.
+- `Executor` completion is not workflow completion. After local implementation work is complete, the run must either continue into `Reviewer` and then `Finisher`, or halt explicitly as `superteam halted at <teammate or gate>: <reason>`.
 - Never push, rebase, or open a PR.
 - Recommend `superpowers:test-driven-development` as the ATDD execution skill.
 - Recommend `superpowers:systematic-debugging` when debugging or failures appear.
@@ -266,6 +267,7 @@ Before resolving or replying to comments tied to a prior branch state:
 - Local review findings taking ownership of external PR feedback away from `Finisher`.
 - `Finisher` resolving prior-state comments without checking current branch state first.
 - Treating local-only state as a valid end state for a `superteam` run.
+- Letting a run stop with a completion-style closeout after `Executor` finishes local work without reaching `Reviewer` and `Finisher`, unless the run halts explicitly with a blocker.
 - Treating PR publication plus a status snapshot as the end of the workflow while `Finisher`-owned work is still active.
 - Shutting down with unresolved review threads or other blocking external PR feedback still open.
 

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -23,6 +23,7 @@ Agent({
            3. If your work touches `skills/**/*.md`, invoke `superpowers:writing-skills` before editing.
            4. Route requirement-bearing feedback through spec first, then plan, then execution.
            5. `Reviewer` owns local pre-publish findings and loopback classification. `Finisher` owns publish-state follow-through and external PR feedback.
+           6. `Executor` completion is not workflow completion. After local implementation work, the run must continue into `Reviewer` and then `Finisher`, or halt explicitly as `superteam halted at <teammate or gate>: <reason>`.
            {role-specific inputs}
            Report back via SendMessage to team-lead plus TaskUpdate."
 })
@@ -95,6 +96,7 @@ Recommend `superpowers:verification-before-completion` before claiming completio
 If any task touches `skills/**/*.md`, also recommend `superpowers:writing-skills`.
 
 Implement only the assigned task batch.
+Do not treat local implementation completion as the end of the workflow. Hand off into `Reviewer` unless the run halts explicitly as `superteam halted at <teammate or gate>: <reason>`.
 Do not push, rebase, or open a PR.
 Done-report contract:
 - `completed_task_ids[]`: explicit task IDs completed in this batch
@@ -114,6 +116,7 @@ Recommend `superpowers:writing-skills` when reviewing changes to `skills/**/*.md
 
 Review locally before publish.
 Own receiving and interpreting local pre-publish review findings.
+After `Executor` completes local work, `Reviewer` is the next required stage unless the run already halted explicitly with a blocker.
 When the changed scope includes `skills/**/*.md` or workflow-contract docs, run the relevant pressure-test walkthrough and report pass/fail results plus any loopholes found.
 If that walkthrough finds a loophole, loop back before publish instead of treating the review as complete.
 Done-report contract:
@@ -134,6 +137,7 @@ Recommend `superpowers:receiving-code-review` when handling PR comments, review 
 
 Own publish-state follow-through and all external review/comment handling.
 Own receiving and interpreting external post-publish PR feedback.
+After `Reviewer` completes the local pre-publish pass, `Finisher` is the next required stage unless the run halts explicitly with a blocker.
 Every `superteam` run is expected to publish a PR. Local-only state is never a valid completion, demo, or handoff state.
 Push the branch and create or update the PR before treating the run as being in publish-state follow-through.
 Stay in the `Finisher` loop after PR publication until the publish-state follow-through is stable enough to hand off cleanly or an explicit blocker is reported.


### PR DESCRIPTION
## Summary
- require the post-implementation transition from Executor into Reviewer and Finisher, or an explicit halt
- mirror the same handoff rule in the delegated spawn template so Codex-facing prompts cannot stop early
- add a behavioral pressure-test scenario for the local-only polished-closeout failure mode

## Linked Issue
- Closes #21

## Validation Notes
- `rg -n 'Executor completion is not workflow completion|completion-style closeout|next required stage|Run ends after local implementation without reaching Reviewer or Finisher|Behavioral check' skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
- `git show --stat --oneline HEAD`
- `git status --short`
- `pnpm exec commitlint --help` currently fails in this worktree because `commitlint` is not installed locally

## Acceptance Criteria
### AC-21-1
Prevent local-only completion-style closeout once implementation is done and Reviewer/Finisher responsibilities remain unsatisfied.
- [x] Added canonical skill language that makes Executor completion non-terminal.
- [x] Added delegated prompt language that preserves the same rule in Codex-facing handoffs.

### AC-21-2
Route normal post-implementation flow into Reviewer and then Finisher instead of stopping after local-only work.
- [x] Added explicit next-stage language for Reviewer after Executor work.
- [x] Added explicit next-stage language for Finisher after Reviewer completes.

### AC-21-3
If the workflow cannot continue safely, halt with the contract-style blocker message instead of implying success.
- [x] Canonical and delegated wording both use `superteam halted at <teammate or gate>: <reason>` as the explicit halt path.

### AC-21-4
Keep delegated Codex-facing prompts aligned with the canonical rule that local implementation completion is not workflow completion.
- [x] Updated the global hard rules in the spawn template.
- [x] Updated the Executor, Reviewer, and Finisher role blocks for the same handoff rule.

### AC-21-5
Preserve the same two allowed post-implementation outcomes across both the canonical skill and delegated spawn template.
- [x] Verified both surfaces allow only continuing into Reviewer/Finisher or halting explicitly.

### AC-21-6
Cover the exact failure mode where a run ends after local-only work with no reviewer pass, no PR publication, and no finisher follow-through.
- [x] Added a repo-local pressure-test scenario for the polished local-only closeout case.
- [x] Made the walkthrough behavioral rather than wording-only so it judges reroute-or-halt behavior.

Closes #21 