### PR TITLE
docs: #24 add closing keywords to finisher prs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,9 @@ This title rule applies to pull requests only. GitHub issue titles should stay p
 
 ## Linked Issue
 
-- 
+- `Closes #<issue>` when this PR is intended to complete the issue
+- Otherwise: `Related to #<issue>` plus a short explanation of why this PR does not close it yet
+- Omit this section when no issue applies
 
 ## Acceptance Criteria
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,13 +14,13 @@ This title rule applies to pull requests only. GitHub issue titles should stay p
 
 - 
 
-## Linked Issue
+## Linked issue
 
 - `Closes #<issue>` when this PR is intended to complete the issue
 - Otherwise: `Related to #<issue>` plus a short explanation of why this PR does not close it yet
 - Omit this section when no issue applies
 
-## Acceptance Criteria
+## Acceptance criteria
 
 ### AC-<issue>-<n>
 Short outcome summary.
@@ -34,7 +34,7 @@ Deferred to `<repo-or-follow-up>`.
 
 - Additional validation not tied to a single AC, if any
 
-## Docs Updated
+## Docs updated
 
 - [ ] Not needed
 - [ ] Updated in this PR

--- a/docs/superpowers/plans/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-plan.md
+++ b/docs/superpowers/plans/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-plan.md
@@ -1,0 +1,134 @@
+# Plan: Finisher should add closing keywords to PRs when an issue is present [#24](https://github.com/patinaproject/superteam/issues/24)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `Finisher` render `Closes #<issue-number>` in PR bodies for issue-completing runs, require a brief explanation for issue-linked non-closing runs, and keep the implementation narrow without adding new intent-detection heuristics.
+
+**Architecture:** Update the canonical PR body template first so the desired output shape is explicit. Then mirror the same narrow rule in the directly relevant `Finisher` contract surfaces. Finally, inspect PR-facing mirrored docs and only update any file whose wording would otherwise contradict the new contract.
+
+**Tech Stack:** Markdown docs, repository workflow assets, `rg`, `sed`
+
+---
+
+## File Structure
+
+- `docs/superpowers/specs/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-design.md`
+  - Approved design doc and source of acceptance criteria.
+- `docs/superpowers/plans/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-plan.md`
+  - This implementation plan.
+- `skills/superteam/pr-body-template.md`
+  - Canonical PR body output contract for `Finisher`.
+- `skills/superteam/SKILL.md`
+  - Canonical `superteam` workflow contract; update only if the `Finisher` PR-body rule needs to be explicit here.
+- `skills/superteam/agent-spawn-template.md`
+  - Directly relevant `Finisher` prompt surface; mirror the narrow PR-body rule if needed.
+- `.github/pull_request_template.md`
+  - Repository PR-facing template to inspect for contradiction before deciding whether any mirrored doc change is necessary.
+
+### Task 1: Make the PR body template encode the new issue-closing contract
+
+**Files:**
+- Modify: `skills/superteam/pr-body-template.md`
+
+- [ ] **Step 1: Inspect the current template and locate the top-of-body placement**
+
+Run: `sed -n '1,220p' skills/superteam/pr-body-template.md`
+Expected: identify where a linked-issue line can be added near the top without disturbing the existing acceptance-criteria structure.
+
+- [ ] **Step 2: Add the minimal template change**
+
+Update `skills/superteam/pr-body-template.md` so it includes explicit issue-linking guidance near the top, equivalent to:
+
+```md
+## Linked Issue
+- `Closes #<issue-number>` when this PR is intended to complete the issue
+- Otherwise: `Related to #<issue-number>` plus one short explanation of why the PR does not close it yet
+- Omit this section entirely when no issue number is present
+```
+
+Keep the rest of the PR body structure intact.
+
+- [ ] **Step 3: Re-read the template for clarity**
+
+Run: `sed -n '1,240p' skills/superteam/pr-body-template.md`
+Expected: the issue-linking contract is easy to find, uses `Closes` as the canonical closing keyword, and does not imply that a fake issue should be invented.
+
+### Task 2: Mirror the same narrow rule in the directly relevant Finisher contract
+
+**Files:**
+- Modify: `skills/superteam/SKILL.md`
+- Modify: `skills/superteam/agent-spawn-template.md`
+
+- [ ] **Step 1: Inspect the current Finisher wording**
+
+Run: `rg -n "PR body|pull request body|Closes|Related to|issue number|issue is present" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md`
+Expected: confirm whether the rule is absent or too implicit in the `Finisher` contract surfaces.
+
+- [ ] **Step 2: Add the minimal wording needed for contract parity**
+
+Update only the directly relevant `Finisher` text so it states all of the following:
+
+```md
+When a real issue number is available and the run is issue-completing, render `Closes #<issue-number>` in the PR body.
+When the issue is related but not complete, render a non-closing issue reference and a brief explanation.
+When no issue number is present, omit the issue-reference line entirely.
+Do not invent a new intent-detection system or infer intent from weak heuristics such as commit wording, diff size, or acceptance-criteria count.
+```
+
+Keep the broader publish-state workflow unchanged.
+
+- [ ] **Step 3: Re-read the Finisher wording in context**
+
+Run: `sed -n '180,260p' skills/superteam/SKILL.md && sed -n '130,220p' skills/superteam/agent-spawn-template.md`
+Expected: the PR-body rule is explicit, narrow, and consistent with the approved design.
+
+### Task 3: Inspect mirrored docs and update only if needed
+
+**Files:**
+- Inspect: `.github/pull_request_template.md`
+- Modify only if contradictory: `.github/pull_request_template.md`
+
+- [ ] **Step 1: Inspect the mirrored PR-facing doc**
+
+Run: `sed -n '1,220p' .github/pull_request_template.md`
+Expected: determine whether the repo PR template already permits the new linked-issue contract or would contradict it.
+
+- [ ] **Step 2: Make no change unless contradiction is real**
+
+If the mirrored template would contradict the new contract, update it minimally so it allows the same three-way behavior:
+
+```md
+- `Closes #<issue-number>` for issue-completing PRs
+- `Related to #<issue-number>` plus a short explanation for non-closing issue-linked PRs
+- no issue-reference line when no issue exists
+```
+
+If there is no contradiction, leave the file untouched.
+
+- [ ] **Step 3: Verify the final changed scope stays narrow**
+
+Run: `git diff -- skills/superteam/pr-body-template.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md .github/pull_request_template.md`
+Expected: only the PR-body contract and directly relevant mirrored wording changed, with no unrelated workflow edits.
+
+### Task 4: Verify acceptance coverage for the final doc changes
+
+**Files:**
+- Verify: `skills/superteam/pr-body-template.md`
+- Verify: `skills/superteam/SKILL.md`
+- Verify: `skills/superteam/agent-spawn-template.md`
+- Verify: `.github/pull_request_template.md`
+
+- [ ] **Step 1: Confirm the canonical closing keyword path**
+
+Run: `rg -n "Closes #<issue-number>|Closes #|Related to #<issue-number>|Related to #" skills/superteam/pr-body-template.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md .github/pull_request_template.md`
+Expected: the canonical `Closes` path is present where needed, and the non-closing path is present only where relevant.
+
+- [ ] **Step 2: Confirm heuristic-free intent handling**
+
+Run: `rg -n "heuristic|commit wording|diff size|acceptance-criteria count|invent" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md`
+Expected: the contract explicitly avoids new intent-detection heuristics.
+
+- [ ] **Step 3: Confirm acceptance-criteria coverage**
+
+Run: `sed -n '1,220p' docs/superpowers/specs/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-design.md`
+Expected: final edits cover `AC-24-1` through `AC-24-4` without broadening scope.

--- a/docs/superpowers/plans/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-plan.md
+++ b/docs/superpowers/plans/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-plan.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make `Finisher` render `Closes #<issue-number>` in PR bodies for issue-completing runs, require a brief explanation for issue-linked non-closing runs, and keep the implementation narrow without adding new intent-detection heuristics.
+**Goal:** Make `Finisher` render `Closes #<issue-number>` in PR bodies for issue-completing runs, require a brief explanation for issue-linked non-closing runs, treat project-owned PR templates as authoritative when they exist, and use Sentence case headings in this repo's PR templates without adding new intent-detection heuristics.
 
-**Architecture:** Update the canonical PR body template first so the desired output shape is explicit. Then mirror the same narrow rule in the directly relevant `Finisher` contract surfaces. Finally, inspect PR-facing mirrored docs and only update any file whose wording would otherwise contradict the new contract.
+**Architecture:** Update the canonical `superteam` PR body template first so the desired fallback shape and project-template precedence rule are explicit. Then mirror the same narrow rule in the directly relevant `Finisher` contract surfaces. Finally, update this repository's `.github` PR template so it stays aligned with the fallback contract and uses Sentence case headings.
 
 **Tech Stack:** Markdown docs, repository workflow assets, `rg`, `sed`
 
@@ -23,9 +23,9 @@
 - `skills/superteam/agent-spawn-template.md`
   - Directly relevant `Finisher` prompt surface; mirror the narrow PR-body rule if needed.
 - `.github/pull_request_template.md`
-  - Repository PR-facing template to inspect for contradiction before deciding whether any mirrored doc change is necessary.
+  - Repository PR-facing template; keep it aligned with the fallback contract and convert its headings to Sentence case.
 
-### Task 1: Make the PR body template encode the new issue-closing contract
+### Task 1: Make the fallback PR body template encode precedence and issue-linking behavior
 
 **Files:**
 - Modify: `skills/superteam/pr-body-template.md`
@@ -37,21 +37,23 @@ Expected: identify where a linked-issue line can be added near the top without d
 
 - [ ] **Step 2: Add the minimal template change**
 
-Update `skills/superteam/pr-body-template.md` so it includes explicit issue-linking guidance near the top, equivalent to:
+Update `skills/superteam/pr-body-template.md` so it includes explicit issue-linking guidance near the top and a precedence rule, equivalent to:
 
 ```md
+If the project has its own PR template or PR-body rules, satisfy that project-owned template first. Use this template as the fallback/default shape when no project-specific surface overrides it.
+
 ## Linked Issue
 - `Closes #<issue-number>` when this PR is intended to complete the issue
 - Otherwise: `Related to #<issue-number>` plus one short explanation of why the PR does not close it yet
 - Omit this section entirely when no issue number is present
 ```
 
-Keep the rest of the PR body structure intact.
+Keep the dedicated `Linked issue` section and convert the affected headings in this template to Sentence case.
 
 - [ ] **Step 3: Re-read the template for clarity**
 
 Run: `sed -n '1,240p' skills/superteam/pr-body-template.md`
-Expected: the issue-linking contract is easy to find, uses `Closes` as the canonical closing keyword, and does not imply that a fake issue should be invented.
+Expected: the precedence rule is explicit, the issue-linking contract is easy to find, the headings are in Sentence case, and the template does not imply that a fake issue should be invented.
 
 ### Task 2: Mirror the same narrow rule in the directly relevant Finisher contract
 
@@ -69,6 +71,7 @@ Expected: confirm whether the rule is absent or too implicit in the `Finisher` c
 Update only the directly relevant `Finisher` text so it states all of the following:
 
 ```md
+When a project-owned PR template exists, satisfy it first and treat the `superteam` PR template as fallback/default guidance.
 When a real issue number is available and the run is issue-completing, render `Closes #<issue-number>` in the PR body.
 When the issue is related but not complete, render a non-closing issue reference and a brief explanation.
 When no issue number is present, omit the issue-reference line entirely.
@@ -82,33 +85,37 @@ Keep the broader publish-state workflow unchanged.
 Run: `sed -n '180,260p' skills/superteam/SKILL.md && sed -n '130,220p' skills/superteam/agent-spawn-template.md`
 Expected: the PR-body rule is explicit, narrow, and consistent with the approved design.
 
-### Task 3: Inspect mirrored docs and update only if needed
+### Task 3: Align the project-owned PR template with the fallback contract
 
 **Files:**
-- Inspect: `.github/pull_request_template.md`
-- Modify only if contradictory: `.github/pull_request_template.md`
+- Modify: `.github/pull_request_template.md`
 
-- [ ] **Step 1: Inspect the mirrored PR-facing doc**
+- [ ] **Step 1: Inspect the project-owned PR-facing doc**
 
 Run: `sed -n '1,220p' .github/pull_request_template.md`
-Expected: determine whether the repo PR template already permits the new linked-issue contract or would contradict it.
+Expected: confirm the linked-issue section and heading casing that need to stay aligned with the fallback contract.
 
-- [ ] **Step 2: Make no change unless contradiction is real**
+- [ ] **Step 2: Update only the project-level presentation details that should align**
 
-If the mirrored template would contradict the new contract, update it minimally so it allows the same three-way behavior:
+Update `.github/pull_request_template.md` so it preserves the dedicated `Linked issue` section, supports the same three-way issue-linking behavior, and uses Sentence case headings, for example:
 
 ```md
+- `Summary`
+- `Linked issue`
+- `Acceptance criteria`
+- `Validation`
+- `Docs updated`
 - `Closes #<issue-number>` for issue-completing PRs
 - `Related to #<issue-number>` plus a short explanation for non-closing issue-linked PRs
 - no issue-reference line when no issue exists
 ```
 
-If there is no contradiction, leave the file untouched.
+Keep the repo-specific PR title guidance and overall structure intact.
 
 - [ ] **Step 3: Verify the final changed scope stays narrow**
 
 Run: `git diff -- skills/superteam/pr-body-template.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md .github/pull_request_template.md`
-Expected: only the PR-body contract and directly relevant mirrored wording changed, with no unrelated workflow edits.
+Expected: only the fallback PR-body contract, directly relevant `Finisher` wording, and Sentence case/project-template alignment changed, with no unrelated workflow edits.
 
 ### Task 4: Verify acceptance coverage for the final doc changes
 
@@ -123,12 +130,17 @@ Expected: only the PR-body contract and directly relevant mirrored wording chang
 Run: `rg -n "Closes #<issue-number>|Closes #|Related to #<issue-number>|Related to #" skills/superteam/pr-body-template.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md .github/pull_request_template.md`
 Expected: the canonical `Closes` path is present where needed, and the non-closing path is present only where relevant.
 
-- [ ] **Step 2: Confirm heuristic-free intent handling**
+- [ ] **Step 2: Confirm project-template precedence and heuristic-free intent handling**
 
-Run: `rg -n "heuristic|commit wording|diff size|acceptance-criteria count|invent" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md`
-Expected: the contract explicitly avoids new intent-detection heuristics.
+Run: `rg -n "project-owned PR template|fallback/default|heuristic|commit wording|diff size|acceptance-criteria count|invent" skills/superteam/pr-body-template.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md`
+Expected: the contract explicitly gives project-owned templates precedence and avoids new intent-detection heuristics.
 
-- [ ] **Step 3: Confirm acceptance-criteria coverage**
+- [ ] **Step 3: Confirm Sentence case headings and dedicated linked-issue section**
+
+Run: `rg -n "^## |^### " skills/superteam/pr-body-template.md .github/pull_request_template.md`
+Expected: the affected PR headings use Sentence case and keep `Linked issue` as a dedicated section.
+
+- [ ] **Step 4: Confirm acceptance-criteria coverage**
 
 Run: `sed -n '1,220p' docs/superpowers/specs/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-design.md`
-Expected: final edits cover `AC-24-1` through `AC-24-4` without broadening scope.
+Expected: final edits cover `AC-24-1` through `AC-24-6` without broadening scope.

--- a/docs/superpowers/specs/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-design.md
+++ b/docs/superpowers/specs/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-design.md
@@ -10,6 +10,8 @@ Teach `Finisher` to include a GitHub-recognized closing-keyword line in the gene
 - Keep the line in a GitHub-recognized format for automatic issue closure on merge
 - Require a brief explanation when an issue is present but the PR intentionally does not close it
 - Preserve the current behavior when no issue number is present by omitting the issue-closing line entirely
+- Treat a project-owned PR template as the authority when one exists, with `superteam` providing fallback/default PR-body structure rather than overriding project-owned presentation
+- Use Sentence case headings in this repository's PR templates
 - Keep the change focused on `Finisher` PR-body generation guidance instead of redesigning the broader publish workflow
 
 ## Non-Goals
@@ -17,6 +19,7 @@ Teach `Finisher` to include a GitHub-recognized closing-keyword line in the gene
 - Introducing a new issue-detection mechanism beyond the issue context already available to the workflow
 - Changing PR title rules or acceptance-criteria formatting
 - Adding multiple closing lines or supporting arbitrary linked-work item formats outside standard GitHub issue references
+- Building a generalized template-merging engine beyond a simple precedence rule
 
 ## Approaches Considered
 
@@ -44,6 +47,23 @@ The generated PR body should include a dedicated linked-issue area near the top 
 
 The design assumes one issue number for the current workflow because that is the repository convention surfaced by the current branch and issue-driven docs. The template should use placeholders that make the issue number explicit while still allowing omission when the workflow has no issue.
 
+The linked issue should stay in its own `Linked issue` section rather than becoming the first `Summary` bullet. The issue reference is workflow-significant metadata rather than a prose summary item, so a dedicated section keeps the automation contract easier to scan and less likely to get rewritten as free-form text.
+
+PR headings in this repository's templates should use Sentence case, including `Linked issue`, `Branch state`, `Test plan`, `Review follow-up`, `Known CI state`, and other human-facing headings.
+
+### Project template precedence
+
+When a repository has its own PR template or explicit PR-body rules, that project-owned template is the outer authority. `superteam` should treat its own PR-body template as the fallback/default contract for teammate behavior, not as a replacement for project-owned presentation.
+
+The precedence rule should stay simple:
+
+- if the project has its own PR template, `Finisher` should satisfy that template first
+- if the project template and `superteam` template do not conflict, `Finisher` may merge `superteam`'s required issue-linking behavior into the project template
+- if there is a conflict, project-level PR-template requirements win over `superteam` presentation details
+- do not turn this rule into a generalized template-merging engine or speculative formatting system
+
+For this repository, that means the checked-in `.github` PR template should stay aligned with the `superteam` fallback template so the local project surface and the skill-owned default do not drift apart.
+
 ### Conditional rendering rule
 
 `Finisher` should render the closing-keyword line only when the workflow has a real issue number available and the PR is intended to complete that issue. If no issue number is present, `Finisher` must omit the line instead of inventing a placeholder, fake reference, or malformed keyword.
@@ -70,8 +90,10 @@ Do not add heuristics that infer intent from commit messages, diff size, accepta
 The repository changes should stay narrow:
 
 - update [`skills/superteam/pr-body-template.md`](/Users/tlmader/.codex/worktrees/d113/superteam/skills/superteam/pr-body-template.md) so the template shows where the closing keyword line goes and makes omission explicit when no issue is present
+- update the fallback template wording so it explicitly defers to project-owned PR templates when they exist
 - update the directly relevant `Finisher` guidance in [`skills/superteam/SKILL.md`](/Users/tlmader/.codex/worktrees/d113/superteam/skills/superteam/SKILL.md) and/or [`skills/superteam/agent-spawn-template.md`](/Users/tlmader/.codex/worktrees/d113/superteam/skills/superteam/agent-spawn-template.md) if needed so the teammate contract explicitly requires that behavior
-- inspect mirrored public-facing docs before editing them; only update a mirrored doc if it already describes PR body behavior closely enough that leaving it unchanged would create a contradiction
+- inspect mirrored public-facing docs before editing them; update the repository-owned PR template because it is the project-level surface for this repo and should stay aligned with the fallback template
+- convert the affected PR-template headings in this repo to Sentence case while keeping the existing structure otherwise intact
 
 At the time of implementation, this means checking the repository-owned PR templates and public workflow docs first, then editing only the files that would otherwise disagree with the new `Finisher` contract.
 
@@ -81,6 +103,8 @@ At the time of implementation, this means checking the repository-owned PR templ
 - `AC-24-2`: The closing-keyword line uses a GitHub-recognized automatic-closing format.
 - `AC-24-3`: When an issue number is present but the PR intentionally does not close it, `Finisher` includes a brief explanation instead of silently omitting the issue reference.
 - `AC-24-4`: When no issue number is present, `Finisher` omits the issue-reference line and does not invent an issue reference.
+- `AC-24-5`: When a project-owned PR template exists, `Finisher` treats it as authoritative and uses the `superteam` PR template as fallback/default guidance rather than as an override.
+- `AC-24-6`: The repo PR templates use Sentence case headings, and the issue reference stays in a dedicated `Linked issue` section rather than moving into `Summary`.
 
 ## Testing And Verification
 
@@ -88,5 +112,7 @@ At the time of implementation, this means checking the repository-owned PR templ
 - inspect the relevant `Finisher` contract text to confirm the behavior is conditional on both issue presence and issue-completing intent
 - verify the template includes a non-closing issue-reference explanation path for issue-linked partial work
 - verify the implementation rules do not introduce new heuristics for inferring intent
-- inspect mirrored PR-facing docs and confirm only genuinely contradictory docs were changed
+- inspect the fallback template and `Finisher` wording to confirm project-owned PR templates take precedence when they exist
+- inspect mirrored PR-facing docs and confirm the repository-owned PR template stays aligned with the fallback template
+- verify the affected PR headings use Sentence case and keep `Linked issue` as a dedicated section
 - verify there is no template text that implies a closing-keyword line must be emitted when no issue exists

--- a/docs/superpowers/specs/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-design.md
+++ b/docs/superpowers/specs/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-design.md
@@ -1,0 +1,92 @@
+# Design: Finisher should add closing keywords to PRs when an issue is present [#24](https://github.com/patinaproject/superteam/issues/24)
+
+## Summary
+
+Teach `Finisher` to include a GitHub-recognized closing-keyword line in the generated PR body whenever the current workflow has a real issue number available. Keep the change narrow by updating the PR body contract and the directly relevant `Finisher` wording so the workflow closes linked issues automatically on merge without inventing issue references when none exist.
+
+## Goals
+
+- Add a closing-keyword line such as `Closes #24` to generated PR bodies when the workflow has an issue number and the PR is intended to complete that issue
+- Keep the line in a GitHub-recognized format for automatic issue closure on merge
+- Require a brief explanation when an issue is present but the PR intentionally does not close it
+- Preserve the current behavior when no issue number is present by omitting the issue-closing line entirely
+- Keep the change focused on `Finisher` PR-body generation guidance instead of redesigning the broader publish workflow
+
+## Non-Goals
+
+- Introducing a new issue-detection mechanism beyond the issue context already available to the workflow
+- Changing PR title rules or acceptance-criteria formatting
+- Adding multiple closing lines or supporting arbitrary linked-work item formats outside standard GitHub issue references
+
+## Approaches Considered
+
+### Recommended: add an explicit linked-issue section and Finisher rule
+
+Update the PR body template so it contains a dedicated section or line for the closing keyword, and document that `Finisher` must render it only when an issue number is available. This keeps the contract visible in the exact artifact `Finisher` already uses and gives reviewers a stable place to inspect.
+
+### Alternative: mention closing keywords only in prose guidance
+
+Document the behavior only in `Finisher` instructions without updating the PR template. This is weaker because the desired output shape stays implicit and is easier to omit or render inconsistently.
+
+### Alternative: add the closing keyword to the summary section ad hoc
+
+Allow `Finisher` to place the closing keyword somewhere in `## Summary`. This technically could work, but it hides an important automation contract inside free-form prose and makes future review harder.
+
+## Design
+
+### PR body shape
+
+The generated PR body should include a dedicated linked-issue area near the top of the template so the closing keyword is easy to find and hard to forget. The rendered line should use a standard GitHub keyword format such as:
+
+- `Closes #<issue-number>`
+
+`Closes` should be the canonical keyword for this workflow. It is the most semantically direct match for the intended result: merging the PR closes the linked issue. The design should not vary between `Closes`, `Fixes`, and `Resolves` unless a future repository rule explicitly requires that flexibility.
+
+The design assumes one issue number for the current workflow because that is the repository convention surfaced by the current branch and issue-driven docs. The template should use placeholders that make the issue number explicit while still allowing omission when the workflow has no issue.
+
+### Conditional rendering rule
+
+`Finisher` should render the closing-keyword line only when the workflow has a real issue number available and the PR is intended to complete that issue. If no issue number is present, `Finisher` must omit the line instead of inventing a placeholder, fake reference, or malformed keyword.
+
+If an issue number is present but the PR intentionally does not close that issue, `Finisher` should still make the relationship explicit and explain the omission briefly. The PR body should include a non-closing linked-issue note plus a short explanation such as:
+
+- `Related to #<issue-number>`
+- `This PR does not close #<issue-number> because follow-up work remains.`
+
+This rule belongs in the directly relevant `Finisher` support text as well as the PR body template so both the output artifact and the teammate contract say the same thing.
+
+### Intent decision stays narrow
+
+The implementation should not invent a new intent-detection system. `Finisher` should use only explicit workflow context already available at PR-render time:
+
+- if the run is the canonical issue-backed workflow for a single issue and nothing in the current run says the work is partial, render `Closes #<issue-number>`
+- if the current run explicitly says the work is partial, follow-up, or otherwise not issue-completing, render the non-closing explanation path instead
+- if the workflow has no issue number, omit the issue-reference line entirely
+
+Do not add heuristics that infer intent from commit messages, diff size, acceptance-criteria count, branch wording beyond the issue number, or speculative interpretation of unfinished work. When the workflow lacks explicit non-closing intent, prefer the existing issue-completing default for issue-backed runs rather than adding new decision machinery.
+
+### Scope of repository changes
+
+The repository changes should stay narrow:
+
+- update [`skills/superteam/pr-body-template.md`](/Users/tlmader/.codex/worktrees/d113/superteam/skills/superteam/pr-body-template.md) so the template shows where the closing keyword line goes and makes omission explicit when no issue is present
+- update the directly relevant `Finisher` guidance in [`skills/superteam/SKILL.md`](/Users/tlmader/.codex/worktrees/d113/superteam/skills/superteam/SKILL.md) and/or [`skills/superteam/agent-spawn-template.md`](/Users/tlmader/.codex/worktrees/d113/superteam/skills/superteam/agent-spawn-template.md) if needed so the teammate contract explicitly requires that behavior
+- inspect mirrored public-facing docs before editing them; only update a mirrored doc if it already describes PR body behavior closely enough that leaving it unchanged would create a contradiction
+
+At the time of implementation, this means checking the repository-owned PR templates and public workflow docs first, then editing only the files that would otherwise disagree with the new `Finisher` contract.
+
+## Acceptance Criteria
+
+- `AC-24-1`: When an issue number is available in the current workflow and the PR is intended to complete that issue, `Finisher` adds a `Closes #<issue-number>` line to the generated PR body.
+- `AC-24-2`: The closing-keyword line uses a GitHub-recognized automatic-closing format.
+- `AC-24-3`: When an issue number is present but the PR intentionally does not close it, `Finisher` includes a brief explanation instead of silently omitting the issue reference.
+- `AC-24-4`: When no issue number is present, `Finisher` omits the issue-reference line and does not invent an issue reference.
+
+## Testing And Verification
+
+- inspect the PR body template to confirm it contains a dedicated closing-keyword line or section tied to an issue-number placeholder
+- inspect the relevant `Finisher` contract text to confirm the behavior is conditional on both issue presence and issue-completing intent
+- verify the template includes a non-closing issue-reference explanation path for issue-linked partial work
+- verify the implementation rules do not introduce new heuristics for inferring intent
+- inspect mirrored PR-facing docs and confirm only genuinely contradictory docs were changed
+- verify there is no template text that implies a closing-keyword line must be emitted when no issue exists

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -194,6 +194,7 @@ If revisions are requested after an approval pass, re-fire approval with delta-o
 - Own push, branch publication, PR updates, PR body rendering, CI triage, and external review/comment handling.
 - Own receiving and interpreting external post-publish PR feedback.
 - Report pushed SHAs, current branch state on origin, PR state, and CI state.
+- When a project-owned PR template or PR-body rule exists, satisfy it first and treat the `superteam` PR template as fallback/default guidance rather than as an override.
 - When a real issue number is available for the canonical single-issue workflow and nothing in the current run says the work is partial, follow-up, or otherwise non-closing, render `Closes #<issue-number>` in the PR body.
 - When the issue is related but the run is not issue-completing, render a non-closing issue reference plus a brief explanation.
 - When no issue number is present, omit the issue-reference line entirely.

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -194,6 +194,10 @@ If revisions are requested after an approval pass, re-fire approval with delta-o
 - Own push, branch publication, PR updates, PR body rendering, CI triage, and external review/comment handling.
 - Own receiving and interpreting external post-publish PR feedback.
 - Report pushed SHAs, current branch state on origin, PR state, and CI state.
+- When a real issue number is available for the canonical single-issue workflow and nothing in the current run says the work is partial, follow-up, or otherwise non-closing, render `Closes #<issue-number>` in the PR body.
+- When the issue is related but the run is not issue-completing, render a non-closing issue reference plus a brief explanation.
+- When no issue number is present, omit the issue-reference line entirely.
+- Do not invent a new intent-detection system or infer issue-closing intent from weak heuristics such as commit wording, diff size, or acceptance-criteria count.
 - Every `superteam` run is expected to publish a PR; local-only state is never a valid completion, demo, or handoff state.
 - Push the branch and create or update the PR before treating the run as being in publish-state follow-through.
 - Stay in the `Finisher` loop after PR publication until publish-state follow-through is stable enough to hand off cleanly or an explicit blocker is reported.

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -138,6 +138,10 @@ Recommend `superpowers:receiving-code-review` when handling PR comments, review 
 Own publish-state follow-through and all external review/comment handling.
 Own receiving and interpreting external post-publish PR feedback.
 After `Reviewer` completes the local pre-publish pass, `Finisher` is the next required stage unless the run halts explicitly with a blocker.
+When a real issue number is available for the canonical single-issue workflow and nothing in the current run says the work is partial, follow-up, or otherwise non-closing, render `Closes #<issue-number>` in the PR body.
+When the issue is related but not complete, render a non-closing issue reference plus a brief explanation.
+When no issue number is present, omit the issue-reference line entirely.
+Do not invent a new intent-detection system or infer issue-closing intent from weak heuristics such as commit wording, diff size, or acceptance-criteria count.
 Every `superteam` run is expected to publish a PR. Local-only state is never a valid completion, demo, or handoff state.
 Push the branch and create or update the PR before treating the run as being in publish-state follow-through.
 Stay in the `Finisher` loop after PR publication until the publish-state follow-through is stable enough to hand off cleanly or an explicit blocker is reported.

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -138,6 +138,7 @@ Recommend `superpowers:receiving-code-review` when handling PR comments, review 
 Own publish-state follow-through and all external review/comment handling.
 Own receiving and interpreting external post-publish PR feedback.
 After `Reviewer` completes the local pre-publish pass, `Finisher` is the next required stage unless the run halts explicitly with a blocker.
+When a project-owned PR template or PR-body rule exists, satisfy it first and treat the `superteam` PR template as fallback/default guidance rather than as an override.
 When a real issue number is available for the canonical single-issue workflow and nothing in the current run says the work is partial, follow-up, or otherwise non-closing, render `Closes #<issue-number>` in the PR body.
 When the issue is related but not complete, render a non-closing issue reference plus a brief explanation.
 When no issue number is present, omit the issue-reference line entirely.

--- a/skills/superteam/pr-body-template.md
+++ b/skills/superteam/pr-body-template.md
@@ -6,6 +6,11 @@
 ## Summary
 - <1-3 bullets>
 
+## Linked Issue
+- `Closes #<issue-number>` when this PR is intended to complete the issue
+- Otherwise: `Related to #<issue-number>` plus one short explanation of why this PR does not close it yet
+- Omit this section entirely when no issue number is present
+
 ## Branch state
 - Latest pushed branch state: `<branch>@<sha>`
 - Review state: <no open findings | open findings summarized below>
@@ -36,6 +41,9 @@ Only include this section when CI is still red and the operator has explicitly c
 
 ## Status rules
 
+- Use `Closes #<issue-number>` as the canonical closing-keyword line for issue-completing runs.
+- If the issue is related but not complete, keep a non-closing issue reference and explain the omission briefly.
+- If no issue number is present, omit the linked-issue section instead of inventing a placeholder.
 - Use the summary line under each `### AC-<issue-number>-<n>` heading for the outcome.
 - Use checkboxes only for verification steps beneath the AC heading.
 - Keep the acceptance criteria and verification synchronized with the latest pushed branch state.

--- a/skills/superteam/pr-body-template.md
+++ b/skills/superteam/pr-body-template.md
@@ -2,11 +2,13 @@
 
 `Finisher` renders this when opening or updating a PR so acceptance criteria, review state, and verification stay anchored to the latest pushed branch state.
 
+If the project has its own PR template or explicit PR-body rules, satisfy that project-owned template first. Use this template as the fallback/default shape when no project-specific surface overrides it.
+
 ````markdown
 ## Summary
 - <1-3 bullets>
 
-## Linked Issue
+## Linked issue
 - `Closes #<issue-number>` when this PR is intended to complete the issue
 - Otherwise: `Related to #<issue-number>` plus one short explanation of why this PR does not close it yet
 - Omit this section entirely when no issue number is present
@@ -16,7 +18,7 @@
 - Review state: <no open findings | open findings summarized below>
 - CI state: <passing | failing | pending>
 
-## Acceptance Criteria
+## Acceptance criteria
 ### AC-<issue-number>-1
 Short outcome summary for this acceptance criterion.
 - [ ] Verification: `path/to/test.spec.ts > should ...` — ✅ verified
@@ -41,6 +43,7 @@ Only include this section when CI is still red and the operator has explicitly c
 
 ## Status rules
 
+- If a project-owned PR template exists, treat it as authoritative and use this template as fallback/default guidance rather than as an override.
 - Use `Closes #<issue-number>` as the canonical closing-keyword line for issue-completing runs.
 - If the issue is related but not complete, keep a non-closing issue reference and explain the omission briefly.
 - If no issue number is present, omit the linked-issue section instead of inventing a placeholder.


### PR DESCRIPTION
## Summary

- add an explicit project-template-precedence rule so `superteam` treats repository-owned PR templates as authoritative when they exist
- keep `Linked issue` as a dedicated section and preserve the canonical `Closes #<issue-number>` / `Related to #<issue-number>` behavior
- convert the repository PR templates to Sentence case headings and align the `Finisher` contract surfaces with that rule

## Linked issue

- Closes #24

## Acceptance criteria

### AC-24-1
`Finisher` adds `Closes #<issue-number>` for canonical issue-completing runs.

- [x] `rg -n "Closes #<issue-number>|canonical single-issue workflow" skills/superteam/pr-body-template.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md`

### AC-24-2
The closing path uses a GitHub-recognized automatic-closing format.

- [x] `sed -n '1,80p' skills/superteam/pr-body-template.md`

### AC-24-3
Issue-linked non-closing runs include a brief explanation instead of silent omission.

- [x] `rg -n "Related to #<issue-number>|Related to #<issue>" skills/superteam/pr-body-template.md .github/pull_request_template.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md`

### AC-24-4
No-issue runs omit the issue-reference line and do not invent an issue.

- [x] `rg -n "omit the issue-reference line entirely|Omit this section entirely when no issue number is present|Omit this section when no issue applies" skills/superteam/pr-body-template.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md .github/pull_request_template.md`

### AC-24-5
Project-owned PR templates take precedence, with the `superteam` template acting as fallback/default guidance.

- [x] `rg -n "project-owned PR template|fallback/default" skills/superteam/pr-body-template.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md`

### AC-24-6
The repo PR templates use Sentence case headings, and the issue reference stays in a dedicated `Linked issue` section.

- [x] `rg -n "^## " skills/superteam/pr-body-template.md .github/pull_request_template.md`

## Validation

- local review pass included a follow-up fix to restore the explicit default-to-`Closes` path for canonical single-issue runs
- `git diff -- skills/superteam/pr-body-template.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md .github/pull_request_template.md docs/superpowers/specs/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-design.md docs/superpowers/plans/2026-04-23-24-finisher-should-add-closing-keywords-to-prs-when-an-issue-is-present-plan.md`

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
