### PR TITLE
docs: #26 keep finisher monitoring pending PR checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,9 @@ No formal test suite exists yet. Validate changes with targeted file checks and 
 - Check rewritten references with `rg '<pattern>'`
 - Review rendered content with `sed -n '1,200p' <file>`
 - Verify root install metadata with `sed -n '1,200p' .codex-plugin/plugin.json` and confirm there is no stale `plugins/superteam/` tree
+- For changes to `skills/**/*.md` and workflow-contract guidance, do not claim production readiness from confidence language alone.
+- Readiness claims for those changes must be backed by the required pressure tests, review loops, and role-specific verification that actually ran.
+- If that evidence is incomplete, report the missing evidence or blocker explicitly instead of asserting readiness.
 
 If you add executable tooling later, document the exact verification command in `docs/`.
 

--- a/docs/superpowers/plans/2026-04-23-26-finisher-should-keep-monitoring-pr-checks-until-stable-or-blocked-plan.md
+++ b/docs/superpowers/plans/2026-04-23-26-finisher-should-keep-monitoring-pr-checks-until-stable-or-blocked-plan.md
@@ -1,0 +1,236 @@
+# Plan: Finisher should keep monitoring PR checks until stable or blocked [#26](https://github.com/patinaproject/superteam/issues/26)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Use checkbox (`- [ ]`) tracking while executing. When editing `skills/**/*.md`, invoke `superpowers:writing-skills` before editing. During local review of skill or workflow-contract changes, invoke `superpowers:writing-skills` and run the relevant pressure-test walkthrough before publish.
+
+**Goal:** Keep `Finisher` in publish-state follow-through while required checks on the latest pushed PR head are still pending, reroute automatically when later failures appear, and allow a ready handoff only after the latest head is actually stable or an explicit blocker is reported.
+
+**Architecture:** Tighten the canonical `Finisher` and `Reviewer` workflow contracts in the source skill, mirror the same behavior in the delegated teammate prompt, expand the repo-local pressure tests to cover the pending-check monitoring loop and required reruns, and add a narrow repository gate in `AGENTS.md` that requires evidence-backed readiness language for skill and workflow-contract changes. Keep the change scoped to the four approved surfaces from the design and preserve the existing spec-first reroute rules.
+
+**Tech Stack:** Markdown workflow docs, repo-local pressure tests, `rg`, `sed`, `git diff`
+
+---
+
+## File Structure
+
+- `docs/superpowers/specs/2026-04-23-26-finisher-should-keep-monitoring-pr-checks-until-stable-or-blocked-design.md`
+  - Approved design artifact and acceptance source for issue `#26`.
+- `docs/superpowers/plans/2026-04-23-26-finisher-should-keep-monitoring-pr-checks-until-stable-or-blocked-plan.md`
+  - This implementation plan.
+- `skills/superteam/SKILL.md`
+  - Canonical workflow contract; source of truth for `Finisher` monitoring behavior, later-failure triage re-entry, `Reviewer` pressure-test reruns, and publish-state readiness boundaries.
+- `skills/superteam/agent-spawn-template.md`
+  - Delegated teammate prompt surface that must mirror the canonical `Reviewer` and `Finisher` rules closely enough to prevent drift in spawned runs.
+- `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+  - Repo-local pressure tests that must exercise pending checks, later failures, later passes, explicit pending-external blockers, and reruns after later workflow-contract changes.
+- `AGENTS.md`
+  - Canonical repository guidance; add the narrow evidence-based production-readiness gate for `skills/**/*.md` and workflow-contract changes.
+
+## Planned Workstreams
+
+- Workstream 1: tighten the canonical source contract in `skills/superteam/SKILL.md`
+- Workstream 2: mirror the same monitoring and rerun rules in `skills/superteam/agent-spawn-template.md`
+- Workstream 3: expand `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` with the new monitoring-loop scenarios and rerun expectations
+- Workstream 4: add the narrow evidence-based readiness gate in `AGENTS.md`, then verify the four surfaces stay aligned and scoped to issue `#26`
+
+### Task 1: Tighten the canonical `Reviewer` and `Finisher` contracts
+
+**Files:**
+- Modify: `skills/superteam/SKILL.md`
+
+- [ ] **Step 1: Inspect the current `Reviewer` and `Finisher` contract language**
+
+Run: `rg -n "### Reviewer|### Finisher|pressure-test|pending|required checks|blocked|ready|triage|monitor" skills/superteam/SKILL.md`
+Expected: locate the current ownership and shutdown wording that governs pending checks, review-loop pressure tests, and publish-state follow-through.
+
+- [ ] **Step 2: Invoke the required skill-doc editing discipline**
+
+Before editing `skills/superteam/SKILL.md`, invoke `superpowers:writing-skills`.
+Expected: the skill-editing pass explicitly treats this file as a workflow-contract change rather than ordinary prose cleanup.
+
+- [ ] **Step 3: Add the explicit `Finisher` state model and latest-head monitoring loop**
+
+Update the `Finisher` contract so it clearly describes this behavior:
+
+```md
+Treat publish-state on the latest pushed head as an explicit `Finisher` state machine:
+
+1. `triage`
+2. `monitoring`
+3. `ready`
+4. `blocked`
+
+When required checks on the latest pushed head are still pending after immediate branch-side fixes are complete, stay in `monitoring` rather than presenting the run as complete.
+If later required checks fail while monitoring, re-enter `triage` automatically on the latest head.
+If later required checks pass, allow `ready` only after the rest of the latest-head publish-state sweep is also clear.
+If the workflow cannot safely continue waiting on pending external systems, report an explicit blocker instead of a completion-style summary.
+Any new push invalidates earlier assumptions and restarts evaluation on the new latest head.
+```
+
+Keep the wording portable across runtimes: do not invent a scheduler, a fixed polling interval, or runtime-specific waiting mechanics.
+
+- [ ] **Step 4: Tighten the `Reviewer` contract for workflow-contract pressure-test reruns**
+
+Update the `Reviewer` section so it explicitly requires:
+
+```md
+When the changed scope includes `skills/**/*.md` or workflow-contract docs, run the relevant pressure-test walkthrough before publish.
+If later fixes change those same workflow-contract surfaces again after an earlier review pass, rerun the relevant pressure tests before handing the run back to `Finisher`.
+Report the pass/fail results and any loopholes found.
+```
+
+Keep the rerun rule tied to later workflow-contract changes, not just to the first review pass.
+
+- [ ] **Step 5: Re-read the updated canonical contract in context**
+
+Run: `sed -n '150,280p' skills/superteam/SKILL.md`
+Expected: the source skill now treats pending required checks as active `Finisher` work, later failures as automatic triage re-entry, pending external systems as explicit blockers when monitoring cannot continue safely, and later workflow-contract changes as requiring pressure-test reruns before publish.
+
+### Task 2: Mirror the same monitoring and rerun rules in the delegated prompt surface
+
+**Files:**
+- Modify: `skills/superteam/agent-spawn-template.md`
+
+- [ ] **Step 1: Inspect the `Reviewer` and `Finisher` prompt blocks**
+
+Run: `rg -n "### Reviewer|### Finisher|pressure-test|pending|required checks|blocked|ready|triage|monitor" skills/superteam/agent-spawn-template.md`
+Expected: locate the delegated prompt lines that currently govern review-stage pressure tests and publish-state follow-through.
+
+- [ ] **Step 2: Invoke the required skill-doc editing discipline**
+
+Before editing `skills/superteam/agent-spawn-template.md`, invoke `superpowers:writing-skills`.
+Expected: the prompt-template update follows the same skill-authoring discipline as the source contract.
+
+- [ ] **Step 3: Mirror the new `Finisher` monitoring behavior in plain delegation language**
+
+Update the `Finisher` block so it mirrors the source contract closely, including language equivalent to:
+
+```text
+Treat pending required checks on the latest pushed head as active `Finisher` monitoring work, not as completion.
+If later required checks fail while monitoring, re-enter triage automatically on the latest head.
+If later required checks pass, only hand off as ready after the rest of the latest-head publish-state sweep is clear.
+If pending external systems still block readiness and the run cannot safely keep monitoring, report an explicit blocker instead of a completion-style summary.
+Any new push makes earlier status assumptions stale and requires re-evaluation on the new latest head.
+```
+
+Preserve `Finisher` ownership of external feedback and publish-state follow-through.
+
+- [ ] **Step 4: Mirror the `Reviewer` rerun requirement**
+
+Update the `Reviewer` block so it explicitly requires rerunning the relevant pressure-test walkthrough after later changes to `skills/**/*.md` or workflow-contract docs before the next handoff back to `Finisher`.
+
+- [ ] **Step 5: Re-read the delegated prompt surface**
+
+Run: `sed -n '70,240p' skills/superteam/agent-spawn-template.md`
+Expected: the delegated `Reviewer` and `Finisher` prompts match the canonical source contract on monitoring, triage re-entry, ready-vs-blocked boundaries, and rerun timing.
+
+### Task 3: Expand the repo-local pressure tests for the monitoring loop
+
+**Files:**
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+- [ ] **Step 1: Inspect current publish-state and review-loop scenarios**
+
+Run: `rg -n "Finisher|Reviewer|pending|required checks|blocked|ready|triage|monitor|pressure-test" docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: identify the current scenarios that already cover publish-state follow-through so the new additions stay narrow and non-duplicative.
+
+- [ ] **Step 2: Add the pending-check monitoring scenario**
+
+Add a scenario that checks this behavior:
+
+```md
+## Finisher keeps monitoring while required checks on the latest pushed head are pending
+
+- Starting condition: the latest pushed head has no immediate branch-side fix left, but required checks are still pending.
+- Required halt or reroute behavior: remain in `Finisher`-owned monitoring instead of presenting the run as complete.
+- Rule surface: the canonical skill and delegated prompt should both treat pending required checks as active publish-state follow-through.
+```
+
+- [ ] **Step 3: Add the later-failure, later-pass, and pending-external-blocker scenarios**
+
+Add or refine scenarios that explicitly cover:
+
+```md
+## Finisher re-enters triage when later required checks fail on the latest pushed head
+## Finisher allows ready handoff only after later passing checks leave the whole latest-head sweep clear
+## Pending external systems stop the run as an explicit blocker, not a completion summary
+```
+
+Keep each scenario behavioral. Judge what the documented workflow would do, not whether the wording merely sounds strict.
+
+- [ ] **Step 4: Add the rerun expectation for later workflow-contract edits**
+
+Add a pressure-test scenario that fails if a run changes `skills/**/*.md` or workflow-contract docs after an earlier review pass but does not rerun the relevant pressure-test walkthrough before the next publish handoff.
+
+- [ ] **Step 5: Re-read the pressure-test doc in context**
+
+Run: `sed -n '1,260p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: the doc now covers pending checks, later failures, later passes, pending external blockers, and the required rerun after later workflow-contract changes before publish.
+
+### Task 4: Add the evidence-based repository readiness gate
+
+**Files:**
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Inspect the existing contributor guidance around testing and publish readiness**
+
+Run: `rg -n "Testing Guidelines|Commit & Pull Request Guidelines|confidence|readiness|skills/\\*\\*/\\.md|workflow-contract" AGENTS.md`
+Expected: find the right narrow insertion point for the repository-level gate without broadening the issue scope.
+
+- [ ] **Step 2: Add the narrow evidence-based guidance**
+
+Update `AGENTS.md` so it adds repository guidance equivalent to:
+
+```md
+For changes to `skills/**/*.md` and workflow-contract guidance, do not claim production readiness from confidence language alone.
+Readiness claims for those changes must be backed by the required pressure tests, review loops, and role-specific verification that actually ran.
+If that evidence is incomplete, report the missing evidence or blocker explicitly instead of asserting readiness.
+```
+
+Keep this scoped to the approved surfaces and avoid turning `AGENTS.md` into a generic release policy rewrite.
+
+- [ ] **Step 3: Re-read the updated guidance in context**
+
+Run: `sed -n '1,240p' AGENTS.md`
+Expected: the repository gate is evidence-based, auditable, and does not rely on a literal `100% confidence` promise.
+
+### Task 5: Verify cross-surface alignment, scope, and rerun discipline
+
+**Files:**
+- Modify: `skills/superteam/SKILL.md`
+- Modify: `skills/superteam/agent-spawn-template.md`
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Check that all four surfaces cover the same issue-`#26` contract**
+
+Run: `rg -n "monitoring|latest pushed head|required checks|triage|ready|blocked|pending external|pressure-test walkthrough|rerun" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md AGENTS.md`
+Expected: the canonical skill, delegated prompt, pressure-test doc, and repo guidance all reflect the same narrow monitoring-loop behavior and evidence-based readiness gate.
+
+- [ ] **Step 2: Review the diff for narrow scope**
+
+Run: `git diff -- AGENTS.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: the diff stays confined to issue `#26` behavior: pending required-check monitoring, later failure reroute, later-pass ready gating, explicit pending-external blockers, pressure-test reruns, and evidence-based readiness language.
+
+- [ ] **Step 3: Run the local review-stage pressure-test walkthrough before publish**
+
+During `Reviewer`, invoke `superpowers:writing-skills` and walk through the updated pressure-test scenarios for:
+
+```text
+1. pending required checks after the latest push
+2. later required-check failure while monitoring
+3. later required-check pass with the rest of the latest-head sweep clear
+4. pending external systems that force an explicit blocker
+5. later workflow-contract changes that require rerunning the pressure-test walkthrough before the next handoff
+```
+
+Expected: `Reviewer` reports pass/fail outcomes and loopholes for these scenarios before the run moves toward publish.
+
+- [ ] **Step 4: Enforce the rerun rule before the next `Finisher` handoff**
+
+If any later loopback changes `skills/**/*.md` or workflow-contract docs after the first review pass, rerun the relevant pressure-test walkthrough before the next handoff back to `Finisher`.
+Expected: pressure testing happens in the owning stages and reruns after later workflow-contract changes instead of being treated as a one-time end-of-run checklist.
+
+- [ ] **Step 5: Commit the workflow-contract update**
+
+Run: `git add AGENTS.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md && git commit -m "docs: #26 keep finisher monitoring pending PR checks"`
+Expected: a single docs-focused commit records the four aligned workflow-contract changes for issue `#26`.

--- a/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+++ b/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
@@ -111,6 +111,12 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Required halt or reroute behavior: Halt review completion and require the pressure-test walkthrough results before publish.
 - Rule surface: The Reviewer contract should require pressure-test pass/fail reporting for skill and workflow-contract changes.
 
+## Workflow-contract changes after review do not rerun the pressure-test walkthrough
+
+- Starting condition: Reviewer already completed a pressure-test walkthrough, then later fixes change `skills/**/*.md` or workflow-contract docs again before the next handoff.
+- Required halt or reroute behavior: Halt the publish handoff and rerun the relevant pressure-test walkthrough before the run returns to `Finisher`.
+- Rule surface: The Reviewer contract and delegated prompt should require reruns after later workflow-contract changes, not just the first review pass.
+
 ## Loophole found during skill review but ignored before publish
 
 - Starting condition: A pressure-test walkthrough on a skill or workflow-contract change finds a loophole, but the run still treats review as complete and moves toward publish.
@@ -128,6 +134,13 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Starting condition: The workflow creates or updates the PR, reports a single status snapshot, and then stops even though mergeability, CI, PR metadata correction, or external feedback handling still requires Finisher-owned follow-through.
 - Required halt or reroute behavior: Do not present the run as complete. Continue the Finisher loop until publish-state follow-through is stable enough to hand off cleanly or an explicit blocker is reported.
 - Rule surface: The Finisher contract should state that PR publication is a milestone rather than the end of the workflow.
+
+## Finisher keeps monitoring while required checks on the latest pushed head are pending
+
+- Starting condition: The latest pushed head has no immediate branch-side fix left, but required checks are still pending.
+- Required halt or reroute behavior: Remain in `Finisher`-owned `monitoring` instead of presenting the run as complete.
+- Behavioral check: Judge the workflow by what it would do next on the latest pushed head, not by whether it uses stern wording about follow-through.
+- Rule surface: The canonical skill and delegated prompt should both treat pending required checks as active publish-state follow-through.
 
 ## Finisher stops with only local commits and no PR
 
@@ -177,6 +190,18 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Required halt or reroute behavior: Do not shut down based on partial success signals. Continue the Finisher loop, report the remaining blockers explicitly, and only allow shutdown after the full publish-state follow-through is stable.
 - Rule surface: The shutdown contract should make clear that PR creation, mergeability restoration, or green CI alone are insufficient completion signals.
 
+## Finisher re-enters triage when later required checks fail on the latest pushed head
+
+- Starting condition: `Finisher` is monitoring the latest pushed head, and a required check later transitions from pending to failing.
+- Required halt or reroute behavior: Re-enter `triage` automatically on the latest pushed head and route any needed corrective work through the normal workflow instead of waiting for a user re-prompt.
+- Rule surface: The Finisher contract should make later required-check failures an automatic triage transition while monitoring.
+
+## Finisher allows ready handoff only after later passing checks leave the whole latest-head sweep clear
+
+- Starting condition: `Finisher` is monitoring the latest pushed head, and required checks later transition from pending to passing.
+- Required halt or reroute behavior: Allow `ready` only if the rest of the latest-head sweep is also clear, including mergeability, PR metadata, and unresolved external review state.
+- Rule surface: The Finisher contract should require a full latest-head sweep, not just passing required checks, before a ready handoff.
+
 ## Shutdown attempted using stale completeness from an earlier PR head
 
 - Starting condition: Feedback or checks were cleared on one PR head, a newer commit is pushed, and the workflow still treats the earlier green or previously-cleared state as sufficient for completion.
@@ -188,6 +213,12 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Starting condition: The workflow cannot tell whether review threads or recent reviewer/bot findings still block the latest pushed state.
 - Required halt or reroute behavior: Do not guess and do not present success. Halt with an explicit blocker and prompt the operator.
 - Rule surface: The shutdown contract should require operator escalation when shutdown readiness cannot be determined safely.
+
+## Pending external systems stop the run as an explicit blocker, not a completion summary
+
+- Starting condition: Required checks, manual approvals, or other external publish-state signals remain pending on the latest pushed head, and the workflow cannot safely continue monitoring.
+- Required halt or reroute behavior: Report an explicit blocker tied to the latest pushed head and pending external dependency instead of using completion-style language.
+- Rule surface: The Finisher contract should turn unsafe-to-continue monitoring into a `blocked` state rather than a soft success summary.
 
 ## Finisher fails to distinguish branch-caused CI failures from likely baseline failures
 

--- a/docs/superpowers/specs/2026-04-23-26-finisher-should-keep-monitoring-pr-checks-until-stable-or-blocked-design.md
+++ b/docs/superpowers/specs/2026-04-23-26-finisher-should-keep-monitoring-pr-checks-until-stable-or-blocked-design.md
@@ -1,0 +1,190 @@
+# Design: Finisher should keep monitoring PR checks until stable or blocked [#26](https://github.com/patinaproject/superteam/issues/26)
+
+## Summary
+
+Strengthen the `Finisher` publish-state contract so required checks in a pending state after the latest push are treated as active work, not as a reason to stop with a completion-style handoff. `Finisher` should keep ownership of the PR after immediate branch-side fixes are complete, continue monitoring the latest pushed head while required checks or other publish-state signals remain in flight, re-enter triage automatically if those checks later fail, and only hand off the PR as ready when the latest head is actually stable.
+
+The design stays narrow. It does not introduce a runtime-specific background scheduler or redesign the full workflow. Instead, it makes pending required checks a first-class `Finisher` state, clarifies what later status changes must do to the workflow, and adds pressure-test coverage so repeated review and publish loops keep rerunning the right checks instead of assuming earlier green or pending snapshots still apply.
+
+## Goals
+
+- Prevent `Finisher` from presenting the run as complete while required checks on the latest pushed head are still pending
+- Make pending required checks a first-class `Finisher` monitoring state rather than an implicit idle state
+- Require `Finisher` to re-enter triage automatically when later check results fail on the latest pushed head
+- Allow `Finisher` to hand off the PR as ready only after required checks later pass and no unresolved publish-state blockers remain
+- Require an explicit blocker report when pending external systems remain and the run cannot continue monitoring safely
+- Place pressure testing in the appropriate stages and rerun it after later changes to workflow-contract surfaces before publish
+- Add a repository-level production-readiness gate for `skills/**/*.md` and workflow-contract changes so the repo does not ship those changes on unsupported confidence claims
+
+## Non-Goals
+
+- Building a runtime-specific background scheduler or automation system for waiting on checks
+- Redesigning the canonical teammate roster or replacing the existing publish-state model from `#18`
+- Changing unrelated PR body or issue-linking behavior
+- Solving every possible CI flake or external-system failure mode beyond the `Finisher` contract for handling them
+- Expanding the fix beyond the workflow-contract and pressure-test surfaces that directly control this behavior
+- Requiring a literal `100% confidence` promise as the release gate for skill or workflow-contract changes
+
+## Approaches Considered
+
+### Recommended: explicit Finisher monitoring loop for pending checks
+
+Treat pending required checks on the latest pushed head as an active `Finisher` state. `Finisher` keeps ownership, rechecks status until the head becomes stable or an explicit blocker is reached, and re-enters triage automatically if later results fail. This matches the issue goal without requiring new runtime machinery.
+
+### Alternative: stop immediately with a blocker whenever checks are pending
+
+This is better than a false success summary, but it still pushes the operator back into the loop even when the only missing work is ordinary check completion. It does not satisfy the desired "keep monitoring until stable or blocked" behavior.
+
+### Alternative: rely on user re-prompts or out-of-band automation
+
+This preserves the current failure mode. It turns `Finisher` monitoring into an optional human follow-up instead of a workflow responsibility, so it does not meet the issue requirements.
+
+## Design
+
+### Pending required checks become a first-class Finisher state
+
+`Finisher` should treat publish-state as four explicit outcomes on the latest pushed head:
+
+1. `triage`: branch-side or publish-side corrective action is immediately required
+2. `monitoring`: no immediate branch-side fix is available, but required checks or other external publish-state signals are still pending
+3. `ready`: the latest pushed head is stable enough for a clean handoff
+4. `blocked`: the workflow cannot continue safely or cannot reach `ready` without explicit external intervention
+
+The key change for this issue is `monitoring`. After the latest push, if immediate branch-side fixes are complete but required checks are still pending, `Finisher` must stay active in the same ownership loop instead of presenting the run as complete. A pending required check is not a success signal and not a silent idle state.
+
+This state remains head-relative. Any new push invalidates earlier assumptions and restarts evaluation on the new latest head.
+
+### Monitoring stays with Finisher until the head becomes ready or blocked
+
+While the latest pushed head is in `monitoring`, `Finisher` should keep the run in publish-state follow-through and continue rechecking the active PR rather than asking the user to prompt it back into the loop.
+
+During monitoring, `Finisher` should:
+
+- keep reporting against the latest pushed head and active PR rather than older snapshots
+- treat required checks still pending as active publish-state work, not as completion
+- continue checking mergeability, unresolved review state, and other publish-state blockers that may resolve or appear while checks are running
+- invalidate any earlier completion assumption when a new push lands
+- avoid completion-style language until the head reaches `ready`
+
+This should be documented as a portable workflow rule, not as a hard-coded polling interval. The contract should describe the behavior and completion boundary, while runtime-specific waiting mechanics remain an implementation detail.
+
+### Later failing checks re-enter triage automatically
+
+If required checks later fail while `Finisher` is monitoring the latest pushed head, the workflow should re-enter `triage` without requiring a user re-prompt.
+
+That triage should:
+
+- inspect enough evidence to identify the failing required checks on the latest head
+- distinguish branch-caused failures from likely baseline or unrelated failures when possible
+- keep clearly external, manual-approval, or indeterminate failures in `blocked`
+- route corrective branch work back through the existing loopback path instead of letting `Finisher` absorb implementation ownership
+
+When a failure requires a code or requirements change, the workflow should preserve the existing routing contract:
+
+- requirement-bearing feedback returns to `Brainstormer`, then `Planner`, then `Executor`
+- implementation-only corrections route through the normal implementation loop
+- after a corrective push that changes skill or workflow-contract files, the appropriate pre-publish pressure tests must be rerun before `Finisher` resumes monitoring
+
+This keeps later failures inside the workflow instead of turning them into a fresh human-started run.
+
+### Passing checks allow ready handoff only after the whole latest head is clear
+
+Required checks later passing is necessary but not sufficient for `ready`. `Finisher` may hand off the PR as ready only when the latest pushed head has all of the following:
+
+- required checks in a terminal passing state
+- no unresolved external review feedback that still blocks readiness on the latest head
+- no mergeability or PR metadata blockers that still require `Finisher` action
+- no newer push that made the evaluated state stale
+
+This preserves the broader publish-state contract from `#18` while making the pending-check transition explicit for this issue. A check moving from pending to passing should move the workflow from `monitoring` to `ready` only if the rest of the latest-head sweep is also clean.
+
+### Pending external systems must stop as an explicit blocker, not a completion summary
+
+The workflow should not pretend that pending external systems are success. If the run stops while required checks, manual approvals, external CI services, or other publish-state signals remain pending on the latest pushed head, `Finisher` must report that pending state as an explicit blocker rather than using a completion-style summary.
+
+For this issue, `blocked` should cover cases such as:
+
+- required checks remain pending but the workflow cannot safely keep monitoring further in the current run
+- a manual approval or external system action is still required
+- the workflow cannot determine whether the latest head is truly ready
+- an external service appears stuck or inaccessible
+
+The blocker report should name the latest head context and the still-pending publish-state signal so the operator can see that the run stopped because the PR was not yet stable, not because the workflow finished successfully.
+
+### AGENTS.md should add an evidence-based production-readiness gate
+
+This issue can absorb a narrow repository-gate update in `AGENTS.md` because the new requirement is directly tied to the same failure pattern: the workflow should not let skill or workflow-contract changes move toward publish on vague assurances that they are "probably fine" or "confident enough" when the available evidence is still incomplete.
+
+The added repository guidance should target `skills/**/*.md` and workflow-contract changes such as teammate contracts, prompt templates, pressure-test docs, and other behavior-steering docs. For those changes, the repo should require a production-readiness gate based on concrete evidence rather than unsupported confidence language.
+
+That gate should be phrased as an evidence-based readiness rule, not as a literal `100% confidence` promise. A confidence promise is both weaker and less auditable:
+
+- it invites performative certainty instead of verification evidence
+- it is impossible to interpret consistently across operators and teammates
+- it can be claimed even when required pressure tests, review loops, or publish-state checks are still missing
+
+The repository rule should therefore require something closer to:
+
+- no production-readiness claim for skill or workflow-contract changes unless the required pressure tests, review loops, and role-specific verification for the changed surface have actually run
+- if evidence is incomplete, report the missing evidence or blocker explicitly instead of asserting readiness
+- readiness claims for these changes must be tied to observed verification outcomes, not to an abstract confidence percentage
+
+This keeps the issue coherent: `Finisher` should stay active until publish-state is stable or blocked, and the repository guidance should likewise prevent behavior-steering changes from shipping on unsupported certainty while the relevant verification state is still incomplete.
+
+### Pressure tests belong in the workflow loops, not only at the end
+
+This issue should be designed for repeated review and pressure-test loops rather than a single final walkthrough. The workflow-contract surfaces changed for this issue should be pressure-tested in the stages that own them:
+
+- `Brainstormer` defines the required behavior and the scenarios that must be covered
+- `Planner` turns those scenarios into explicit implementation and verification work, rather than deferring all pressure testing to the end
+- `Reviewer` invokes `superpowers:writing-skills` when the changed scope includes `skills/**/*.md` or workflow-contract docs and runs the relevant pressure-test walkthrough before publish
+- if later fixes change those same workflow-contract surfaces again, `Reviewer` reruns the relevant pressure tests before the next handoff back to `Finisher`
+- `Finisher` reruns publish-state evaluation after every push and after later external status changes on the latest head
+- when the changed scope includes skill or workflow-contract behavior, production-readiness claims must be backed by the rerun evidence rather than by unsupported confidence language
+
+This issue therefore needs repo-local pressure tests that cover at least:
+
+- required checks pending after the latest push with no immediate branch-side fix left
+- a later required check failure while `Finisher` is monitoring
+- a later required check pass that clears the latest head for ready handoff
+- a run stopping while pending external systems still block readiness
+
+### Scope of repository changes
+
+The implementation should stay narrow and update only the surfaces that directly govern or validate this behavior:
+
+- `skills/superteam/SKILL.md`
+  - make pending required checks an explicit `Finisher` monitoring state
+  - require automatic re-entry to triage on later failures
+  - require explicit blocker reporting when pending external systems keep the run from reaching `ready`
+- `skills/superteam/agent-spawn-template.md`
+  - mirror the same monitoring, re-entry, and blocker rules in delegated prompts
+- `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+  - add or refine scenarios for pending checks, later failure, later success, and pending external blockers
+- `AGENTS.md`
+  - add a repository production-readiness gate for `skills/**/*.md` and workflow-contract changes
+  - require evidence-backed readiness language rather than unsupported confidence claims
+
+Inspect other docs only if they currently say something that would materially undermine this behavior. Avoid broad wording cleanup outside the directly relevant workflow-contract surfaces.
+
+## Testing And Verification
+
+- inspect the canonical `Finisher` contract and confirm that required checks still pending on the latest pushed head keep the run in an active monitoring state rather than allowing completion
+- verify the canonical skill forbids completion-style handoff while required checks are still pending
+- verify the delegated `Finisher` prompt mirrors the same monitoring-state behavior
+- verify the contract requires re-evaluation against the latest pushed head after every push
+- verify later failing required checks route the workflow back into `Finisher` triage without requiring user re-prompting
+- verify later passing required checks allow ready handoff only after the rest of the latest-head publish-state sweep is clear
+- verify stopping with pending external systems produces an explicit blocker report instead of a completion-style summary
+- verify the pressure-test doc covers pending checks, later failure, later success, and pending external blocker scenarios
+- verify review guidance reruns the relevant pressure tests after later workflow-contract changes before publish
+- verify `AGENTS.md` requires an evidence-based production-readiness gate for `skills/**/*.md` and workflow-contract changes
+- verify the repo guidance forbids unsupported readiness claims based only on confidence language and instead requires concrete verification evidence or an explicit blocker
+
+## Acceptance Criteria
+
+- AC-26-1: Given a PR has been updated and all immediately actionable branch-side fixes are complete, when required checks are still pending, then `Finisher` stays active instead of presenting the run as complete
+- AC-26-2: Given checks later fail on the latest pushed head, when `Finisher` is monitoring, then it re-enters triage instead of requiring the user to prompt it back into the loop
+- AC-26-3: Given checks later pass and no unresolved review feedback remains, when `Finisher` is monitoring, then it may hand off the PR as ready
+- AC-26-4: Given pending external systems remain after the latest push, when the run stops, then it reports that pending publish-state as an explicit blocker rather than a completion-style summary
+- AC-26-5: Given a change touches `skills/**/*.md` or workflow-contract guidance, when the repo guidance describes production readiness, then it requires evidence-backed readiness criteria and explicit blocker reporting instead of unsupported confidence-only claims

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -186,6 +186,7 @@ If revisions are requested after an approval pass, re-fire approval with delta-o
 - Recommend `superpowers:requesting-code-review` for first-pass local review.
 - Also recommend `superpowers:receiving-code-review` when analyzing existing or disputed findings before publish.
 - When reviewing changes to `skills/**/*.md` or workflow-contract docs, invoke `superpowers:writing-skills` and run the relevant pressure-test walkthrough before publish.
+- If later fixes change those same workflow-contract surfaces again after an earlier review pass, rerun the relevant pressure-test walkthrough before handing the run back to `Finisher`.
 - Report pressure-test pass/fail results and any loopholes found for skill or workflow-contract changes.
 - Keep findings local; do not take ownership of external review feedback.
 
@@ -201,6 +202,16 @@ If revisions are requested after an approval pass, re-fire approval with delta-o
 - Do not invent a new intent-detection system or infer issue-closing intent from weak heuristics such as commit wording, diff size, or acceptance-criteria count.
 - Every `superteam` run is expected to publish a PR; local-only state is never a valid completion, demo, or handoff state.
 - Push the branch and create or update the PR before treating the run as being in publish-state follow-through.
+- Treat publish-state on the latest pushed head as an explicit `Finisher` state machine:
+  1. `triage`
+  2. `monitoring`
+  3. `ready`
+  4. `blocked`
+- When required checks on the latest pushed head are still pending after immediate branch-side fixes are complete, stay in `monitoring` rather than presenting the run as complete.
+- If later required checks fail while monitoring, re-enter `triage` automatically on the latest pushed head.
+- If later required checks pass while monitoring, allow `ready` only after the rest of the latest-head publish-state sweep is also clear.
+- If pending external systems still block readiness and the workflow cannot safely continue monitoring, report an explicit `blocked` state instead of using a completion-style summary.
+- Any new push invalidates earlier assumptions and restarts evaluation on the new latest head.
 - Stay in the `Finisher` loop after PR publication until publish-state follow-through is stable enough to hand off cleanly or an explicit blocker is reported.
 - Do not treat PR creation, one status snapshot, restored mergeability, or green CI alone as workflow completion.
 - Verify current branch state before resolving or replying to comments tied to prior state.

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -118,6 +118,7 @@ Review locally before publish.
 Own receiving and interpreting local pre-publish review findings.
 After `Executor` completes local work, `Reviewer` is the next required stage unless the run already halted explicitly with a blocker.
 When the changed scope includes `skills/**/*.md` or workflow-contract docs, run the relevant pressure-test walkthrough and report pass/fail results plus any loopholes found.
+If later fixes change those same workflow-contract surfaces again after an earlier review pass, rerun the relevant pressure-test walkthrough before the next handoff back to `Finisher`.
 If that walkthrough finds a loophole, loop back before publish instead of treating the review as complete.
 Done-report contract:
 - `findings[]`: local findings, if any, with one entry per issue
@@ -147,6 +148,11 @@ Every `superteam` run is expected to publish a PR. Local-only state is never a v
 Push the branch and create or update the PR before treating the run as being in publish-state follow-through.
 Stay in the `Finisher` loop after PR publication until the publish-state follow-through is stable enough to hand off cleanly or an explicit blocker is reported.
 Do not treat PR creation, one status snapshot, restored mergeability, or green CI alone as workflow completion.
+Treat publish-state on the latest pushed head as explicit `Finisher` state: `triage`, `monitoring`, `ready`, or `blocked`.
+Treat pending required checks on the latest pushed head as active `Finisher` monitoring work, not as completion.
+If later required checks fail while monitoring, re-enter triage automatically on the latest pushed head.
+If later required checks pass while monitoring, only hand off as ready after the rest of the latest-head publish-state sweep is also clear.
+If pending external systems still block readiness and the run cannot safely keep monitoring, report an explicit blocker instead of a completion-style summary.
 Shutdown is success-only. Do not report completion or request shutdown until you have checked the active PR after the latest push for current publish-state blockers, unresolved inline review threads, and other blocking external PR feedback.
 Treat shutdown readiness as head-relative. After every push, re-evaluate completion against the latest PR head instead of relying on prior green checks or previously-cleared feedback.
 Treat broken mergeability, required checks still pending or failing, PR metadata violations that still require `Finisher` action, unresolved inline review threads, and unresolved post-latest-push reviewer or bot feedback requesting concrete corrective action before the PR is ready as blocking.


### PR DESCRIPTION
# Pull Request

## Summary

- Keep `Finisher` in explicit `monitoring` while required checks on the latest pushed head are pending.
- Require automatic triage re-entry on later failing checks, ready handoff only after the full latest-head sweep clears, and explicit blockers when external systems remain pending.
- Add an evidence-based readiness gate in `AGENTS.md` for `skills/**/*.md` and workflow-contract guidance, and record the approved design and plan artifacts for issue `#26`.

## Linked issue

- Closes #26

## Acceptance criteria

### AC-26-1
`Finisher` stays active in explicit `monitoring` when required checks are still pending after immediate branch-side fixes are complete.

- [x] `sed -n '180,235p' skills/superteam/SKILL.md`
- [x] `sed -n '140,170p' skills/superteam/agent-spawn-template.md`
- [x] `sed -n '135,145p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md`

### AC-26-2
Later required-check failures while monitoring reroute back into `triage` without requiring a user re-prompt.

- [x] `sed -n '209,213p' skills/superteam/SKILL.md`
- [x] `sed -n '151,154p' skills/superteam/agent-spawn-template.md`
- [x] `sed -n '193,197p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md`

### AC-26-3
Later required-check passes only allow ready handoff after the rest of the latest-head publish-state sweep is also clear.

- [x] `sed -n '211,213p' skills/superteam/SKILL.md`
- [x] `sed -n '153,154p' skills/superteam/agent-spawn-template.md`
- [x] `sed -n '199,203p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md`

### AC-26-4
Pending external systems now produce an explicit blocker instead of a completion-style summary when monitoring cannot safely continue.

- [x] `sed -n '212,214p' skills/superteam/SKILL.md`
- [x] `sed -n '154,155p' skills/superteam/agent-spawn-template.md`
- [x] `sed -n '217,221p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md`

### AC-26-5
Repo guidance for `skills/**/*.md` and workflow-contract changes now requires evidence-backed readiness criteria and explicit blocker reporting instead of confidence-only readiness claims.

- [x] `sed -n '50,60p' AGENTS.md`
- [x] `sed -n '114,121p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
- [x] `sed -n '186,190p' skills/superteam/SKILL.md`

## Validation

- `git diff --check`
- `git diff -- AGENTS.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
- `rg -n "production-readiness|confidence|monitoring|later required checks fail|rerun the relevant pressure-test walkthrough|pending external systems" AGENTS.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
- Reviewer pressure-test walkthrough covering pending checks, later failures, later passes, pending external blockers, rerun requirements, and the new `AGENTS.md` evidence gate

## Docs updated

- [x] Updated in this PR
