### PR TITLE
docs: #28 recommend runtime follow-through aids

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
-# Claude Instructions
+@AGENTS.md
 
-See [AGENTS.md](./AGENTS.md) for the repository instructions and contributor workflow.
+## Claude Code
+
+- Keep the shared workflow contract in `AGENTS.md`; put Claude-only guidance below this import instead of duplicating the repo rules.
+- When you add Claude-specific teammates, prefer project subagents under `.claude/agents/`.
+- When you need Claude-specific enforcement for teammate creation or completion, prefer project hooks in `.claude/settings.json`.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Before any teammate edits governed files, the workflow discovers repository rule
 
 Each teammate owns specific artifacts and verification gates, so work stays understandable across handoffs instead of becoming ad hoc subagent output. `Reviewer` owns local pre-publish review intake and finding classification. `Finisher` owns publish-state follow-through, branch and PR handling, CI, and external post-publish review feedback.
 
+When a host runtime supports background agents or subagents, Superteam prefers using them for bounded, independent work that is unlikely to need live clarification. Tightly coupled or ambiguity-heavy steps should stay in the foreground. For publish-state follow-through, durable wakeups remain optional execution aids: in Codex, same-thread automations are a natural fit for `Finisher`, while Claude Code can pair project subagents with optional hooks without changing the shared contract.
+
 ## What Happens At Each Stage
 
 This is the short version of what developers should expect during a normal run:
@@ -170,7 +172,7 @@ For local setup, add `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` to the `env` block i
 
 Then run the same Superteam workflow as usual.
 
-Agent Teams is optional. If you do not enable it, Superteam still works with the regular single-agent or subagent flow described above.
+Agent Teams is optional. If you do not enable it, Superteam still works with the regular single-agent or subagent flow described above. When using Agent Teams, prefer them for bounded, independent teammate work; keep highly interactive or clarification-heavy steps in the foreground.
 
 ### OpenAI Codex CLI
 
@@ -191,6 +193,8 @@ Use $superteam to route this issue through teammate-owned design, planning, exec
 ```text
 Use $superteam to route this issue through teammate-owned design, planning, execution, review, and Finisher-owned publish follow-through.
 ```
+
+When `Finisher` is waiting on external publish-state in the Codex app, prefer a thread automation attached to the current thread so follow-through stays in the same conversation context.
 
 ## First use
 

--- a/docs/superpowers/plans/2026-04-23-28-recommend-runtime-monitors-or-heartbeats-for-finisher-follow-through-when-available-plan.md
+++ b/docs/superpowers/plans/2026-04-23-28-recommend-runtime-monitors-or-heartbeats-for-finisher-follow-through-when-available-plan.md
@@ -1,0 +1,214 @@
+# Plan: Recommend runtime monitors or heartbeats for Finisher follow-through when available [#28](https://github.com/patinaproject/superteam/issues/28)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Use checkbox (`- [ ]`) tracking while executing. When editing `skills/**/*.md`, invoke `superpowers:writing-skills` before editing. During local review of skill or workflow-contract changes, invoke `superpowers:writing-skills` and run the relevant pressure-test walkthrough before publish.
+
+**Goal:** Keep the `superteam` workflow portable while explicitly recommending background-agent delegation and durable runtime follow-up aids such as heartbeats or monitors when the host supports them, especially for `Finisher` publish-state follow-through.
+
+**Architecture:** Update the canonical workflow contract in `skills/superteam/SKILL.md`, mirror the same runtime-aware preferences in `skills/superteam/agent-spawn-template.md`, and extend the orchestration pressure tests so the new behavior is exercised in both runtime-capable and runtime-incapable scenarios. Keep the contract behavioral and portable: runtime features remain execution aids for the existing teammate and `Finisher` loops rather than new requirements or a separate workflow.
+
+**Tech Stack:** Markdown workflow docs, repo-local pressure tests, `rg`, `sed`, `git diff`
+
+---
+
+## File Structure
+
+- `docs/superpowers/specs/2026-04-23-28-recommend-runtime-monitors-or-heartbeats-for-finisher-follow-through-when-available-design.md`
+  - Approved design artifact and authority for issue `#28`.
+- `docs/superpowers/plans/2026-04-23-28-recommend-runtime-monitors-or-heartbeats-for-finisher-follow-through-when-available-plan.md`
+  - This implementation plan.
+- `skills/superteam/SKILL.md`
+  - Canonical workflow contract; source of truth for runtime-aware recommendations, `Brainstormer` approval-packet rules, and `Finisher` ownership boundaries.
+- `skills/superteam/agent-spawn-template.md`
+  - Delegated teammate prompt surface that must mirror the canonical runtime-aware recommendations closely enough to keep spawned work aligned.
+- `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+  - Repo-local pressure-test scenarios that validate teammate delegation, approval-packet reporting, and `Finisher` follow-through behavior across runtime-capable and runtime-incapable environments.
+
+## Planned Workstreams
+
+- Workstream 1: tighten the canonical `superteam` skill contract for runtime-aware delegation, `Finisher` follow-through aids, and `Brainstormer` concern reporting
+- Workstream 2: mirror the same recommendations and wording constraints in the delegated teammate prompt template
+- Workstream 3: expand the pressure-test walkthrough so `Reviewer` can verify both supported and unsupported runtime paths without weakening the portable contract
+
+### Task 1: Update the canonical workflow contract in `skills/superteam/SKILL.md`
+
+**Files:**
+- Modify: `skills/superteam/SKILL.md`
+
+- [ ] **Step 1: Inspect the current runtime-aware and approval-packet sections**
+
+Run: `rg -n "## Pre-flight|## Gate 1: Brainstormer approval|### Brainstormer|### Finisher|concerns|heartbeat|monitor|background" skills/superteam/SKILL.md`
+Expected: locate the existing pre-flight guidance, approval-packet rules, `Brainstormer` contract, and `Finisher` contract language that issue `#28` will refine.
+
+- [ ] **Step 2: Invoke the required skill-doc editing discipline**
+
+Before editing `skills/superteam/SKILL.md`, invoke `superpowers:writing-skills`.
+Expected: the change is handled as a workflow-contract update rather than a casual prose edit.
+
+- [ ] **Step 3: Add the portable runtime-aware delegation and follow-through recommendations**
+
+Update `SKILL.md` so the runtime-aware sections explicitly say:
+
+```md
+- Prefer the host runtime's normal multi-agent capabilities when available.
+- When the host supports background-agent execution for delegated teammate work, prefer using that capability as an execution aid rather than a correctness dependency.
+- When the runtime offers durable follow-up features such as thread heartbeats, monitors, or equivalent wakeups, prefer using them for `Finisher` publish-state follow-through while required checks or external review state remain pending.
+- Treat these runtime capabilities as aids for the existing teammate and `Finisher` loops, not as separate workflows or replacement contracts.
+- If the host lacks those capabilities, do not stop early; continue using the portable teammate and `Finisher` contracts or report an explicit blocker when follow-through cannot safely continue.
+```
+
+Keep the wording feature-agnostic and portable across runtimes.
+
+- [ ] **Step 4: Tighten the approval-packet reporting contract**
+
+Update the approval guidance and `Brainstormer` contract so they explicitly require:
+
+```md
+- `concerns[]` is always reported in the approval packet.
+- When concerns exist, surface them as approval-relevant concerns.
+- When no concerns exist, preserve the explicit empty `concerns[]` result under the contract and render the operator-facing packet exactly as `Remaining concerns: None`.
+```
+
+Keep this scoped to approval-packet reporting discipline rather than broader gate semantics.
+
+- [ ] **Step 5: Re-read the updated canonical contract in context**
+
+Run: `sed -n '1,260p' skills/superteam/SKILL.md`
+Expected: the canonical skill now recommends background-agent delegation and durable `Finisher` follow-through aids when available, preserves portable behavior when they are not, and makes the no-concerns approval rendering explicitly `Remaining concerns: None`.
+
+### Task 2: Mirror the same runtime-aware guidance in `skills/superteam/agent-spawn-template.md`
+
+**Files:**
+- Modify: `skills/superteam/agent-spawn-template.md`
+
+- [ ] **Step 1: Inspect the current delegation template and role-specific blocks**
+
+Run: `rg -n "Recommend|concerns\\[\\]|Brainstormer|Finisher|background|heartbeat|monitor|runtime" skills/superteam/agent-spawn-template.md`
+Expected: locate the shared delegation preamble plus the `Brainstormer` and `Finisher` role-specific prompt blocks that need alignment with the canonical contract.
+
+- [ ] **Step 2: Invoke the required skill-doc editing discipline**
+
+Before editing `skills/superteam/agent-spawn-template.md`, invoke `superpowers:writing-skills`.
+Expected: the prompt-template update follows the same skill-authoring discipline as the source contract.
+
+- [ ] **Step 3: Mirror the background-agent recommendation in the shared delegation guidance**
+
+Update the shared prompt template so it nudges runtime-capable hosts toward background-agent execution for delegated teammate work while still warning that missing support is not a blocker by itself. Use language equivalent to:
+
+```text
+When the host runtime supports background-agent execution for delegated teammate work, prefer using it.
+If that capability is unavailable, continue with the normal portable teammate workflow instead of treating the missing feature as permission to stop.
+```
+
+- [ ] **Step 4: Mirror the `Brainstormer` and `Finisher` runtime-aware rules**
+
+Update the role-specific blocks so they include:
+
+```text
+Brainstormer:
+- `concerns[]` must always be reported.
+- When none exist, preserve the explicit empty result and render the operator-facing no-concerns line as `Remaining concerns: None`.
+
+Finisher:
+- When the runtime offers durable follow-up features such as thread heartbeats, monitors, or equivalent wakeups, prefer using them while pending external publish-state remains.
+- Treat those features as aids for the same latest-head follow-through loop, not as a separate workflow.
+- If the runtime lacks those features, continue the portable `Finisher` ownership model or report an explicit blocker instead of stopping early.
+```
+
+Keep the delegated language close to `SKILL.md` so the prompt surface does not drift.
+
+- [ ] **Step 5: Re-read the delegated prompt surface**
+
+Run: `sed -n '1,260p' skills/superteam/agent-spawn-template.md`
+Expected: the shared template plus the `Brainstormer` and `Finisher` blocks all reflect the same background-agent preference, portable fallback behavior, and `Remaining concerns: None` rendering rule.
+
+### Task 3: Expand the orchestration pressure tests for runtime-aware follow-through and approval reporting
+
+**Files:**
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+- [ ] **Step 1: Inspect the current scenarios that already cover approval packets and `Finisher` follow-through**
+
+Run: `rg -n "approval|concerns|Brainstormer|Finisher|monitor|heartbeat|background|runtime|stop early" docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: identify the existing scenarios so the new tests extend them cleanly instead of duplicating nearby checks.
+
+- [ ] **Step 2: Add approval-packet reporting scenarios for `concerns[]` and `Remaining concerns: None`**
+
+Add scenarios that fail when:
+
+```md
+## Approval packet omits `concerns[]` entirely
+## Approval packet with no concerns does not render `Remaining concerns: None`
+```
+
+Each scenario should describe the required halt or reroute behavior and point back to the `Brainstormer` approval-packet rules.
+
+- [ ] **Step 3: Add teammate delegation and `Finisher` follow-through runtime-capable scenarios**
+
+Add scenarios that check:
+
+```md
+## Delegated teammate work ignores available background-agent execution
+## Finisher ignores available durable runtime follow-up while external publish-state is pending
+## Runtime follow-up resumes the existing Finisher loop instead of creating a new workflow
+```
+
+Keep them behavioral: judge whether the documented workflow recommends the right runtime-capable path while preserving the same ownership model.
+
+- [ ] **Step 4: Add runtime-incapable fallback scenarios**
+
+Add scenarios that check:
+
+```md
+## Missing background-agent support does not permit early stop
+## Missing runtime follow-up support does not permit Finisher to stop early
+```
+
+Each scenario should require the workflow to continue under the portable contract or report an explicit blocker when safe follow-through cannot continue.
+
+- [ ] **Step 5: Re-read the pressure-test doc in context**
+
+Run: `sed -n '1,320p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: the pressure tests now cover approval-packet concern reporting, the exact `Remaining concerns: None` operator-facing rendering, runtime-capable delegation and follow-through, and runtime-incapable fallback behavior without weakening the canonical contract.
+
+### Task 4: Verify cross-surface alignment and narrow scope
+
+**Files:**
+- Modify: `skills/superteam/SKILL.md`
+- Modify: `skills/superteam/agent-spawn-template.md`
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+- [ ] **Step 1: Check alignment across the three approved surfaces**
+
+Run: `rg -n "background-agent|heartbeats|heartbeat|monitor|Remaining concerns: None|concerns\\[\\]|stop early|portable" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: all three files use consistent terms for background-agent preference, runtime follow-up aids, portable fallback behavior, and the no-concerns rendering rule.
+
+- [ ] **Step 2: Review the diff for design-scope discipline**
+
+Run: `git diff -- skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: the diff stays within the approved scope from the design and does not spill into unrelated workflow-contract rewrites.
+
+- [ ] **Step 3: Prepare the local review verification handoff**
+
+During `Reviewer`, invoke `superpowers:writing-skills` and walk through the updated pressure-test scenarios for:
+
+```text
+1. available background-agent delegation
+2. missing background-agent support
+3. available durable runtime follow-up for `Finisher`
+4. missing runtime follow-up support
+5. approval packets with concerns present
+6. approval packets with no concerns rendered as `Remaining concerns: None`
+7. runtime wakeups resuming the same `Finisher` loop instead of a separate workflow
+```
+
+Expected: `Reviewer` reports pass/fail results and any loopholes before the run moves toward publish.
+
+- [ ] **Step 4: Enforce pressure-test reruns after later workflow-contract fixes**
+
+If later loopbacks change `skills/**/*.md` or `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` after an earlier review pass, rerun the relevant pressure-test walkthrough before the next handoff to `Finisher`.
+Expected: review evidence stays current with the latest workflow-contract state.
+
+- [ ] **Step 5: Commit the workflow-contract update**
+
+Run: `git add skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md && git commit -m "docs: #28 recommend runtime follow-through aids"`
+Expected: a single docs-focused commit records the aligned workflow-contract changes for issue `#28`.

--- a/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+++ b/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
@@ -56,11 +56,17 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Required halt or reroute behavior: Halt silent delegation and reissue the prompt with an explicit unavailable-skill warning to the operator and teammate.
 - Rule surface: The delegation prompt should include a visible unavailable skill warning path.
 
-## Delegated teammate work ignores available background-agent execution
+## Delegated bounded teammate work ignores available background-agent execution
 
-- Starting condition: The host runtime supports background-agent execution for delegated teammate work, but the workflow never recommends or prefers that capability when dispatching teammates.
+- Starting condition: The host runtime supports background-agent execution for delegated teammate work, the delegated task is bounded and independent enough not to need live clarification, but the workflow never recommends or prefers that capability when dispatching the teammate.
 - Required halt or reroute behavior: Reissue the delegated guidance so runtime-capable hosts are explicitly nudged toward background-agent execution while keeping it optional rather than mandatory.
-- Rule surface: The runtime-aware delegation guidance should prefer background-agent execution when available without turning it into a correctness dependency.
+- Rule surface: The runtime-aware delegation guidance should prefer background-agent execution for bounded, independent work when available without turning it into a correctness dependency.
+
+## Delegated teammate work forces background-agent execution on clarification-heavy work
+
+- Starting condition: The host runtime supports background-agent execution, but the workflow treats it as a blanket default and pushes tightly coupled, ambiguity-heavy, or clarification-driven teammate work into the background anyway.
+- Required halt or reroute behavior: Keep that work in the foreground and reserve background-agent execution for bounded, independent work that is unlikely to need live clarification.
+- Rule surface: The runtime-aware delegation guidance should distinguish between independent work that benefits from background execution and interactive work that should stay in the foreground.
 
 ## Hard-coded repo rules drifting from canonical docs
 
@@ -166,6 +172,12 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Required halt or reroute behavior: Reroute to guidance that prefers those durable runtime aids for the same latest-head `Finisher` loop while the external publish-state remains pending.
 - Rule surface: The canonical skill and delegated Finisher prompt should explicitly recommend durable runtime follow-up features when available and relevant.
 
+## Codex follow-through uses a fresh run when same-thread automation is the better fit
+
+- Starting condition: The workflow is running in the Codex app, `Finisher` is waiting on external publish-state, preserving the current thread context matters, and the guidance never recommends a thread automation attached to the current thread.
+- Required halt or reroute behavior: Reissue the Codex-specific guidance so same-thread automation is recommended as the native follow-through aid in that situation, while keeping the underlying `Finisher` contract portable.
+- Rule surface: The runtime-aware `Finisher` guidance should mention Codex thread automations as a same-thread aid without making them a correctness dependency.
+
 ## Runtime follow-up resumes the existing Finisher loop instead of creating a new workflow
 
 - Starting condition: The workflow recommends runtime wakeups for `Finisher`, but the documented behavior treats the wakeup as a separate workflow with different routing, shutdown rules, or ownership.
@@ -254,7 +266,7 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 
 - Starting condition: The host runtime does not support background-agent execution for delegated teammate work, and the workflow treats that missing capability as sufficient reason to stop or soften the teammate handoff rules.
 - Required halt or reroute behavior: Continue with the normal portable teammate workflow and do not allow the missing runtime capability to become an early-stop excuse.
-- Rule surface: The runtime-aware delegation guidance should make background-agent execution a preference when available and preserve the portable teammate workflow when it is not.
+- Rule surface: The runtime-aware delegation guidance should make background-agent execution a preference for bounded, independent work when available and preserve the portable teammate workflow when it is not.
 
 ## Missing runtime follow-up support does not permit Finisher to stop early
 

--- a/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+++ b/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
@@ -32,6 +32,18 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Required halt or reroute behavior: Halt approval and reissue the packet with the remaining approval-relevant concerns included, unless the concern is severe enough to block approval entirely.
 - Rule surface: The first-stage approval contract should require Brainstormer to surface real approval-relevant concerns when present.
 
+## Approval packet omits `concerns[]` entirely
+
+- Starting condition: Brainstormer requests approval, but the packet omits `concerns[]` instead of explicitly reporting concerns or an empty result.
+- Required halt or reroute behavior: Halt approval and reissue the packet with `concerns[]` present under the contract before planning can continue.
+- Rule surface: The approval-packet contract should require `concerns[]` on every Brainstormer approval request.
+
+## Approval packet with no concerns does not render `Remaining concerns: None`
+
+- Starting condition: The approval packet reaches the operator with no approval-relevant concerns remaining, but the no-concerns case is rendered as silence, an empty array, or some other wording.
+- Required halt or reroute behavior: Halt approval presentation and reissue the operator-facing packet with the no-concerns line rendered exactly as `Remaining concerns: None`.
+- Rule surface: The approval-packet rendering guidance should preserve the explicit empty `concerns[]` result under the contract while rendering the operator-facing no-concerns case exactly as `Remaining concerns: None`.
+
 ## Delegated prompts missing expected `superpowers` recommendations
 
 - Starting condition: A delegated teammate prompt omits the expected `superpowers` skill recommendations for that role.
@@ -43,6 +55,12 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Starting condition: A delegated prompt silently skips an expected skill because it is unavailable in the current environment.
 - Required halt or reroute behavior: Halt silent delegation and reissue the prompt with an explicit unavailable-skill warning to the operator and teammate.
 - Rule surface: The delegation prompt should include a visible unavailable skill warning path.
+
+## Delegated teammate work ignores available background-agent execution
+
+- Starting condition: The host runtime supports background-agent execution for delegated teammate work, but the workflow never recommends or prefers that capability when dispatching teammates.
+- Required halt or reroute behavior: Reissue the delegated guidance so runtime-capable hosts are explicitly nudged toward background-agent execution while keeping it optional rather than mandatory.
+- Rule surface: The runtime-aware delegation guidance should prefer background-agent execution when available without turning it into a correctness dependency.
 
 ## Hard-coded repo rules drifting from canonical docs
 
@@ -142,6 +160,18 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Behavioral check: Judge the workflow by what it would do next on the latest pushed head, not by whether it uses stern wording about follow-through.
 - Rule surface: The canonical skill and delegated prompt should both treat pending required checks as active publish-state follow-through.
 
+## Finisher ignores available durable runtime follow-up while external publish-state is pending
+
+- Starting condition: The runtime offers durable follow-up features such as thread heartbeats, monitors, or equivalent wakeups, required checks or external review state remain pending, and the workflow provides no recommendation to use those capabilities for `Finisher` follow-through.
+- Required halt or reroute behavior: Reroute to guidance that prefers those durable runtime aids for the same latest-head `Finisher` loop while the external publish-state remains pending.
+- Rule surface: The canonical skill and delegated Finisher prompt should explicitly recommend durable runtime follow-up features when available and relevant.
+
+## Runtime follow-up resumes the existing Finisher loop instead of creating a new workflow
+
+- Starting condition: The workflow recommends runtime wakeups for `Finisher`, but the documented behavior treats the wakeup as a separate workflow with different routing, shutdown rules, or ownership.
+- Required halt or reroute behavior: Halt the forked workflow and restore the wakeup path to the same latest-head `Finisher` loop, preserving the normal routing and shutdown rules.
+- Rule surface: Runtime monitors or heartbeats should be documented as execution aids for the portable `Finisher` contract rather than as a replacement workflow.
+
 ## Finisher stops with only local commits and no PR
 
 - Starting condition: The run reaches Finisher-owned work with local commits present, but the branch is not pushed and the PR does not exist.
@@ -219,6 +249,18 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Starting condition: Required checks, manual approvals, or other external publish-state signals remain pending on the latest pushed head, and the workflow cannot safely continue monitoring.
 - Required halt or reroute behavior: Report an explicit blocker tied to the latest pushed head and pending external dependency instead of using completion-style language.
 - Rule surface: The Finisher contract should turn unsafe-to-continue monitoring into a `blocked` state rather than a soft success summary.
+
+## Missing background-agent support does not permit early stop
+
+- Starting condition: The host runtime does not support background-agent execution for delegated teammate work, and the workflow treats that missing capability as sufficient reason to stop or soften the teammate handoff rules.
+- Required halt or reroute behavior: Continue with the normal portable teammate workflow and do not allow the missing runtime capability to become an early-stop excuse.
+- Rule surface: The runtime-aware delegation guidance should make background-agent execution a preference when available and preserve the portable teammate workflow when it is not.
+
+## Missing runtime follow-up support does not permit Finisher to stop early
+
+- Starting condition: The runtime does not support durable follow-up features such as thread heartbeats or monitors, pending external publish-state still exists, and the workflow tries to stop with a completion-style handoff anyway.
+- Required halt or reroute behavior: Keep the issue in the portable `Finisher` loop or report an explicit blocker when safe follow-through cannot continue, but do not treat missing runtime support as permission to stop early.
+- Rule surface: The `Finisher` contract should preserve the same ownership and shutdown rules even when runtime follow-up features are unavailable.
 
 ## Finisher fails to distinguish branch-caused CI failures from likely baseline failures
 

--- a/docs/superpowers/specs/2026-04-23-28-recommend-runtime-monitors-or-heartbeats-for-finisher-follow-through-when-available-design.md
+++ b/docs/superpowers/specs/2026-04-23-28-recommend-runtime-monitors-or-heartbeats-for-finisher-follow-through-when-available-design.md
@@ -1,0 +1,148 @@
+# Design: Recommend runtime monitors or heartbeats for Finisher follow-through when available [#28](https://github.com/patinaproject/superteam/issues/28)
+
+## Summary
+
+Refine the `superteam` workflow guidance so `Finisher` follow-through stays behaviorally portable while still taking advantage of runtime support when it exists. The canonical contract should continue to define only the required behavior: `Finisher` remains responsible for publish-state follow-through until the latest pushed PR head is stable enough to hand off cleanly or an explicit blocker is reported.
+
+Within that portable contract, the workflow should recommend using durable runtime follow-up features such as thread heartbeats, monitors, or equivalent host-provided wakeups when they are available and the latest pushed head is waiting on external state such as CI checks or review activity. These runtime features are execution aids for maintaining the existing `Finisher` loop, not a replacement for the loop itself. If a runtime does not provide those features, the workflow must still keep the same ownership and shutdown rules rather than treating the missing feature as permission to stop early.
+
+## Goals
+
+- Preserve the canonical `Finisher` contract as behavioral and portable across runtimes
+- Recommend durable runtime follow-up mechanisms when available to support `Finisher` publish-state monitoring
+- Keep runtime-specific follow-up recommendations clearly subordinate to the portable contract
+- Prevent missing runtime monitor features from being interpreted as a valid reason to stop the `Finisher` loop early
+- Clarify where this recommendation belongs so future runtimes can adopt it without rewriting the core contract
+
+## Non-Goals
+
+- Replacing the existing `Finisher` state machine or shutdown rules added for issue `#26`
+- Requiring one specific automation primitive, polling interval, or host product feature
+- Expanding the workflow into a runtime-specific scheduler design
+- Weakening the expectation that every `superteam` run publishes a PR and continues through publish-state follow-through
+- Moving ownership of external feedback or pending checks away from `Finisher`
+
+## Approaches Considered
+
+### Recommended: add a portable recommendation layer above the existing Finisher contract
+
+Keep the required workflow contract behavioral and runtime-agnostic, then add explicit guidance that `Finisher` should prefer durable runtime follow-up features when the host supports them. This preserves portability while still nudging implementations toward better follow-through in capable runtimes.
+
+### Alternative: encode heartbeat or monitor usage directly into the Finisher contract
+
+This would overfit the contract to runtimes that expose those features and would make the core workflow less portable. It would also turn an execution aid into a mandatory dependency.
+
+### Alternative: leave runtime follow-through entirely implicit
+
+This preserves portability, but it misses the issue goal. Runtimes that can keep following up automatically would receive no guidance to do so, and operators could continue to stop after a status snapshot even when the runtime could have kept the `Finisher` loop alive.
+
+## Design
+
+### The core Finisher contract remains behavioral
+
+The canonical skill should continue to describe what `Finisher` must do, not which host mechanism it must use. The contract remains:
+
+- publish the branch and ensure the PR exists
+- keep ownership of publish-state follow-through on the latest pushed head
+- remain in `triage`, `monitoring`, `ready`, or `blocked` based on current publish-state
+- continue the `Finisher` loop until the latest head is stable enough for clean handoff or an explicit blocker is reported
+- re-evaluate after every push and after new external feedback or status changes
+
+This issue should not re-open the behavioral decisions already made for pending checks, shutdown readiness, or review ownership. The new change is guidance about how to maintain that loop more reliably when the runtime can wake the workflow back up on its own.
+
+### Runtime monitors or heartbeats are an execution aid recommendation
+
+The skill should add a recommendation in the runtime-aware guidance surfaces that says, in effect:
+
+- when the host runtime supports background-agent execution for delegated teammate work, prefer running teammate work through that capability
+- when the runtime offers durable follow-up features such as thread heartbeats, monitors, or equivalent wakeups, prefer using them for `Finisher` follow-through while required checks or external review state remain pending
+- keep both recommendations as host-capability preferences rather than correctness dependencies
+- use those features to resume the existing `Finisher` ownership loop on the latest pushed head rather than as a separate workflow with different shutdown rules
+- keep the recommendation feature-agnostic so the wording remains portable across runtimes that use different names for similar capabilities
+
+This recommendation belongs in a place that already discusses runtime-awareness, such as pre-flight guidance and `Finisher`-owned follow-through guidance, rather than inside acceptance criteria or shutdown logic alone. The contract should remain authoritative; runtime features simply help the runtime live up to it.
+
+### Missing runtime support is never a success condition
+
+The workflow must explicitly reject the rationalization that "this runtime cannot monitor in the background, so stopping now is acceptable." If durable follow-up features are unavailable, disabled, or unsuitable in the current environment, `Finisher` still owns the same pending publish-state work.
+
+In that case the workflow should:
+
+- continue allowing teammate work to run through the normal portable workflow even when background-agent execution is unavailable
+- continue using the existing `monitoring` and `blocked` semantics from the portable contract
+- avoid treating feature absence as a soft success or completion boundary
+- surface an explicit blocker when the workflow cannot safely continue follow-through in the current run
+- preserve the difference between "the runtime lacks a convenience feature" and "the publish-state is actually stable"
+
+This keeps issue `#28` aligned with issue `#26`: runtime aids may improve follow-through, but they do not define readiness.
+
+### Finisher should prefer durable follow-through when pending state is external
+
+The recommendation should be especially explicit for situations where `Finisher` is waiting on external systems rather than immediate branch-side fixes. Examples include:
+
+- required checks still running on the latest pushed head
+- external review threads or bot findings that may appear after publication
+- manual approvals or other repository signals that are expected to change later
+
+When a runtime can register a heartbeat, monitor, or equivalent wakeup, `Finisher` should prefer that durable follow-through path instead of relying only on the operator to remember to ask again later. The recommendation is strongest in these external-wait states because the workflow already knows the next meaningful step is to re-check publish-state after something outside the branch changes.
+
+### The recommendation must not fork the ownership model
+
+Runtime monitors or heartbeats should not create a second, competing workflow. They should wake the same thread or resume the same `Finisher` responsibility so that:
+
+- the latest pushed head remains the evaluation target
+- branch and PR state are re-checked using the same shutdown rules
+- external feedback still stays with `Finisher`
+- requirement-bearing deltas still route through `Brainstormer`, then `Planner`, then `Executor`
+
+This matters because issue `#28` is about follow-through quality, not about inventing a new automation architecture. The durable wakeup should keep the workflow in the canonical loop rather than bypassing it.
+
+### Brainstormer approval packets must always report `concerns[]`
+
+This issue should also tighten the approval-packet reporting contract in a narrow way so the design and later workflow guidance stay consistent about approval visibility. When `Brainstormer` requests approval, the packet should always include `concerns[]` as a required field.
+
+That requirement should be explicit in the design:
+
+- if approval-relevant concerns remain, report them in `concerns[]`
+- if no approval-relevant concerns remain, still report `concerns[]` with an explicit empty result
+- when rendering the operator-facing approval packet for the no-concerns case, present it exactly as `Remaining concerns: None` instead of displaying an empty array
+- do not omit the field based on the assumption that "no concerns" can be inferred from silence
+
+This is a reporting-discipline refinement, not a broader change to approval gates or teammate ownership.
+
+### Scope of repository changes
+
+The implementation should stay narrow and update only the workflow-contract surfaces that directly guide this behavior:
+
+- `skills/superteam/SKILL.md`
+  - prefer background-agent execution for teammate work when the host runtime supports it, while keeping teammate contracts portable when it does not
+  - add portable recommendation language for durable runtime follow-up features in the runtime-aware guidance and `Finisher` sections
+  - explicitly state that missing runtime support does not permit early stop or completion-style handoff
+- `skills/superteam/agent-spawn-template.md`
+  - mirror the same background-agent and follow-through recommendations in delegated prompts so runtime-capable hosts are nudged to use them without making them mandatory
+- `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+  - add scenarios that distinguish "background-agent or runtime follow-up recommended and available" from "those capabilities unavailable, but the workflow still must not stop early"
+
+Other files should remain unchanged unless they already contain wording that would directly conflict with this recommendation.
+
+## Testing And Verification
+
+- verify the canonical skill keeps the `Finisher` contract behavioral and portable rather than making heartbeat support a required dependency
+- verify the canonical skill recommends background-agent execution for delegated teammate work when the host supports it without making that capability a correctness dependency
+- verify the canonical skill recommends runtime monitors, heartbeats, or equivalent wakeups when the host supports them and pending external publish-state remains
+- verify the delegated prompts mirror the same background-agent preference for runtime-capable hosts
+- verify the delegated `Finisher` prompt mirrors that recommendation instead of leaving runtime-capable hosts unguided
+- verify the canonical skill explicitly states that missing runtime monitor support does not permit an early stop or completion-style handoff
+- verify the canonical skill explicitly allows the normal portable teammate workflow when background-agent support is unavailable
+- verify the approval-packet contract requires `concerns[]` on every `Brainstormer` approval request, including an explicit empty result when no approval-relevant concerns exist
+- verify operator-facing approval packets render the no-concerns case exactly as `Remaining concerns: None` while preserving the underlying explicit empty `concerns[]` result
+- verify the pressure-test doc covers both runtime-capable and runtime-incapable follow-through scenarios
+- verify the recommendation keeps the wakeup path inside the existing `Finisher` ownership loop rather than creating a separate ownership model
+
+## Acceptance Criteria
+
+- AC-28-1: Given the runtime supports durable follow-up features such as thread heartbeats, monitors, or equivalent wakeups, when `Finisher` is waiting on pending external publish-state, then the workflow recommends using those features for `Finisher` follow-through
+- AC-28-2: Given the host runtime supports background-agent execution for teammate work, when the workflow delegates teammate responsibilities, then it recommends using that capability without making it a correctness dependency
+- AC-28-3: Given the runtime does not support background-agent execution or durable follow-up features, when pending publish-state still exists, then the workflow keeps the same portable teammate and `Finisher` ownership rules and does not treat feature absence as permission to stop early
+- AC-28-4: Given runtime follow-up features are used, when `Finisher` wakes back up, then it resumes the existing latest-head publish-state loop rather than a separate workflow with different routing or shutdown rules
+- AC-28-5: Given `Brainstormer` requests approval, when approval-relevant concerns are present or absent, then the approval packet always reports `concerns[]`, uses an explicit empty result when none exist, and renders that no-concerns case to the operator exactly as `Remaining concerns: None`

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -106,7 +106,11 @@ flowchart TD
 ## Pre-flight
 
 - Prefer the host runtime's normal multi-agent capabilities when available.
+- When the host runtime supports background-agent execution for delegated teammate work, prefer using that capability as an execution aid rather than a correctness dependency.
+- When the runtime offers durable follow-up features such as thread heartbeats, monitors, or equivalent wakeups, prefer using them for `Finisher` publish-state follow-through while required checks or external review state remain pending.
+- Treat these runtime capabilities as aids for the existing teammate and `Finisher` loops, not as separate workflows or replacement contracts.
 - Do not block solely because a preferred team feature is unavailable; fall back to direct subagent dispatch.
+- If the host lacks those capabilities, do not stop early; continue using the portable teammate and `Finisher` contracts or report an explicit blocker when follow-through cannot safely continue.
 - Keep runtime-specific checks lightweight. Teammate ownership, gate discipline, and artifact authority are the important parts.
 
 ## Canonical rule discovery
@@ -129,7 +133,9 @@ Before asking for approval:
 2. Return the exact artifact path under review.
 3. Include a concise intent summary of what the artifact changes or decides.
 4. Include the full requirement set currently under review.
-5. Surface any remaining approval-relevant concerns that could materially affect the decision to approve, revise, or narrow the design.
+5. Always report `concerns[]` in the approval packet, including an explicit empty result when no approval-relevant concerns remain.
+6. Render the operator-facing no-concerns line exactly as `Remaining concerns: None`.
+7. Surface any remaining approval-relevant concerns that could materially affect the decision to approve, revise, or narrow the design.
 
 If the approval packet is too large to present cleanly, split it into multiple approval requests or sections. Do not collapse it into a vague fallback summary.
 
@@ -155,6 +161,8 @@ If revisions are requested after an approval pass, re-fire approval with delta-o
 - Return the exact design doc path.
 - Return the ordered active AC list.
 - Report the concise intent summary and the full requirement set used for approval.
+- Always report `concerns[]` when requesting approval, including an explicit empty result when no approval-relevant concerns remain under the contract.
+- Render the operator-facing no-concerns line exactly as `Remaining concerns: None`.
 - Surface any remaining approval-relevant concerns when requesting approval.
 - Recommend `superpowers:brainstorming`.
 
@@ -214,6 +222,9 @@ If revisions are requested after an approval pass, re-fire approval with delta-o
 - Any new push invalidates earlier assumptions and restarts evaluation on the new latest head.
 - Stay in the `Finisher` loop after PR publication until publish-state follow-through is stable enough to hand off cleanly or an explicit blocker is reported.
 - Do not treat PR creation, one status snapshot, restored mergeability, or green CI alone as workflow completion.
+- When the runtime offers durable follow-up features such as thread heartbeats, monitors, or equivalent wakeups, prefer using them while required checks or external review state remain pending.
+- Treat those runtime features as aids for the same latest-head `Finisher` loop rather than as a separate workflow or replacement contract.
+- If the runtime lacks those features, continue the portable `Finisher` ownership model or report an explicit blocker instead of stopping early.
 - Verify current branch state before resolving or replying to comments tied to prior state.
 - Route requirement-bearing feedback through `Brainstormer` first, then `Planner`, then `Executor`.
 - Recommend `superpowers:finishing-a-development-branch`.
@@ -260,6 +271,7 @@ Before resolving or replying to comments tied to a prior branch state:
 | "The design file probably exists if Brainstormer says it does." | Gate 1 requires verifying the artifact exists at the reported path before approval. |
 | "I can summarize the approval request in one short fallback blurb." | Approval packets must include artifact path, concise intent summary, and full requirement set; split oversized packets instead of collapsing them. |
 | "I can replay the whole approval request after a small revision." | Re-fired approval after revisions must be delta-only. |
+| "If the runtime has background agents or wakeups, the contract must require them." | Runtime capabilities are execution aids for the portable workflow, not correctness dependencies. |
 | "I remember the repo rules already." | Discover canonical repository guidance before touching governed files. |
 | "Executor finished the spirit of the task." | `Executor` must report completion against explicit task IDs with evidence. |
 | "Reviewer can just send everything back to execution." | `Reviewer` must classify implementation-level, plan-level, and spec-level loopbacks. |
@@ -271,10 +283,12 @@ Before resolving or replying to comments tied to a prior branch state:
 - Using older stage-only language where the canonical teammate roster should be used.
 - Asking for design approval before verifying the cited artifact exists.
 - Approval requests that omit the artifact path, concise intent summary, or full requirement set.
+- Approval requests that omit `concerns[]` or render the no-concerns case as anything other than `Remaining concerns: None`.
 - Oversized approval requests collapsed into a vague summary instead of split into clean sections.
 - Approval requests that hide real approval-relevant concerns.
 - Replaying already-approved content instead of sending delta-only approval after revisions.
 - Touching governed files without canonical-rule discovery from repository guidance.
+- Delegated teammate work in a runtime-capable host that ignores available background-agent execution without justification.
 - Delegated teammate prompts that omit expected `superpowers` recommendations or fail to warn when an expected skill is unavailable.
 - `Executor` claiming completion without explicit task IDs, SHAs, or verification evidence.
 - `Reviewer` failing to classify findings as `implementation-level`, `plan-level`, or `spec-level`.
@@ -282,6 +296,7 @@ Before resolving or replying to comments tied to a prior branch state:
 - Skill or workflow-contract changes reviewed without `superpowers:writing-skills` or a pressure-test walkthrough.
 - Local review findings taking ownership of external PR feedback away from `Finisher`.
 - `Finisher` resolving prior-state comments without checking current branch state first.
+- `Finisher` treating missing runtime wakeups as permission to stop early or present a completion-style handoff.
 - Treating local-only state as a valid end state for a `superteam` run.
 - Letting a run stop with a completion-style closeout after `Executor` finishes local work without reaching `Reviewer` and `Finisher`, unless the run halts explicitly with a blocker.
 - Treating PR publication plus a status snapshot as the end of the workflow while `Finisher`-owned work is still active.

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -106,8 +106,10 @@ flowchart TD
 ## Pre-flight
 
 - Prefer the host runtime's normal multi-agent capabilities when available.
-- When the host runtime supports background-agent execution for delegated teammate work, prefer using that capability as an execution aid rather than a correctness dependency.
+- When the host runtime supports background-agent execution for delegated teammate work, prefer using that capability for bounded, independent work that is unlikely to need live clarification, as an execution aid rather than a correctness dependency.
+- Keep tightly coupled, ambiguity-heavy, or clarification-driven teammate work in the foreground even when background agents are available.
 - When the runtime offers durable follow-up features such as thread heartbeats, monitors, or equivalent wakeups, prefer using them for `Finisher` publish-state follow-through while required checks or external review state remain pending.
+- In Codex app environments, same-thread automations are the native fit when `Finisher` follow-through should stay attached to the current conversation.
 - Treat these runtime capabilities as aids for the existing teammate and `Finisher` loops, not as separate workflows or replacement contracts.
 - Do not block solely because a preferred team feature is unavailable; fall back to direct subagent dispatch.
 - If the host lacks those capabilities, do not stop early; continue using the portable teammate and `Finisher` contracts or report an explicit blocker when follow-through cannot safely continue.
@@ -153,7 +155,7 @@ If revisions are requested after an approval pass, re-fire approval with delta-o
 - Enforce gates and halt on unsatisfied contracts.
 - Route requirement-changing deltas back through `Brainstormer`.
 - Recommend `superpowers:using-superpowers`.
-- Also recommend `superpowers:dispatching-parallel-agents` when splitting independent work.
+- Also recommend `superpowers:dispatching-parallel-agents` when splitting bounded, independent work, and keep tightly coupled or interactive steps in the foreground.
 
 ### Brainstormer
 
@@ -223,6 +225,7 @@ If revisions are requested after an approval pass, re-fire approval with delta-o
 - Stay in the `Finisher` loop after PR publication until publish-state follow-through is stable enough to hand off cleanly or an explicit blocker is reported.
 - Do not treat PR creation, one status snapshot, restored mergeability, or green CI alone as workflow completion.
 - When the runtime offers durable follow-up features such as thread heartbeats, monitors, or equivalent wakeups, prefer using them while required checks or external review state remain pending.
+- In Codex app environments, prefer a thread automation attached to the current thread when the goal is to preserve the same `Finisher` context while waiting on external publish-state.
 - Treat those runtime features as aids for the same latest-head `Finisher` loop rather than as a separate workflow or replacement contract.
 - If the runtime lacks those features, continue the portable `Finisher` ownership model or report an explicit blocker instead of stopping early.
 - Verify current branch state before resolving or replying to comments tied to prior state.
@@ -272,6 +275,7 @@ Before resolving or replying to comments tied to a prior branch state:
 | "I can summarize the approval request in one short fallback blurb." | Approval packets must include artifact path, concise intent summary, and full requirement set; split oversized packets instead of collapsing them. |
 | "I can replay the whole approval request after a small revision." | Re-fired approval after revisions must be delta-only. |
 | "If the runtime has background agents or wakeups, the contract must require them." | Runtime capabilities are execution aids for the portable workflow, not correctness dependencies. |
+| "If background agents are available, every teammate step should use them." | Use background agents for bounded, independent work; keep tightly coupled or clarification-heavy steps in the foreground. |
 | "I remember the repo rules already." | Discover canonical repository guidance before touching governed files. |
 | "Executor finished the spirit of the task." | `Executor` must report completion against explicit task IDs with evidence. |
 | "Reviewer can just send everything back to execution." | `Reviewer` must classify implementation-level, plan-level, and spec-level loopbacks. |
@@ -288,7 +292,7 @@ Before resolving or replying to comments tied to a prior branch state:
 - Approval requests that hide real approval-relevant concerns.
 - Replaying already-approved content instead of sending delta-only approval after revisions.
 - Touching governed files without canonical-rule discovery from repository guidance.
-- Delegated teammate work in a runtime-capable host that ignores available background-agent execution without justification.
+- Delegated teammate work that either ignores available background-agent execution for clearly bounded, independent work or forces background execution on tightly coupled, clarification-heavy work.
 - Delegated teammate prompts that omit expected `superpowers` recommendations or fail to warn when an expected skill is unavailable.
 - `Executor` claiming completion without explicit task IDs, SHAs, or verification evidence.
 - `Reviewer` failing to classify findings as `implementation-level`, `plan-level`, or `spec-level`.

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -13,7 +13,8 @@ Agent({
            Before starting, discover canonical repository rules: read root contributor docs
            such as `AGENTS.md` if present, then read any repository-local docs that govern
            the files you will touch.
-           When the host runtime supports background-agent execution for delegated teammate work, prefer using it.
+           When the host runtime supports background-agent execution for delegated teammate work, prefer using it for bounded, independent work that is unlikely to need live clarification.
+           Keep tightly coupled, ambiguity-heavy, or clarification-driven teammate work in the foreground even when background agents are available.
            If that capability is unavailable, continue with the normal portable teammate workflow instead of treating the missing feature as permission to stop.
            Recommend the relevant expected `superpowers` skills for your role. If any expected
            skill is unavailable in the current environment, state that explicitly in this
@@ -40,7 +41,7 @@ Append this block in place of `{role-specific inputs}`:
 ```text
 Own orchestration, delegation, gates, and loopbacks.
 Recommend `superpowers:using-superpowers`.
-Also recommend `superpowers:dispatching-parallel-agents` when splitting independent work.
+Also recommend `superpowers:dispatching-parallel-agents` when splitting bounded, independent work, and keep tightly coupled or interactive steps in the foreground.
 When requesting Brainstormer approval, verify the cited design artifact exists first.
 Each approval packet must include:
 - exact artifact path
@@ -145,6 +146,7 @@ Own publish-state follow-through and all external review/comment handling.
 Own receiving and interpreting external post-publish PR feedback.
 After `Reviewer` completes the local pre-publish pass, `Finisher` is the next required stage unless the run halts explicitly with a blocker.
 When the runtime offers durable follow-up features such as thread heartbeats, monitors, or equivalent wakeups, prefer using them while pending external publish-state remains.
+In Codex app environments, prefer a thread automation attached to the current thread when the goal is to preserve the same `Finisher` context while waiting on external publish-state.
 Treat those runtime features as aids for the same latest-head `Finisher` loop rather than as a separate workflow.
 If the runtime lacks those features, continue the portable `Finisher` ownership model or report an explicit blocker instead of stopping early.
 When a project-owned PR template or PR-body rule exists, satisfy it first and treat the `superteam` PR template as fallback/default guidance rather than as an override.

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -13,6 +13,8 @@ Agent({
            Before starting, discover canonical repository rules: read root contributor docs
            such as `AGENTS.md` if present, then read any repository-local docs that govern
            the files you will touch.
+           When the host runtime supports background-agent execution for delegated teammate work, prefer using it.
+           If that capability is unavailable, continue with the normal portable teammate workflow instead of treating the missing feature as permission to stop.
            Recommend the relevant expected `superpowers` skills for your role. If any expected
            skill is unavailable in the current environment, state that explicitly in this
            delegated prompt and carry the same warning into your work so the operator and
@@ -44,6 +46,8 @@ Each approval packet must include:
 - exact artifact path
 - concise intent summary
 - full requirement set under review
+- `concerns[]`, including an explicit empty result when none exist under the contract
+- operator-facing no-concerns rendering exactly as `Remaining concerns: None`
 - remaining approval-relevant concerns when they exist
 If the approval packet is too large, split it instead of collapsing it.
 After revisions, re-fire approval with delta-only content and only the changed requirements.
@@ -65,6 +69,7 @@ Done-report contract:
 - `intent_summary`: concise summary of what the artifact changes or decides
 - `requirements[]`: full requirement set currently under review
 - `concerns[]`: remaining approval-relevant concerns that could materially affect approval, or an explicit empty result when none exist
+Operator-facing approval packets must render the no-concerns case exactly as `Remaining concerns: None`.
 ```
 
 ### Planner
@@ -139,6 +144,9 @@ Recommend `superpowers:receiving-code-review` when handling PR comments, review 
 Own publish-state follow-through and all external review/comment handling.
 Own receiving and interpreting external post-publish PR feedback.
 After `Reviewer` completes the local pre-publish pass, `Finisher` is the next required stage unless the run halts explicitly with a blocker.
+When the runtime offers durable follow-up features such as thread heartbeats, monitors, or equivalent wakeups, prefer using them while pending external publish-state remains.
+Treat those runtime features as aids for the same latest-head `Finisher` loop rather than as a separate workflow.
+If the runtime lacks those features, continue the portable `Finisher` ownership model or report an explicit blocker instead of stopping early.
 When a project-owned PR template or PR-body rule exists, satisfy it first and treat the `superteam` PR template as fallback/default guidance rather than as an override.
 When a real issue number is available for the canonical single-issue workflow and nothing in the current run says the work is partial, follow-up, or otherwise non-closing, render `Closes #<issue-number>` in the PR body.
 When the issue is related but not complete, render a non-closing issue reference plus a brief explanation.


### PR DESCRIPTION
## Summary
- recommend background-agent delegation when the host runtime supports it while keeping teammate execution portable when it does not
- recommend durable runtime follow-up aids such as monitors or heartbeats for `Finisher` while pending external publish-state remains
- require `Brainstormer` approval packets to always report `concerns[]` and render the no-concerns operator view as `Remaining concerns: None`

## Linked issue
Closes #28

## Branch state
- Latest pushed branch state: `28-recommend-runtime-monitors-or-heartbeats-for-finisher-follow-through-when-available@05db9522cb3bfbe29540c15a60922089ba71df89`
- Review state: no open findings
- CI state: pending post-publish sweep

## Acceptance Criteria
### AC-28-1
The workflow recommends durable runtime follow-up aids for `Finisher` when pending external publish-state exists and the host supports them.
- [x] Verification: `sed -n '1,280p' skills/superteam/SKILL.md` - verified runtime follow-up guidance in the canonical contract.
- [x] Verification: `sed -n '1,280p' skills/superteam/agent-spawn-template.md` - verified delegated `Finisher` guidance mirrors the same recommendation.
- [x] Verification: `sed -n '1,360p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md` - verified pressure-test coverage for available durable runtime follow-up.

### AC-28-2
The workflow recommends background-agent delegation when available without making it a correctness dependency.
- [x] Verification: `sed -n '1,280p' skills/superteam/SKILL.md` - verified pre-flight guidance prefers background-agent delegation while keeping the contract portable.
- [x] Verification: `sed -n '1,280p' skills/superteam/agent-spawn-template.md` - verified shared delegation guidance mirrors the same recommendation and fallback.
- [x] Verification: `sed -n '1,360p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md` - verified runtime-capable and runtime-incapable delegation scenarios are covered.

### AC-28-3
The workflow preserves the same portable teammate and `Finisher` ownership rules when runtime aids are unavailable and does not allow early stop.
- [x] Verification: `sed -n '1,280p' skills/superteam/SKILL.md` - verified missing runtime support is not treated as permission to stop early.
- [x] Verification: `sed -n '1,280p' skills/superteam/agent-spawn-template.md` - verified delegated guidance preserves the portable fallback path.
- [x] Verification: `sed -n '1,360p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md` - verified fallback pressure tests for missing runtime support and approval-packet rendering.

### AC-28-4
Runtime wakeups resume the same latest-head `Finisher` loop instead of a separate workflow.
- [x] Verification: `sed -n '1,280p' skills/superteam/SKILL.md` - verified runtime follow-up is described as an aid for the same `Finisher` loop.
- [x] Verification: `sed -n '1,360p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md` - verified the loop-preservation scenario is covered.

### AC-28-5
Approval packets always report `concerns[]` and render the no-concerns operator view as `Remaining concerns: None`.
- [x] Verification: `sed -n '1,280p' skills/superteam/SKILL.md` - verified the Gate 1 and `Brainstormer` contract language.
- [x] Verification: `sed -n '1,280p' skills/superteam/agent-spawn-template.md` - verified delegated approval-packet guidance uses the exact rendering.
- [x] Verification: `sed -n '1,360p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md` - verified omission and rendering failure scenarios are covered.

## Test plan
- [x] All required ACs above verified on the latest pushed branch state
- [x] Verification reflects the current branch state, not superseded local work

## Review follow-up
- Local reviewer state: none; local review passed with no findings and the seven required pressure-test walkthrough scenarios passed.
- External feedback state: no open review threads yet; post-publish state to be monitored on the latest pushed head.
- Branch-state-aware next action: monitor PR checks and any new external feedback on `05db9522cb3bfbe29540c15a60922089ba71df89`.
