### PR TITLE
docs: #30 require handoff commits for artifacts

### DIFF
--- a/docs/superpowers/plans/2026-04-23-30-artifact-producing-teammates-should-commit-before-handoff-plan.md
+++ b/docs/superpowers/plans/2026-04-23-30-artifact-producing-teammates-should-commit-before-handoff-plan.md
@@ -1,0 +1,199 @@
+# Plan: Artifact-producing teammates should commit before handoff [#30](https://github.com/patinaproject/superteam/issues/30)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. When editing `skills/**/*.md`, invoke `superpowers:writing-skills` before editing. During local review of skill or workflow-contract changes, invoke `superpowers:writing-skills` and run the relevant pressure-test walkthrough before publish.
+
+**Goal:** Require `Brainstormer`, `Planner`, and `Executor` to commit their owned artifact changes before handoff, make uncommitted artifact-dependent handoffs incomplete unless the run halts explicitly with a blocker, and leave `Reviewer` and `Finisher` free from meaningless commit requirements when they did not materially change durable artifacts.
+
+**Architecture:** Tighten the canonical `superteam` skill first so the workflow-level rule and teammate-specific done contracts define branch-state authority for artifact-producing handoffs. Then mirror the same rule in the delegated teammate prompt template so spawned runs follow the same completion boundary. Finally, expand the repo-local pressure tests so local review can catch uncommitted handoff loopholes and confirm the non-artifact-producing exception.
+
+**Tech Stack:** Markdown workflow docs, repo-local pressure tests, `rg`, `sed`, `git diff`
+
+---
+
+## File Structure
+
+- `docs/superpowers/specs/2026-04-23-30-artifact-producing-teammates-should-commit-before-handoff-design.md`
+  - Approved design doc and acceptance source for issue `#30`.
+- `docs/superpowers/plans/2026-04-23-30-artifact-producing-teammates-should-commit-before-handoff-plan.md`
+  - This implementation plan.
+- `skills/superteam/SKILL.md`
+  - Canonical workflow contract; source of truth for the workflow-level incomplete-handoff rule and the `Brainstormer`/`Planner`/`Executor` commit-before-handoff contracts.
+- `skills/superteam/agent-spawn-template.md`
+  - Delegated teammate prompt surface that must mirror the same artifact-producing handoff rule and done-report fields.
+- `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+  - Repo-local pressure tests that must exercise uncommitted artifact-producing handoffs and the non-artifact-producing exception.
+
+## Planned Workstreams
+
+- Workstream 1: tighten the canonical `superteam` workflow contract and role-specific done reports
+- Workstream 2: mirror the same handoff-commit rule in the delegated teammate prompt template
+- Workstream 3: add pressure-test coverage for uncommitted handoffs and the non-artifact exception, then verify the changed surfaces stay aligned
+
+### Task 1: Tighten the canonical workflow contract and done reports
+
+**Files:**
+- Modify: `skills/superteam/SKILL.md`
+
+- [ ] **Step 1: Inspect the current workflow-level and role-specific handoff language**
+
+Run: `rg -n "handoff|done-report|Done-report|Brainstormer|Planner|Executor|Reviewer|Finisher|commit|SHA|branch state|workspace state" skills/superteam/SKILL.md`
+Expected: locate the existing workflow-level handoff rules and the current `Brainstormer`, `Planner`, and `Executor` done-report contracts that need the commit-before-handoff requirement.
+
+- [ ] **Step 2: Invoke the required skill-doc editing discipline**
+
+Before editing `skills/superteam/SKILL.md`, invoke `superpowers:writing-skills`.
+Expected: the skill-editing pass treats this as a workflow-contract change rather than ordinary prose cleanup.
+
+- [ ] **Step 3: Add the workflow-level incomplete-handoff rule**
+
+Update `skills/superteam/SKILL.md` so it explicitly states behavior equivalent to:
+
+```md
+Handoffs that depend on uncommitted durable artifact changes are incomplete unless the run halts explicitly with a blocker.
+The workflow should trust committed branch state rather than dirty workspace state for artifact-producing handoffs.
+```
+
+Place this where the canonical workflow rules can govern all downstream teammate handoffs without turning it into a generic repo-wide git policy.
+
+- [ ] **Step 4: Add explicit role-specific commit-before-handoff requirements**
+
+Update the `Brainstormer`, `Planner`, and `Executor` teammate sections so each one explicitly requires committing owned artifact changes before reporting done or handing off. Keep the rule tied to durable artifact production for those roles, for example:
+
+```md
+`Brainstormer` must commit the design-doc change before handoff.
+`Planner` must commit the implementation-plan change before handoff.
+`Executor` must commit the completed implementation/test batch before handoff.
+```
+
+Do not add parallel commit requirements to `Reviewer` or `Finisher` merely because they are stages in the workflow.
+
+- [ ] **Step 5: Extend the role-specific done-report contracts with handoff commit fields**
+
+Update the done-report guidance so the artifact-producing roles report a specific handoff commit field alongside their existing required fields, equivalent to:
+
+```md
+Brainstormer:
+- `handoff_commit_sha`: commit containing the approved design artifact
+
+Planner:
+- `handoff_commit_sha`: commit containing the approved implementation plan
+
+Executor:
+- `head_sha`: current HEAD SHA for the committed task batch
+```
+
+Use field names that stay consistent with the surrounding contract and avoid inventing two different names for the same concept unless the existing schema clearly requires it.
+
+- [ ] **Step 6: Re-read the updated canonical contract in context**
+
+Run: `sed -n '80,260p' skills/superteam/SKILL.md`
+Expected: the canonical skill now makes uncommitted artifact-dependent handoffs incomplete, requires commits before `Brainstormer`/`Planner`/`Executor` handoff, and leaves `Reviewer`/`Finisher` outside any meaningless-commit rule.
+
+### Task 2: Mirror the same handoff-commit rule in the delegated teammate prompt
+
+**Files:**
+- Modify: `skills/superteam/agent-spawn-template.md`
+
+- [ ] **Step 1: Inspect the artifact-producing teammate prompt blocks**
+
+Run: `rg -n "Brainstormer|Planner|Executor|Done-report contract|commit|handoff|head_sha" skills/superteam/agent-spawn-template.md`
+Expected: locate the delegated prompt lines that currently define `Brainstormer`, `Planner`, and `Executor` completion and done-report behavior.
+
+- [ ] **Step 2: Invoke the required skill-doc editing discipline**
+
+Before editing `skills/superteam/agent-spawn-template.md`, invoke `superpowers:writing-skills`.
+Expected: the prompt-template update follows the same skill-authoring discipline as the source contract.
+
+- [ ] **Step 3: Add the delegated artifact-producing handoff rule**
+
+Update the relevant teammate prompt blocks so they each explicitly require committing owned artifact changes before reporting done or handing off, in language equivalent to:
+
+```text
+Commit your owned artifact changes before handoff.
+Do not report done while the required design, plan, or implementation artifact exists only as uncommitted workspace state.
+```
+
+Keep the wording role-specific and do not broaden it into a universal commit mandate for all teammates.
+
+- [ ] **Step 4: Add the corresponding handoff commit fields to delegated done reports**
+
+Update the delegated done-report contracts for `Brainstormer`, `Planner`, and `Executor` so they include the same handoff commit reporting required by the canonical skill. Preserve the surrounding contract shape and make sure the delegated fields are named consistently with the source contract wherever possible.
+
+- [ ] **Step 5: Re-read the delegated prompt surface**
+
+Run: `sed -n '1,240p' skills/superteam/agent-spawn-template.md`
+Expected: the delegated prompts now mirror the source contract on artifact-producing commit-before-handoff behavior and handoff commit reporting without forcing commits from `Reviewer` or `Finisher`.
+
+### Task 3: Expand the repo-local pressure tests for handoff commits
+
+**Files:**
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+- [ ] **Step 1: Inspect the current handoff and done-report scenarios**
+
+Run: `rg -n "handoff|done-report|commit|Brainstormer|Planner|Executor|Reviewer|Finisher|workspace|branch state" docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: identify the current scenarios that already cover handoff discipline so the new additions stay narrow and non-duplicative.
+
+- [ ] **Step 2: Add the uncommitted artifact-producing handoff scenarios**
+
+Add scenarios that check behavior equivalent to:
+
+```md
+## Brainstormer hands off an uncommitted design artifact
+## Planner hands off an uncommitted plan artifact
+## Executor hands off uncommitted implementation artifacts
+```
+
+Each scenario should state that the handoff is incomplete and must loop back or halt explicitly with a blocker instead of allowing downstream work to proceed on dirty workspace state.
+
+- [ ] **Step 3: Add the non-artifact-producing exception scenario**
+
+Add a scenario that checks behavior equivalent to:
+
+```md
+## Non-artifact-producing stages are not forced into meaningless commits
+
+- Starting condition: `Reviewer` or `Finisher` completes stage responsibilities without materially changing durable artifacts.
+- Required halt or reroute behavior: do not require a commit solely to satisfy the handoff-commit rule.
+- Rule surface: the artifact-producing handoff rule should apply to artifact-producing roles and artifact-producing changes, not become a ritual for every stage.
+```
+
+- [ ] **Step 4: Re-read the pressure-test doc in context**
+
+Run: `sed -n '1,260p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: the pressure-test doc now covers uncommitted design, plan, and implementation handoffs, plus the non-artifact-producing exception.
+
+### Task 4: Verify cross-surface alignment and local review expectations
+
+**Files:**
+- Modify: `skills/superteam/SKILL.md`
+- Modify: `skills/superteam/agent-spawn-template.md`
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+- [ ] **Step 1: Check that the three changed surfaces describe the same rule**
+
+Run: `rg -n "uncommitted|commit before handoff|handoff_commit_sha|head_sha|workspace state|branch state|meaningless commit" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: the canonical skill, delegated prompt, and pressure-test doc all reflect the same narrow issue-`#30` contract.
+
+- [ ] **Step 2: Review the diff for narrow scope**
+
+Run: `git diff -- skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+Expected: the diff stays confined to handoff commit requirements, handoff commit reporting, incomplete uncommitted handoffs, and the non-artifact-producing exception.
+
+- [ ] **Step 3: Run the local review-stage pressure-test walkthrough before publish**
+
+During `Reviewer`, invoke `superpowers:writing-skills` and walk through the updated pressure-test scenarios for:
+
+```text
+1. Brainstormer hands off an uncommitted design artifact
+2. Planner hands off an uncommitted plan artifact
+3. Executor hands off uncommitted implementation artifacts
+4. Reviewer or Finisher completes work without durable artifact changes
+```
+
+Expected: `Reviewer` reports pass/fail outcomes and loopholes for these scenarios before the run moves toward publish.
+
+- [ ] **Step 4: Commit the workflow-contract update**
+
+Run: `git add skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md && git commit -m "docs: #30 require handoff commits for artifacts"`
+Expected: a single docs-focused commit records the aligned workflow-contract changes for issue `#30`.

--- a/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+++ b/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
@@ -99,6 +99,30 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Required halt or reroute behavior: Halt the handoff and return it to the owning teammate until the required done-report fields are present in the expected shape.
 - Rule surface: Each teammate-specific done contract should define the minimum stable fields needed for downstream handoff.
 
+## Brainstormer hands off an uncommitted design artifact
+
+- Starting condition: `Brainstormer` writes or updates the design doc, but the artifact exists only as uncommitted workspace state when handoff to `Planner` is attempted.
+- Required halt or reroute behavior: Treat the handoff as incomplete and loop it back to `Brainstormer` until the design artifact is committed, or halt explicitly with a blocker if the run cannot proceed safely.
+- Rule surface: The canonical skill and delegated prompt should require `Brainstormer` to commit the design artifact before reporting done or handing off.
+
+## Planner hands off an uncommitted plan artifact
+
+- Starting condition: `Planner` writes or updates the implementation plan, but the artifact exists only as uncommitted workspace state when handoff to `Executor` is attempted.
+- Required halt or reroute behavior: Treat the handoff as incomplete and loop it back to `Planner` until the implementation plan is committed, or halt explicitly with a blocker if the run cannot proceed safely.
+- Rule surface: The canonical skill and delegated prompt should require `Planner` to commit the implementation plan before reporting done or handing off.
+
+## Executor hands off uncommitted implementation artifacts
+
+- Starting condition: `Executor` completes implementation or test changes, but those artifacts exist only as uncommitted workspace state when handoff to `Reviewer` is attempted.
+- Required halt or reroute behavior: Treat the handoff as incomplete and loop it back to `Executor` until the implementation and test changes are committed, or halt explicitly with a blocker if the run cannot proceed safely.
+- Rule surface: The canonical skill and delegated prompt should require `Executor` to commit the completed implementation and test state before reporting done or handing off.
+
+## Non-artifact-producing stages are not forced into meaningless commits
+
+- Starting condition: `Reviewer` or `Finisher` completes stage responsibilities without materially changing durable artifacts.
+- Required halt or reroute behavior: Do not require a commit solely to satisfy the handoff-commit rule.
+- Rule surface: The artifact-producing handoff rule should apply to artifact-producing roles and artifact-producing changes, not become a ritual for every stage.
+
 ## Reviewer findings missing loopback classification
 
 - Starting condition: Reviewer findings identify problems but do not classify them as implementation-level, plan-level, or spec-level loopbacks.

--- a/docs/superpowers/specs/2026-04-23-30-artifact-producing-teammates-should-commit-before-handoff-design.md
+++ b/docs/superpowers/specs/2026-04-23-30-artifact-producing-teammates-should-commit-before-handoff-design.md
@@ -1,0 +1,143 @@
+# Design: Artifact-producing teammates should commit before handoff [#30](https://github.com/patinaproject/superteam/issues/30)
+
+## Summary
+
+Require artifact-producing teammates to commit their owned changes before they can report done or hand off to the next teammate. The workflow should treat committed branch state as the authority for downstream work, not uncommitted workspace state. This keeps design, planning, and execution handoffs anchored to inspectable commits and makes reported SHAs refer to real teammate handoff points instead of speculative local state.
+
+The change stays narrow. It adds an explicit commit-before-handoff rule for `Brainstormer`, `Planner`, and `Executor`, reflects that rule in teammate prompts and done-report contracts, and adds pressure-test coverage for incomplete handoffs that depend on uncommitted artifact changes. It does not require `Reviewer` or `Finisher` to manufacture commits when they did not materially change durable artifacts.
+
+## Goals
+
+- Require each artifact-producing teammate to commit their owned changes before handoff
+- Make handoffs depend on committed branch state rather than dirty workspace state
+- Ensure teammate done reports reference real handoff commits for artifact-producing work
+- Treat uncommitted artifact state as an incomplete handoff unless the run halts explicitly with a blocker
+- Preserve flexibility for non-artifact-producing stages so they are not forced into meaningless commits
+- Keep the canonical skill, delegated prompts, and pressure tests aligned on the same handoff rule
+
+## Non-Goals
+
+- Requiring `Reviewer` or `Finisher` to create commits when they did not materially change durable repo artifacts
+- Changing PR publication, mergeability, or external feedback ownership
+- Redesigning the canonical teammate roster or stage ordering
+- Introducing a new artifact registry or generic state-tracking system
+- Expanding beyond the workflow-contract surfaces that directly define or validate handoff behavior
+
+## Approaches Considered
+
+### Recommended: role-specific commit-before-handoff requirements
+
+Add explicit commit-before-handoff language to the contracts and done reports for `Brainstormer`, `Planner`, and `Executor`, then add a workflow-level rule that any handoff depending on uncommitted durable artifact changes is incomplete. This is the clearest way to satisfy the issue because it names the affected roles directly and keeps the enforcement easy to audit.
+
+### Alternative: one global handoff rule with role exceptions
+
+Add a single top-level rule saying any teammate who materially updates durable artifacts must commit before handoff, then explain that some roles usually do not need to do so. This reduces repetition, but it also leaves more room for interpretation in the exact places where the issue wants clarity.
+
+### Alternative: enforce only through done-report fields
+
+Require handoff commit SHAs in the done reports but keep the prose requirements light. This is too implicit. The next teammate should not have to infer the workflow rule from schema alone.
+
+## Design
+
+### Artifact-producing teammates are not done until their changes are committed
+
+`Brainstormer`, `Planner`, and `Executor` each produce or materially update durable repo artifacts that downstream teammates depend on. For those roles, the workflow should define completion and handoff in branch-state terms: the teammate is not done until their owned changes are committed on the current branch.
+
+This means:
+
+- a design doc written by `Brainstormer` is not handoff-ready while it exists only as uncommitted local changes
+- an implementation plan written by `Planner` is not handoff-ready while it exists only as uncommitted local changes
+- implementation and test changes produced by `Executor` are not handoff-ready while they remain only in the working tree
+
+The rule should be phrased as a completion requirement, not a loose best practice. A teammate who has written the right files but has not committed them has not yet satisfied the handoff contract.
+
+### The workflow should trust branch state, not workspace state
+
+The workflow already depends on stable artifacts, SHAs, and publish-state follow-through. This issue should make explicit that downstream teammates rely on committed branch state instead of inferring intent from a dirty workspace.
+
+At the workflow level, the canonical contract should state that handoffs depending on uncommitted durable artifact changes are incomplete unless the run halts explicitly with a blocker. That gives `Team Lead` and downstream teammates a clear rule for rejecting ambiguous handoffs:
+
+- if the owned artifact changes are committed, handoff may proceed
+- if the owned artifact changes are not committed, the run loops back to the owning teammate
+- if the run cannot safely proceed, it halts explicitly rather than pretending the handoff succeeded
+
+This keeps handoffs auditable and makes each reported SHA point to a real inspectable state.
+
+### Done reports should include the handoff commit for artifact-producing roles
+
+The role-specific done-report contracts for `Brainstormer`, `Planner`, and `Executor` should add a required handoff commit field so downstream teammates can anchor on a specific commit rather than a generic branch tip reference.
+
+The field should be role-specific but semantically consistent:
+
+- `Brainstormer`: report the commit containing the design artifact used for approval and planning
+- `Planner`: report the commit containing the approved implementation plan used for execution
+- `Executor`: report the commit containing the completed task batch and verification-backed implementation state
+
+The requirement is not only about recording a SHA after the fact. The presence of the handoff commit in the done report confirms the ownership rule: artifact-producing work must exist in committed branch history before the teammate can finish.
+
+### Delegated teammate prompts must mirror the same rule
+
+The repository-owned teammate prompt template should repeat the commit-before-handoff requirement anywhere it instructs `Brainstormer`, `Planner`, or `Executor` on their done contracts. Otherwise the canonical skill and delegated prompts can drift apart and recreate the same ambiguity in practice.
+
+The delegated prompt guidance should make two things explicit:
+
+- artifact-producing teammates must commit their owned changes before reporting done or handing off
+- done reports for those roles must include the handoff commit SHA alongside the existing artifact path, task IDs, evidence, or verification fields already required
+
+This keeps subagent execution aligned with the same branch-state authority as the foreground workflow.
+
+### Non-artifact-producing stages should not be forced into meaningless commits
+
+`Reviewer` and `Finisher` should not be required to create commits merely because they participate in the workflow. Their work is often evaluative, routing-oriented, or publish-oriented rather than artifact-producing.
+
+The design should therefore distinguish between:
+
+- artifact-producing roles, which must commit before handoff whenever they materially update owned durable artifacts
+- non-artifact-producing roles, which are not required to create a commit unless their own remediation actually changes durable artifacts they own or are responsible for updating in that moment
+
+This preserves the issue intent without turning the workflow into a commit ritual divorced from real artifact changes.
+
+### Pressure tests should cover incomplete handoffs and the non-artifact exception
+
+The pressure-test doc should add scenarios that exercise the contract directly:
+
+- `Brainstormer` attempts to hand off an uncommitted design doc
+- `Planner` attempts to hand off an uncommitted plan doc
+- `Executor` attempts to hand off uncommitted implementation or test changes
+- a handoff depending on those uncommitted changes is treated as incomplete and loops back or halts explicitly
+- `Reviewer` or `Finisher` is not forced to create a meaningless commit when no durable artifact changes were made
+
+These scenarios should be framed as workflow-contract checks, not tool-specific git tricks. The point is to validate the handoff authority model: branch state is authoritative for artifact-producing handoffs.
+
+### Scope of repository changes
+
+Keep the implementation narrow and update only the surfaces that directly govern or validate this behavior:
+
+- `skills/superteam/SKILL.md`
+  - add the workflow-level incomplete-handoff rule for uncommitted artifact changes
+  - add explicit commit-before-handoff requirements for `Brainstormer`, `Planner`, and `Executor`
+  - add role-appropriate handoff commit reporting to those done contracts
+- `skills/superteam/agent-spawn-template.md`
+  - mirror the same artifact-producing commit-before-handoff requirements
+  - add the corresponding handoff commit fields to delegated done-report contracts
+- `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+  - add scenarios that fail uncommitted artifact-producing handoffs
+  - add a scenario confirming non-artifact-producing stages are not forced into meaningless commits
+
+Inspect other docs only if they materially contradict the intended handoff rule. Avoid broad cleanup outside the directly relevant workflow-contract surfaces.
+
+## Testing And Verification
+
+- verify the canonical `superteam` contract says handoffs depending on uncommitted durable artifact changes are incomplete unless the run halts explicitly with a blocker
+- verify `Brainstormer`, `Planner`, and `Executor` each require a commit before reporting done or handing off
+- verify the role-specific done-report contracts for those teammates require a handoff commit SHA
+- verify the delegated prompt template mirrors the same commit-before-handoff rule and handoff commit fields
+- verify the pressure-test doc covers uncommitted handoff attempts for design, plan, and implementation artifacts
+- verify the pressure-test doc covers the non-artifact-producing exception for `Reviewer` and `Finisher`
+
+## Acceptance Criteria
+
+- AC-30-1: Given `Brainstormer`, `Planner`, or `Executor` materially updates their owned durable artifacts, when that teammate reports done or hands off, then the owned changes already exist in a commit on the current branch
+- AC-30-2: Given a downstream handoff depends on uncommitted durable artifact changes from an artifact-producing teammate, when the workflow evaluates that handoff, then it treats the handoff as incomplete unless the run halts explicitly with a blocker
+- AC-30-3: Given the workflow defines teammate prompts and done-report contracts for artifact-producing roles, when those roles are described, then the commit-before-handoff expectation and handoff commit reporting are explicit
+- AC-30-4: Given `Reviewer` or `Finisher` did not materially change durable artifacts, when they complete their stage responsibilities, then the workflow does not require a meaningless commit solely to satisfy the handoff rule

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -125,6 +125,12 @@ Before any teammate touches governed files, discover the canonical repository ru
 
 If canonical guidance cannot be found, halt and surface the blocker instead of guessing.
 
+## Artifact handoff authority
+
+Handoffs that depend on uncommitted durable artifact changes are incomplete unless the run halts explicitly with a blocker.
+
+For artifact-producing handoffs, the workflow should trust committed branch state rather than dirty workspace state. Downstream teammates should be able to rely on inspectable commits instead of inferring intent from uncommitted local changes.
+
 ## Gate 1: Brainstormer approval
 
 Advancement from `Brainstormer` to `Planner` requires explicit approval of the design artifact. Silence, ambiguity, or partial replies are non-approval.
@@ -160,24 +166,29 @@ If revisions are requested after an approval pass, re-fire approval with delta-o
 ### Brainstormer
 
 - Own the design doc in `docs/superpowers/specs/`.
+- Commit the design artifact change before reporting done or handing off to `Planner`.
 - Return the exact design doc path.
 - Return the ordered active AC list.
 - Report the concise intent summary and the full requirement set used for approval.
 - Always report `concerns[]` when requesting approval, including an explicit empty result when no approval-relevant concerns remain under the contract.
 - Render the operator-facing no-concerns line exactly as `Remaining concerns: None`.
 - Surface any remaining approval-relevant concerns when requesting approval.
+- Include the handoff commit SHA for the committed design artifact in the done report.
 - Recommend `superpowers:brainstorming`.
 
 ### Planner
 
 - Consume the approved design doc, not ad hoc chat summaries.
+- Commit the implementation plan change before reporting done or handing off to `Executor`.
 - Produce the implementation plan or halt with a blocker.
+- Include the handoff commit SHA for the committed implementation plan in the done report.
 - Recommend `superpowers:writing-plans`.
 
 ### Executor
 
 - Drive implementation from acceptance criteria and approved plan tasks using ATDD, not ad hoc coding first.
 - Implement only the assigned tasks from the approved plan.
+- Commit the completed implementation and test changes before reporting done or handing off to `Reviewer`.
 - Report completion against explicit task IDs.
 - Include concrete completion evidence, SHAs, and verification evidence before claiming completion.
 - `Executor` completion is not workflow completion. After local implementation work is complete, the run must either continue into `Reviewer` and then `Finisher`, or halt explicitly as `superteam halted at <teammate or gate>: <reason>`.
@@ -238,6 +249,33 @@ If revisions are requested after an approval pass, re-fire approval with delta-o
 When `Team Lead` delegates work, the prompt must explicitly recommend the expected `superpowers` skills for that role when relevant. If an expected skill is unavailable in the current environment, say so explicitly in the delegated prompt so both the operator and teammate can see the gap.
 
 Do not silently omit expected skill guidance.
+
+## Done-report contracts
+
+Artifact-producing teammate done reports must anchor on committed handoff state rather than uncommitted workspace state.
+
+### Brainstormer done report
+
+- `design_doc_path`: exact path to the written design doc
+- `ac_ids[]`: ordered list of active AC IDs
+- `intent_summary`: concise summary of what the artifact changes or decides
+- `requirements[]`: full requirement set currently under review
+- `concerns[]`: remaining approval-relevant concerns that could materially affect approval, or an explicit empty result when none exist
+- `handoff_commit_sha`: commit containing the design artifact used for approval and planning
+
+### Planner done report
+
+- `plan_path`: exact path to the written implementation plan
+- `workstreams[]`: short summary of planned batches or workstreams
+- `blockers[]`: any blockers preventing execution, or an explicit empty result when none exist
+- `handoff_commit_sha`: commit containing the approved implementation plan used for execution
+
+### Executor done report
+
+- `completed_task_ids[]`: explicit task IDs completed in this batch
+- `completion_evidence[]`: concrete evidence per completed task
+- `head_sha`: current HEAD SHA for the committed implementation and test state being handed to `Reviewer`
+- `verification[]`: verification commands and outcomes
 
 ## Review and loopback routing
 

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -63,6 +63,8 @@ Recommend `superpowers:brainstorming`.
 
 Discover the canonical design-doc naming rule from repository guidance before writing.
 Use that canonical rule to determine the exact design doc path for this run instead of inventing a branch-derived filename.
+Commit the design artifact change before reporting done or handing off to `Planner`.
+Do not report done while the required design artifact exists only as uncommitted workspace state.
 
 Done-report contract:
 - `design_doc_path`: exact path to the written design doc
@@ -71,6 +73,7 @@ Done-report contract:
 - `requirements[]`: full requirement set currently under review
 - `concerns[]`: remaining approval-relevant concerns that could materially affect approval, or an explicit empty result when none exist
 Operator-facing approval packets must render the no-concerns case exactly as `Remaining concerns: None`.
+- `handoff_commit_sha`: commit containing the design artifact used for approval and planning
 ```
 
 ### Planner
@@ -82,6 +85,8 @@ Recommend `superpowers:writing-plans`.
 
 Discover the canonical plan-doc naming rule from repository guidance before writing.
 Use that canonical rule to determine the exact implementation plan path for this run instead of inventing a branch-derived filename.
+Commit the implementation plan change before reporting done or handing off to `Executor`.
+Do not report done while the required plan artifact exists only as uncommitted workspace state.
 
 Do not write AC-to-file:line mapping tables in the plan.
 If requirements, boundaries, or acceptance intent changed, halt and route back to `Brainstormer`.
@@ -89,6 +94,7 @@ Done-report contract:
 - `plan_path`: exact path to the written implementation plan
 - `workstreams[]`: short summary of planned batches or workstreams
 - `blockers[]`: any blockers preventing execution, or an explicit empty result when none exist
+- `handoff_commit_sha`: commit containing the approved implementation plan used for execution
 ```
 
 ### Executor
@@ -102,12 +108,14 @@ Recommend `superpowers:verification-before-completion` before claiming completio
 If any task touches `skills/**/*.md`, also recommend `superpowers:writing-skills`.
 
 Implement only the assigned task batch.
+Commit the completed implementation and test changes before reporting done or handing off to `Reviewer`.
+Do not report done while the required implementation state exists only as uncommitted workspace state.
 Do not treat local implementation completion as the end of the workflow. Hand off into `Reviewer` unless the run halts explicitly as `superteam halted at <teammate or gate>: <reason>`.
 Do not push, rebase, or open a PR.
 Done-report contract:
 - `completed_task_ids[]`: explicit task IDs completed in this batch
 - `completion_evidence[]`: concrete evidence per completed task
-- `head_sha`: current HEAD SHA
+- `head_sha`: current HEAD SHA for the committed implementation and test state being handed to `Reviewer`
 - `verification[]`: verification commands and outcomes
 ```
 


### PR DESCRIPTION
# Pull Request

## Summary

- require `Brainstormer`, `Planner`, and `Executor` to commit owned artifact changes before handoff
- add committed-state done-report fields so artifact-producing handoffs anchor on real branch history
- expand pressure tests to fail uncommitted artifact handoffs while exempting non-artifact-producing stages from meaningless commits

## Linked issue

Closes #30

## Acceptance criteria

### AC-30-1
Artifact-producing teammates must commit owned durable artifacts before reporting done or handing off.

- [x] `sed -n '100,270p' skills/superteam/SKILL.md`
- [x] `sed -n '45,135p' skills/superteam/agent-spawn-template.md`

### AC-30-2
Uncommitted artifact-dependent handoffs are treated as incomplete unless the run halts explicitly with a blocker.

- [x] `sed -n '100,270p' skills/superteam/SKILL.md`
- [x] `sed -n '65,135p' docs/superpowers/pressure-tests/superteam-orchestration-contract.md`

### AC-30-3
Artifact-producing teammate prompts and done-report contracts explicitly require handoff commit reporting.

- [x] `rg -n "handoff_commit_sha|current HEAD SHA for the committed implementation and test state" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md`

### AC-30-4
Non-artifact-producing stages are not forced into meaningless commits solely to satisfy the handoff rule.

- [x] `rg -n "Non-artifact-producing stages are not forced into meaningless commits" docs/superpowers/pressure-tests/superteam-orchestration-contract.md`

## Validation

- `git diff HEAD~1 -- skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
- `git show --stat --oneline --decorate=short HEAD`

## Docs updated

- [x] Updated in this PR
