### PR TITLE
feat!: #32 declare v1.0.0 stable api

### DIFF
--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -21,3 +21,4 @@ jobs:
           globs: |
             **/*.md
             #node_modules
+            #CHANGELOG.md


### PR DESCRIPTION
## Summary

- Fix lint-md CI to exclude `CHANGELOG.md` (matches local `pnpm lint:md` glob; release-please-generated CHANGELOGs intentionally violate MD012, as documented in `RELEASING.md`).
- Carry the `feat!:` + `BREAKING CHANGE:` markers so release-please bumps 0.2.0 → 1.0.0 on the next standing release PR.

## Linked issue

Closes #32

The bootstrap PR (#33) merged without a breaking-change marker, so release-please cut [v0.2.0](https://github.com/patinaproject/superteam/releases/tag/v0.2.0) instead of v1.0.0. This PR delivers the marker (folded onto a real fix) so the original "release v1" half of issue #32 completes on the next release PR.

## Acceptance criteria

### AC-32-3

`v1.0.0` is tagged and a GitHub Release is published.

- [ ] Manual test: after this PR merges, observe the next `Release` workflow run; confirm release-please opens a `chore: release 1.0.0` PR with `package.json`, both plugin manifests, and `CHANGELOG.md` bumped to `1.0.0`. Merge that PR and verify the `v1.0.0` tag exists, the GitHub Release page shows the auto-generated notes (including the "⚠ BREAKING CHANGES" entry from this commit's footer), and the `notify-patinaproject-skills` job dispatched `plugin-release-bump.yml` on `patinaproject/skills`.

### AC-32-4

Once tagged, link back to [patinaproject/skills#12](https://github.com/patinaproject/skills/issues/12) so the marketplace can pin this version.

- [ ] Manual test: after `v1.0.0` exists, confirm the marketplace dispatch landed (or comment manually on patinaproject/skills#12 with the tag).

## Validation

Local checks on this branch:

- `pnpm exec markdownlint-cli2 "**/*.md" "#node_modules" "#CHANGELOG.md"` → 0 errors.
- `pnpm exec markdownlint-cli2 "**/*.md" "#node_modules"` → 1 error (`CHANGELOG.md:5 MD012`), which is exactly what the workflow change suppresses.
- `lint-pr.yml` `mark-breaking-change` job will pass: title has `!`, body has `BREAKING CHANGE:` footer below.

## Docs updated

- [x] Not needed — `RELEASING.md` already documents the CHANGELOG-MD012 rationale; this PR aligns CI with that documented decision.

BREAKING CHANGE: superteam transitions from pre-stable (0.x) to stable (1.x). Future major bumps will follow strict semver against the documented public skill contract; consumers can pin v1.x.x with confidence.
