### PR TITLE
docs: #41 make loopback combined-commit precedence explicit

### DIFF
--- a/docs/superpowers/plans/2026-04-26-41-superteam-define-loopback-trailers-behavior-when-one-commit-carries-both-originating-and-resolved-trailers-plan.md
+++ b/docs/superpowers/plans/2026-04-26-41-superteam-define-loopback-trailers-behavior-when-one-commit-carries-both-originating-and-resolved-trailers-plan.md
@@ -1,0 +1,179 @@
+# Plan: Superteam: define loopback-trailers behavior when one commit carries both originating and resolved trailers [#41](https://github.com/patinaproject/superteam/issues/41)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the loopback-trailers precedence rule explicit for combined commits (same-class evidence and different-class follow-on), document the corollary that follow-on loopbacks require a separate later commit, and add pressure-test coverage for the different-class follow-on case.
+
+**Architecture:** Documentation-only change across three Markdown surfaces. The recovery algorithm stays pure `git log` with no new tooling, sidecar files, or parsers; only wording is expanded.
+
+**Tech Stack:** Markdown (`markdownlint-cli2` via `pnpm lint:md`); Husky pre-commit hooks.
+
+---
+
+## Context
+
+The approved design at `docs/superpowers/specs/2026-04-26-41-superteam-define-loopback-trailers-behavior-when-one-commit-carries-both-originating-and-resolved-trailers-design.md` is authoritative. This plan turns that design into ordered, reviewable edits across `skills/superteam/loopback-trailers.md`, `skills/superteam/pre-flight.md`, and `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`.
+
+## File Structure
+
+Files modified by this plan:
+
+- `skills/superteam/loopback-trailers.md` — expand precedence paragraph, add corollary, add different-class worked example, restate recovery step 4 (no algorithmic change).
+- `skills/superteam/pre-flight.md` — confirm the `## Loopback-class recovery` reference still resolves; tweak wording only if reference fidelity demands it (no behavioral change).
+- `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` — extend or sibling the existing `Resolving loopback commit uses unambiguous trailer semantics` scenario to cover the different-class follow-on case.
+
+No other files are in scope.
+
+## Workstreams
+
+### Workstream A — Loopback-trailers skill (T1, T2, T3, T4)
+
+Edits to `skills/superteam/loopback-trailers.md` cluster together because they all turn the implicit precedence rule into an explicit, reader-self-sufficient one. Group them in a single commit so reviewers see the new wording alongside the new worked example and the restated step 4.
+
+#### T1 — Expand the precedence paragraph
+
+**File:**
+
+- Modify: `skills/superteam/loopback-trailers.md` (current precedence paragraph at lines 22-25, in `## When to emit`)
+
+Replace the existing two-sentence precedence paragraph with an expanded version that:
+
+1. States the unified rule explicitly: on any single commit, `Loopback: resolved` wins, and every other `Loopback:` trailer on the same commit — regardless of class, and regardless of whether it matches the class being resolved — is treated as evidence of what was resolved and MUST NOT open or reopen any loopback.
+2. Names the two subcases the rule covers:
+   - **Same-class evidence**: e.g. `Loopback: plan-level` + `Loopback: resolved` on one commit closes a plan-level loopback; the class trailer documents what was resolved.
+   - **Different-class follow-on**: e.g. `Loopback: plan-level` + `Loopback: implementation-level` + `Loopback: resolved` on one commit closes the active plan-level loopback; the `implementation-level` trailer is evidence only and does NOT open a new implementation-level loopback.
+
+The wording must let a reader correctly classify a class-A + class-B + `resolved` commit without consulting any other file (AC-41-1).
+
+#### T2 — Add the corollary
+
+**File:**
+
+- Modify: `skills/superteam/loopback-trailers.md` (immediately after the expanded precedence paragraph)
+
+Add a short corollary stating: opening a follow-on loopback after resolving one requires a separate later commit. Concretely, when an author wants to resolve loopback A and immediately open loopback B, the workflow MUST produce two commits — the resolving commit carrying `Loopback: resolved` (optionally with class-A evidence), then a later commit carrying `Loopback: <class-B>` as the originating trailer for B.
+
+Frame the corollary as a direct consequence of the precedence rule, not a separate constraint, matching the design doc's framing.
+
+#### T3 — Add a different-class follow-on worked example
+
+**File:**
+
+- Modify: `skills/superteam/loopback-trailers.md` (`## Worked examples` section, after the existing "Resolution commit with optional class evidence" example at lines 52-59)
+
+Add a new worked example under `## Worked examples` titled to reflect the different-class follow-on case. The example MUST show two separate commits:
+
+1. The resolving commit carrying `Loopback: plan-level` + `Loopback: resolved` (resolves the active plan-level loopback; the class trailer is evidence only).
+2. A later commit carrying `Loopback: implementation-level` as the originating trailer that actually opens the follow-on implementation-level loopback.
+
+Both commit blocks must use the same `text` fenced format as the existing examples and use realistic conventional-commit subjects with an issue tag (e.g. `#41`). The example MUST make clear that combining the two intents into a single commit would be silently swallowed by the precedence rule (AC-41-2).
+
+#### T4 — Restate recovery step 4
+
+**File:**
+
+- Modify: `skills/superteam/loopback-trailers.md` (`## Recovery algorithm`, step 4 at line 74-75)
+
+Reword step 4 so it explicitly covers the different-class follow-on case rather than appearing to apply only to same-class evidence. The algorithmic behavior is unchanged: for any commit containing `Loopback: resolved`, `resolved` wins for that commit regardless of how many other `Loopback:` trailers (of any class) are present on the same commit; no other trailer on that commit opens or reopens a loopback.
+
+Constraints:
+
+- Do NOT add a new step.
+- Do NOT introduce a sidecar file, parser, or any tooling beyond `git log`'s built-in trailer extraction.
+- Keep the surrounding `git log --pretty=format:...` invocation in step 3 unchanged.
+- Preserve the closing line "The algorithm is intentionally pure `git log` ..." after the algorithm block.
+
+This satisfies AC-41-3's first checkbox.
+
+### Workstream B — Pre-flight cross-reference fidelity (T5)
+
+#### T5 — Confirm the pre-flight reference still resolves
+
+**File:**
+
+- Inspect (and modify only if needed): `skills/superteam/pre-flight.md` (`## Loopback-class recovery` at lines 67-69)
+
+After the Workstream A edits land in the working tree, re-read `skills/superteam/pre-flight.md`'s `## Loopback-class recovery` section and confirm the reference `loopback-trailers.md` `## Recovery algorithm` still resolves to a real heading in the updated `skills/superteam/loopback-trailers.md`. If T4's rewording leaves the `## Recovery algorithm` heading unchanged (expected outcome), no edit is required and this task is a no-op confirmation. If the heading text has shifted, update the reference in `pre-flight.md` to match exactly.
+
+This satisfies AC-41-3's second checkbox. Per the canonical pressure-test scenario "Non-artifact-producing stages are not forced into meaningless commits", do not create a commit if no edits are needed; record the no-op outcome in the verification notes instead.
+
+### Workstream C — Pressure-test coverage (T6)
+
+#### T6 — Cover the different-class follow-on in the pressure-test contract
+
+**File:**
+
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` (existing scenario `## Resolving loopback commit uses unambiguous trailer semantics` at lines 355-359)
+
+The implementer chooses one of two equally valid shapes (writing-clarity call):
+
+- **Option A — extend in place**: expand the existing `Resolving loopback commit uses unambiguous trailer semantics` scenario so its starting condition, required behavior, and rule-surface bullets cover both the same-class evidence case and the different-class follow-on case.
+- **Option B — add a sibling scenario**: keep the existing scenario as-is and add a new sibling scenario immediately after it (e.g. titled `## Combined-commit follow-on loopback requires a separate commit`).
+
+Whichever shape is chosen, the scenario MUST exercise all three of the following in one place:
+
+1. A combined commit carrying `Loopback: <class-A>` + `Loopback: <class-B>` + `Loopback: resolved` resolves the active loopback (no class-B loopback is opened from the same commit).
+2. Recovery treats the combined commit as resolved, with no active loopback assuming no later originating trailers exist.
+3. To open a follow-on loopback of class-B, a separate later commit carrying `Loopback: <class-B>` as the originating trailer is required.
+
+Use the existing scenario blocks' three-bullet shape (`Starting condition`, `Required halt or reroute behavior`, `Rule surface`) so it matches the file's prevailing voice. This satisfies AC-41-4.
+
+### Workstream D — Verification and commit (T7, T8)
+
+#### T7 — Run repo lint
+
+**File:** N/A (verification only).
+
+Run `pnpm lint:md` from the worktree root. Expected: clean exit. If markdownlint flags any rule (e.g. line length, fenced block language, heading spacing) on the touched files, fix in place and re-run until clean. Do not bypass the husky pre-commit hook.
+
+#### T8 — Manual recovery walkthrough on the updated skill
+
+**File:** N/A (verification only — reading the updated skill).
+
+Fabricate a combined-commit scenario and confirm the updated `skills/superteam/loopback-trailers.md` answers it correctly without consulting any other file. Use this exact fabricated case:
+
+- The branch range contains, oldest to newest:
+  1. A commit `feat: #41 begin work` with no `Loopback:` trailer.
+  2. A commit `docs: #41 spin out plan-level loopback` carrying `Loopback: plan-level`.
+  3. A commit `docs: #41 close plan-level loopback and note follow-on`carrying both `Loopback: plan-level` and `Loopback: implementation-level` and `Loopback: resolved`.
+- Apply the recovery algorithm in `## Recovery algorithm` to this fabricated range.
+
+Expected outcome from a fresh reader applying only the updated skill text:
+
+- Step 4 treats commit 3 as `resolved`. The `implementation-level` trailer on commit 3 is evidence only and does NOT open an implementation-level loopback.
+- Step 5 sets R to the index of commit 3.
+- Steps 6-7 find no commits with index > R, so no active loopback is in flight.
+- A reader who wants to open a follow-on implementation-level loopback after this state must add a separate later commit carrying `Loopback: implementation-level`, per the corollary.
+
+Record this walkthrough's pass/fail outcome in the Planner done report. If any step is ambiguous when read against the updated text alone, loop back to the relevant Workstream A task before commit.
+
+#### T9 — Commit the documentation changes
+
+**File:** N/A (git commit step).
+
+Stage the touched files explicitly (avoid `git add -A` per AGENTS.md guidance):
+
+```bash
+git add skills/superteam/loopback-trailers.md \
+        docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+Stage `skills/superteam/pre-flight.md` only if T5 produced an edit. Do not stage the plan artifact in this commit (the plan is committed separately as the Planner handoff artifact).
+
+Commit with conventional-commit format (no scope, ≤72 chars, required `#41` tag), for example:
+
+```bash
+git commit -m "docs: #41 make loopback combined-commit precedence explicit"
+```
+
+The husky `commit-msg` hook validates the message; the `pre-commit` hook runs `lint-staged` (markdownlint). If either fails, fix the issue and create a NEW commit (do not amend, do not use `--no-verify`).
+
+## Verification
+
+- **Lint**: `pnpm lint:md` exits clean against the worktree after the edits land. Husky's `pre-commit` runs the same lint on staged files.
+- **Manual recovery walkthrough**: T8 above. A reader applying only the updated `skills/superteam/loopback-trailers.md` to the fabricated combined-commit scenario must arrive at "no active loopback; opening a follow-on requires a separate later commit." Document the walkthrough outcome explicitly.
+- **AC self-check** (for the Reviewer's later pressure-test pass, not for the Planner): AC-41-1 and AC-41-2 verify by reading the updated worked-examples and precedence section; AC-41-3 verifies that recovery step 4 is reworded but the algorithm shape is unchanged and the `pre-flight.md` reference still resolves; AC-41-4 verifies the pressure-test scenario contains the three required assertions.
+
+## Blockers
+
+None.

--- a/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+++ b/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
@@ -354,9 +354,9 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 
 ## Resolving loopback commit uses unambiguous trailer semantics
 
-- Starting condition: A terminating loopback commit completes work that originated from `Loopback: plan-level`.
-- Required halt or reroute behavior: The resolving commit must include `Loopback: resolved`. A matching class trailer may appear as evidence on the same commit, but `resolved` wins and the class trailer must not reopen the loopback. The contract must not require both class and resolved trailers in a way that conflicts with the recovery algorithm.
-- Rule surface: `SKILL.md` and `loopback-trailers.md` should agree on resolving-commit trailer semantics.
+- Starting condition: A terminating loopback commit completes work that originated from `Loopback: plan-level`. Two shapes are exercised: (a) a same-class resolving commit carrying `Loopback: plan-level` + `Loopback: resolved`, and (b) a different-class follow-on resolving commit carrying `Loopback: plan-level` + `Loopback: implementation-level` + `Loopback: resolved`.
+- Required halt or reroute behavior: In both shapes, the resolving commit must include `Loopback: resolved`, and `resolved` wins for that commit. Any other `Loopback:` trailer on the same commit — matching the resolved class or not — is evidence only and must not open or reopen a loopback. For shape (b), recovery must report the active loopback as resolved (no class-B loopback opened from the same commit, assuming no later originating trailers); to actually open a follow-on implementation-level loopback, a separate later commit carrying `Loopback: implementation-level` as the originating trailer is required. The contract must not require both class and resolved trailers in a way that conflicts with the recovery algorithm.
+- Rule surface: `SKILL.md` and `loopback-trailers.md` should agree on resolving-commit trailer semantics, including that follow-on loopbacks of any class require a separate later originating commit.
 
 ## Missing runtime follow-up support does not permit Finisher to stop early
 

--- a/docs/superpowers/specs/2026-04-26-41-superteam-define-loopback-trailers-behavior-when-one-commit-carries-both-originating-and-resolved-trailers-design.md
+++ b/docs/superpowers/specs/2026-04-26-41-superteam-define-loopback-trailers-behavior-when-one-commit-carries-both-originating-and-resolved-trailers-design.md
@@ -1,0 +1,81 @@
+# Design: Superteam: define loopback-trailers behavior when one commit carries both originating and resolved trailers [#41](https://github.com/patinaproject/superteam/issues/41)
+
+## Context
+
+The loopback-trailers convention from #39 / #40 makes the active loopback class recoverable from `git log` across sessions using `Loopback: spec-level | plan-level | implementation-level | resolved` trailers. The recovery algorithm in `skills/superteam/loopback-trailers.md` already includes a precedence rule for the combined-commit case where the class trailer matches the loopback being resolved (lines 22-25 and recovery step 4):
+
+> If one commit contains both a loopback class trailer and `Loopback: resolved`, `resolved` wins for that commit. The class trailer is evidence of what was resolved and MUST NOT reopen the loopback.
+
+The existing pressure test `Resolving loopback commit uses unambiguous trailer semantics` exercises that case as same-class evidence.
+
+The gap, as raised explicitly in the issue body, is the **different-class follow-on** scenario: a single commit that resolves a prior plan-level loopback while simultaneously trying to open a new implementation-level one as a follow-on. The current wording answers this case only by implication (`resolved` wins, the class trailer never reopens — therefore the new follow-on cannot be opened on the same commit). That implicit answer is correct but not explicit, and it is not exercised by any pressure-test walkthrough. Two `/superteam` invocations on different sessions could plausibly read the implicit rule differently.
+
+The intended outcome is a one-pass documentation change that (a) makes the precedence rule explicit for both same-class evidence and different-class follow-on cases, (b) states the corollary that opening a follow-on loopback requires a separate later commit, and (c) closes the pressure-test coverage gap. No new tooling, no sidecar files, and no change to the pure-`git log` recovery algorithm.
+
+## Decision
+
+Adopt one explicit precedence rule that covers every combined-commit case:
+
+**On any single commit, `Loopback: resolved` wins. Every other `Loopback:` trailer on the same commit — regardless of class, and regardless of whether it matches the class being resolved — is treated as evidence of what was resolved and MUST NOT open or reopen any loopback.**
+
+This rule applies uniformly to both subcases the issue raised:
+
+1. **Same-class evidence** (already covered): `Loopback: plan-level` + `Loopback: resolved` on one commit closes a plan-level loopback. The class trailer documents which class was resolved.
+2. **Different-class follow-on** (newly explicit): `Loopback: plan-level` + `Loopback: implementation-level` + `Loopback: resolved` on one commit closes the active plan-level loopback. The `implementation-level` trailer is treated as evidence only and does NOT open a new implementation-level loopback. To open a follow-on implementation-level loopback, the originating trailer MUST appear on a separate later commit.
+
+## Corollary
+
+Opening a follow-on loopback after resolving one requires a separate later commit. Concretely: when an author wants to resolve loopback A and immediately open loopback B, the workflow MUST produce two commits — the resolving commit carrying `Loopback: resolved` (optionally with class-A evidence), then a later commit carrying `Loopback: <class-B>` as the originating trailer for B.
+
+This corollary is a direct consequence of the precedence rule, not a separate constraint. It is called out explicitly because authors will otherwise be tempted to combine the two intents into one commit, which the precedence rule silently swallows.
+
+## Surfaces to update
+
+The implementation plan must change exactly the following surfaces. No other files are in scope.
+
+1. **`skills/superteam/loopback-trailers.md`**
+   - Expand the existing precedence paragraph (currently lines 22-25) so the rule explicitly names both subcases (same-class evidence and different-class follow-on) and states that any non-`resolved` `Loopback:` trailer on a resolving commit is evidence only.
+   - Add the corollary: opening a follow-on loopback requires a separate later commit.
+   - Add a worked example for the different-class follow-on case showing the two-commit shape (resolving commit carrying `resolved` + class-A evidence, then a later commit carrying class-B as the originating trailer).
+   - Restate recovery step 4 so it explicitly covers the different-class case rather than only same-class evidence. The algorithm itself does not change — `resolved` still wins for any commit that contains it — but the wording must match the expanded rule above so a reader cannot conclude that a different-class trailer reopens or opens a loopback on a resolving commit.
+
+2. **`skills/superteam/pre-flight.md`**
+   - The `## Loopback-class recovery` section already references the recovery algorithm by location and does not restate it. Confirm the reference still resolves correctly; no behavioral change is required here unless the section heading or anchor in `loopback-trailers.md` changes. If reference fidelity requires a wording tweak, make it; otherwise leave the section alone.
+
+3. **`docs/superpowers/pressure-tests/superteam-orchestration-contract.md`**
+   - Either expand the existing `Resolving loopback commit uses unambiguous trailer semantics` scenario to cover the different-class follow-on case, or add a new sibling scenario (e.g. `Combined-commit follow-on loopback requires a separate commit`). The choice is a writing-clarity call for the implementer; both shapes satisfy the contract. Whichever shape is chosen, the scenario MUST exercise: (i) a commit carrying class-A + class-B + `resolved`, (ii) the assertion that recovery treats this as resolved with no active loopback (assuming no later originating trailers), and (iii) the assertion that to open a follow-on of class-B, a separate later commit carrying `Loopback: <class-B>` is required.
+
+The recovery algorithm remains pure `git log` with no new tooling, no sidecar files, and no parser beyond `git log`'s built-in trailer extraction. The trailer grammar is unchanged.
+
+## Acceptance criteria
+
+### AC-41-1
+
+`skills/superteam/loopback-trailers.md` states the precedence rule explicitly for both same-class evidence and different-class follow-on cases on a single commit, and documents that any non-`resolved` `Loopback:` trailer on a resolving commit is evidence only and never opens or reopens a loopback.
+
+- [ ] Read the updated `skills/superteam/loopback-trailers.md` and confirm a reader could correctly classify a commit carrying class-A + class-B + `resolved` without consulting any other file.
+
+### AC-41-2
+
+`skills/superteam/loopback-trailers.md` states the corollary that opening a follow-on loopback after resolving one requires a separate later commit, and includes a worked example showing the two-commit shape for that case.
+
+- [ ] Read the updated worked-examples section and confirm both the resolving commit and the follow-on originating commit are shown as separate commits, with their trailers exactly as the rule requires.
+
+### AC-41-3
+
+The recovery algorithm in `skills/superteam/loopback-trailers.md` (step 4 in particular) is worded so that the different-class follow-on case is unambiguously covered by the same precedence rule used for same-class evidence, without changing the algorithm's pure-`git log` shape.
+
+- [ ] Confirm step 4 still says `resolved` wins for any commit containing it, and that no new step, sidecar, or parser is introduced.
+- [ ] Confirm `skills/superteam/pre-flight.md`'s `## Loopback-class recovery` reference still resolves to the updated section.
+
+### AC-41-4
+
+`docs/superpowers/pressure-tests/superteam-orchestration-contract.md` exercises the different-class follow-on case — either by expanding the existing `Resolving loopback commit uses unambiguous trailer semantics` scenario or by adding a sibling scenario — covering: combined commit with class-A + class-B + `resolved` resolves the active loopback, no new loopback is opened from the same commit, and a later separate commit carrying `Loopback: <class-B>` is required to open a follow-on.
+
+- [ ] Read the pressure-test surface and confirm the three required assertions above are present in one scenario.
+
+## Open questions / concerns
+
+None. The precedence rule and its corollary are forced by the current `resolved`-wins semantics; this design only makes them explicit and adds the missing pressure-test coverage. No new tooling, sidecar artifacts, or trailer-grammar changes are introduced, and the recovery algorithm remains pure `git log`.
+
+Remaining concerns: None

--- a/skills/superteam/loopback-trailers.md
+++ b/skills/superteam/loopback-trailers.md
@@ -19,9 +19,29 @@ When work originating from a loopback is committed, intermediate commits MUST in
 
 The class trailer is mandatory on every non-resolving loopback-originated commit. The resolving commit may also include the matching class trailer as evidence of what was resolved, but `Loopback: resolved` is the required durable resolution signal.
 
-If one commit contains both a loopback class trailer and `Loopback: resolved`,
-`resolved` wins for that commit. The class trailer is evidence of what was
-resolved and MUST NOT reopen the loopback.
+On any single commit, `Loopback: resolved` wins. Every other `Loopback:`
+trailer on the same commit — regardless of class, and regardless of whether
+it matches the class being resolved — is treated as evidence of what was
+resolved and MUST NOT open or reopen any loopback. This unified rule covers
+both subcases:
+
+- **Same-class evidence**: `Loopback: plan-level` + `Loopback: resolved` on
+  one commit closes the active plan-level loopback. The class trailer
+  documents which class was resolved.
+- **Different-class follow-on**: `Loopback: plan-level` +
+  `Loopback: implementation-level` + `Loopback: resolved` on one commit
+  closes the active plan-level loopback. The `implementation-level` trailer
+  is evidence only and does NOT open a new implementation-level loopback.
+
+**Corollary.** Opening a follow-on loopback after resolving one requires a
+separate later commit. When an author wants to resolve loopback A and
+immediately open loopback B, the workflow MUST produce two commits — the
+resolving commit carrying `Loopback: resolved` (optionally with class-A
+evidence), then a later commit carrying `Loopback: <class-B>` as the
+originating trailer for B. This is a direct consequence of the precedence
+rule above, not a separate constraint; it is called out because authors
+will otherwise be tempted to combine the two intents into one commit, which
+the precedence rule silently swallows.
 
 ## Worked examples
 
@@ -58,6 +78,35 @@ Loopback: plan-level
 Loopback: resolved
 ```
 
+Different-class follow-on (two commits required):
+
+The resolving commit closes the active plan-level loopback. It MAY carry
+the matching class trailer as evidence; if it ALSO carries an
+`implementation-level` trailer, that trailer is evidence only and is
+silently swallowed by the precedence rule — it does NOT open a follow-on
+implementation-level loopback.
+
+```text
+docs: #41 close plan-level loopback and note follow-on
+
+Loopback: plan-level
+Loopback: implementation-level
+Loopback: resolved
+```
+
+To actually open the follow-on implementation-level loopback, a separate
+later commit MUST carry the originating trailer:
+
+```text
+feat: #41 begin implementation-level follow-on
+
+Loopback: implementation-level
+```
+
+Combining both intents into a single commit (as in the first block above
+without the second) leaves no active follow-on — the precedence rule
+silently swallows the originating trailer on the resolving commit.
+
 ## Recovery algorithm
 
 ```text
@@ -71,8 +120,11 @@ Loopback: resolved
    other issues or inherited history from becoming the active loopback class.
 3. Run `git log --pretty=format:'%H%x09%s%x09%(trailers:key=Loopback,valueonly)' <range>`
    over the scoped range.
-4. For any commit with multiple `Loopback:` trailers, treat `resolved` as
-   winning for that commit.
+4. For any commit containing `Loopback: resolved`, `resolved` wins for that
+   commit regardless of how many other `Loopback:` trailers (of any class,
+   matching or not) appear on the same commit. No other trailer on that
+   commit opens or reopens a loopback — this covers both the same-class
+   evidence case and the different-class follow-on case.
 5. Find the most recent commit whose Loopback trailer is `resolved`.
    Call its index R (0 if none).
 6. Among commits with index > R, find the most recent commit whose Loopback


### PR DESCRIPTION
## Summary

- Make the loopback combined-commit precedence rule explicit for both same-class evidence and different-class follow-on cases in `skills/superteam/loopback-trailers.md`, and document the corollary that opening a follow-on loopback requires a separate later commit.
- Add a worked two-commit example for the different-class follow-on shape, and reword recovery step 4 so the precedence rule is unambiguous without changing the pure-`git log` algorithm.
- Extend the pressure-test scenario in `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` to exercise the class-A + class-B + `resolved` case and assert that a follow-on requires a separate later commit.

## Linked issue

- Closes #41

## Acceptance criteria

### AC-41-1

`skills/superteam/loopback-trailers.md` states the precedence rule explicitly for both same-class evidence and different-class follow-on cases on a single commit, and documents that any non-`resolved` `Loopback:` trailer on a resolving commit is evidence only.

- [ ] Inspection evidence — local | docs | @tlmader | 2026-04-26T16:04:33Z
- [ ] Manual test: 1) Open `skills/superteam/loopback-trailers.md`. 2) Locate the precedence paragraph following the trailer-grammar section. 3) Confirm the rule explicitly names both same-class evidence and different-class follow-on cases. 4) Confirm the wording states that any non-`resolved` `Loopback:` trailer on a resolving commit is evidence only and never opens or reopens a loopback. Observed outcome: a reader can correctly classify a commit carrying class-A + class-B + `resolved` from this file alone.

### AC-41-2

`skills/superteam/loopback-trailers.md` states the corollary that opening a follow-on loopback after resolving one requires a separate later commit, and includes a worked example showing the two-commit shape.

- [ ] Inspection evidence — local | docs | @tlmader | 2026-04-26T16:04:33Z
- [ ] Manual test: 1) Open `skills/superteam/loopback-trailers.md`. 2) Find the worked-examples section for the different-class follow-on case. 3) Confirm two distinct commits are shown — a resolving commit carrying `Loopback: resolved` (with class-A evidence) and a later originating commit carrying `Loopback: <class-B>`. 4) Confirm the corollary statement appears alongside the example. Observed outcome: the two-commit shape is unambiguous from the example.

### AC-41-3

The recovery algorithm in `skills/superteam/loopback-trailers.md` (step 4 in particular) is worded so that the different-class follow-on case is unambiguously covered by the same precedence rule used for same-class evidence, without changing the algorithm's pure-`git log` shape.

- [ ] Inspection evidence — local | docs | @tlmader | 2026-04-26T16:04:33Z
- [ ] Manual test: 1) Open `skills/superteam/loopback-trailers.md` and re-read recovery step 4. 2) Confirm step 4 still says `resolved` wins for any commit containing it. 3) Confirm no new step, sidecar artifact, or parser beyond `git log`'s built-in trailer extraction is introduced. 4) Open `skills/superteam/pre-flight.md` and confirm the `## Loopback-class recovery` reference still resolves to the updated section. Observed outcome: algorithm shape is unchanged; cross-reference still resolves.

### AC-41-4

`docs/superpowers/pressure-tests/superteam-orchestration-contract.md` exercises the different-class follow-on case with all three required assertions.

- [ ] Inspection evidence — local | docs | @tlmader | 2026-04-26T16:04:33Z
- [ ] Manual test: 1) Open `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`. 2) Locate the loopback-trailers scenario covering combined commits. 3) Confirm the scenario exercises a commit carrying class-A + class-B + `resolved`. 4) Confirm the scenario asserts recovery treats this as resolved with no active loopback. 5) Confirm the scenario asserts a separate later commit carrying `Loopback: <class-B>` is required to open a follow-on of class-B. Observed outcome: all three assertions are present in one scenario.

## Validation

- `pnpm lint:md` against the changed Markdown surfaces.
- Manual recovery walkthrough on the two-commit worked example to confirm `git log --grep` plus trailer extraction yields the expected resolved-then-open sequence with no false reopen.

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
