### PR TITLE
docs: #47 align superteam with bootstrap baseline

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -1,0 +1,28 @@
+# Labels
+
+This file is the source of truth for when to apply each issue and pull-request label in this repository. It exists so reporters and agents can pick labels without guessing, and so label drift stays visible in review. For the authoritative runtime inventory, run `gh label list --json name,description`.
+
+## Labels
+
+| Name | Description |
+| --- | --- |
+| `bug` | Apply when the report describes a defect, regression, or unexpected behavior in shipped code or docs. |
+| `documentation` | Apply when the change is primarily to Markdown, in-repo docs, or comments that describe behavior. |
+| `duplicate` | Apply when another open or closed issue already tracks the same problem; link the canonical issue in the body. |
+| `enhancement` | Apply when the report proposes a new capability or improves an existing one without fixing a defect. |
+| `good first issue` | Apply when the work is small, well-scoped, and safe for a first-time contributor to pick up. |
+| `help wanted` | Apply when maintainers are actively soliciting outside contributions on the issue. |
+| `invalid` | Apply when the report is not actionable as filed (wrong repo, not reproducible, out of scope) and cannot be salvaged by editing. |
+| `question` | Apply when the issue is a support request or clarification rather than a change request. |
+| `wontfix` | Apply when the behavior described is intentional or the maintainers have decided not to act on it; leave a short rationale before closing. |
+
+### Release-please (tool-managed)
+
+`release-please` creates and applies these labels automatically on the standing release PR; do not apply or remove them by hand.
+
+- `autorelease: pending`: Applied to the release PR while a release is in progress.
+- `autorelease: tagged`: Applied to the release PR once the release has been tagged.
+
+## Adding or changing labels
+
+Use `gh label list --json name,description` as the canonical inventory and follow the label-hygiene rule in [`AGENTS.md`](../AGENTS.md) (every label must have a non-empty description). Do not introduce new labels in an issue or PR without first updating the repository label set and this file.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@ This title rule applies to pull requests only. GitHub issue titles should stay p
 
 ## Acceptance criteria
 
-<!-- One heading per relevant AC. AC IDs follow the convention in docs/ac-traceability.md. -->
+<!-- One heading per relevant AC. AC IDs follow the AC-<issue>-<n> convention in AGENTS.md. -->
 
 ### AC-<issue>-<n>
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: Release
 
-# release-please requires a run on push to main to cut the tag after
-# the release PR merges. workflow_dispatch is kept as a manual escape hatch.
+# Triggered on every push to `main`. release-please is idempotent: on regular
+# feature/fix merges it opens or refreshes the standing release PR; on the
+# release-PR merge it sees the merged PR (label `autorelease: pending`) and
+# cuts the tag, publishes the release, and dispatches the marketplace bump on
+# patinaproject/skills. A single trigger covers both flows. See RELEASING.md.
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ Agent Teams is optional. If you do not enable it, Superteam still works with the
    codex plugin marketplace add patinaproject/skills
    ```
 
-2. Install the plugin (pin to a tag for reproducible installs):
+2. Install the plugin:
 
    ```bash
-   codex plugin marketplace add patinaproject/superteam@v0.1.0
+   codex plugin marketplace add patinaproject/superteam
    ```
 
 3. Invoke from the target repository:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,13 +4,19 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-1. On every push to `main`, the `Release` workflow runs `release-please`. The same workflow can also be triggered manually from **Actions → Release → Run workflow** as an escape hatch — use it to seed the very first release PR before any push to `main`, or to re-run after a transient failure.
-2. `release-please` scans Conventional Commits since the last tag.
-3. It opens (or updates) a standing **"chore: release X.Y.Z"** PR that:
+The `Release` workflow runs on every push to `main`. There is no separate UI-triggered release path. Cutting a release is the natural by-product of merging PRs:
+
+1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens, or updates, a standing **"chore: release X.Y.Z"** PR that:
+
    - Bumps `package.json` version.
    - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
    - Appends generated entries to `CHANGELOG.md`.
-4. **Clicking Merge on that PR** is the release action. It tags `vX.Y.Z` and publishes a GitHub Release with notes generated from the same commits.
+
+   Release-please attaches the `autorelease: pending` label to this PR. If there are no releasable commits since the last tag, the run no-ops.
+
+2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
+
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No `gh workflow run` step is required.
 
 ## Prerequisites (one-time settings)
 

--- a/docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-plan.md
+++ b/docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-plan.md
@@ -178,7 +178,7 @@ Expected: no output and exit code 1.
 Run:
 
 ```bash
-gh label edit "autorelease: pending" --description "Reserved for Release Please automation while the release PR is pending; do not apply or remove manually."
+gh label edit "autorelease: pending" --description "Reserved for Release Please while release PR is pending; do not apply or remove manually."
 ```
 
 Expected: exit code 0.
@@ -188,7 +188,7 @@ Expected: exit code 0.
 Run:
 
 ```bash
-gh label edit "autorelease: tagged" --description "Reserved for Release Please automation after a release PR has been tagged; do not apply or remove manually."
+gh label edit "autorelease: tagged" --description "Reserved for Release Please after release PR is tagged; do not apply or remove manually."
 ```
 
 Expected: exit code 0.

--- a/docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-plan.md
+++ b/docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-plan.md
@@ -1,0 +1,286 @@
+# Align superteam to the bootstrap baseline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Realign the repository with the approved Bootstrap baseline design for issue #47.
+
+**Architecture:** This is a targeted repository realignment, not a scaffold rewrite. File changes are limited to the missing label policy and stale guidance, while remote label metadata is updated through `gh label edit`.
+
+**Tech Stack:** Markdown, GitHub Actions YAML, GitHub CLI, PNPM, Husky, commitlint, markdownlint-cli2.
+
+---
+
+## File Structure
+
+- Create `.github/LABELS.md`: tracked source of truth for label selection and release-managed labels.
+- Modify `.github/workflows/release.yml`: remove the manual-dispatch trigger and refresh the release-flow comment.
+- Modify `RELEASING.md`: replace the manual-dispatch release flow with the push-to-main and release-PR merge flow.
+- Modify `README.md`: remove the stale `@v0.1.0` Codex CLI install pin from the default install command.
+- Modify `.github/pull_request_template.md`: replace the missing `docs/ac-traceability.md` reference with the existing `AGENTS.md` convention.
+- Remote-only update: edit `autorelease: pending` and `autorelease: tagged` label descriptions.
+
+## Task 1: Add Label Policy Document
+
+**Files:**
+
+- Create: `.github/LABELS.md`
+
+- [ ] **Step 1: Create `.github/LABELS.md`**
+
+```markdown
+# Labels
+
+This file is the source of truth for when to apply each issue and pull-request label in this repository. It exists so reporters and agents can pick labels without guessing, and so label drift stays visible in review. For the authoritative runtime inventory, run `gh label list --json name,description`.
+
+## Labels
+
+| Name | Description |
+| --- | --- |
+| `bug` | Apply when the report describes a defect, regression, or unexpected behavior in shipped code or docs. |
+| `documentation` | Apply when the change is primarily to Markdown, in-repo docs, or comments that describe behavior. |
+| `duplicate` | Apply when another open or closed issue already tracks the same problem; link the canonical issue in the body. |
+| `enhancement` | Apply when the report proposes a new capability or improves an existing one without fixing a defect. |
+| `good first issue` | Apply when the work is small, well-scoped, and safe for a first-time contributor to pick up. |
+| `help wanted` | Apply when maintainers are actively soliciting outside contributions on the issue. |
+| `invalid` | Apply when the report is not actionable as filed (wrong repo, not reproducible, out of scope) and cannot be salvaged by editing. |
+| `question` | Apply when the issue is a support request or clarification rather than a change request. |
+| `wontfix` | Apply when the behavior described is intentional or the maintainers have decided not to act on it; leave a short rationale before closing. |
+
+### Release-please (tool-managed)
+
+`release-please` creates and applies these labels automatically on the standing release PR; do not apply or remove them by hand.
+
+- `autorelease: pending`: Applied to the release PR while a release is in progress.
+- `autorelease: tagged`: Applied to the release PR once the release has been tagged.
+
+## Adding or changing labels
+
+Use `gh label list --json name,description` as the canonical inventory and follow the label-hygiene rule in [`AGENTS.md`](../AGENTS.md) (every label must have a non-empty description). Do not introduce new labels in an issue or PR without first updating the repository label set and this file.
+```
+
+- [ ] **Step 2: Verify label table shape**
+
+Run:
+
+```bash
+rg -n "^## Labels$|^\\| `bug`|^\\| `enhancement`|Release-please" .github/LABELS.md
+```
+
+Expected: output includes the `## Labels` heading, `bug`, `enhancement`, and the release-managed subsection.
+
+## Task 2: Refresh Release Flow Guidance
+
+**Files:**
+
+- Modify: `.github/workflows/release.yml`
+- Modify: `RELEASING.md`
+
+- [ ] **Step 1: Update `.github/workflows/release.yml` trigger comment and remove `workflow_dispatch`**
+
+Replace the current top comment and `on:` block with:
+
+```yaml
+name: Release
+
+# Triggered on every push to `main`. release-please is idempotent: on regular
+# feature/fix merges it opens or refreshes the standing release PR; on the
+# release-PR merge it sees the merged PR (label `autorelease: pending`) and
+# cuts the tag, publishes the release, and dispatches the marketplace bump on
+# patinaproject/skills. A single trigger covers both flows. See RELEASING.md.
+on:
+  push:
+    branches: [main]
+```
+
+- [ ] **Step 2: Update `RELEASING.md` "How it works" section**
+
+Replace only the numbered list under `## How it works` before `## Prerequisites (one-time settings)` with:
+
+```markdown
+The `Release` workflow runs on every push to `main`. There is no manual dispatch. Cutting a release is the natural by-product of merging PRs:
+
+1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens, or updates, a standing **"chore: release X.Y.Z"** PR that:
+
+   - Bumps `package.json` version.
+   - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
+   - Appends generated entries to `CHANGELOG.md`.
+
+   Release-please attaches the `autorelease: pending` label to this PR. If there are no releasable commits since the last tag, the run no-ops.
+
+2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
+
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No `gh workflow run` step is required.
+```
+
+- [ ] **Step 3: Verify manual-dispatch wording is gone**
+
+Run:
+
+```bash
+rg -n "workflow_dispatch|Run workflow|manual dispatch|gh workflow run Release" .github/workflows/release.yml RELEASING.md
+```
+
+Expected: no output and exit code 1.
+
+## Task 3: Refresh Install and PR Guidance
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `.github/pull_request_template.md`
+
+- [ ] **Step 1: Update Codex CLI install command**
+
+In `README.md`, replace:
+
+```bash
+codex plugin marketplace add patinaproject/superteam@v0.1.0
+```
+
+with:
+
+```bash
+codex plugin marketplace add patinaproject/superteam
+```
+
+- [ ] **Step 2: Update the PR-template AC comment**
+
+In `.github/pull_request_template.md`, replace:
+
+```markdown
+<!-- One heading per relevant AC. AC IDs follow the convention in docs/ac-traceability.md. -->
+```
+
+with:
+
+```markdown
+<!-- One heading per relevant AC. AC IDs follow the AC-<issue>-<n> convention in AGENTS.md. -->
+```
+
+- [ ] **Step 3: Verify stale references are gone**
+
+Run:
+
+```bash
+rg -n "v0\\.1\\.0|docs/ac-traceability\\.md" README.md .github/pull_request_template.md
+```
+
+Expected: no output and exit code 1.
+
+## Task 4: Update Release-Reserved Label Metadata
+
+**Files:**
+
+- Remote-only GitHub label metadata
+
+- [ ] **Step 1: Update `autorelease: pending` description**
+
+Run:
+
+```bash
+gh label edit "autorelease: pending" --description "Reserved for Release Please automation while the release PR is pending; do not apply or remove manually."
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 2: Update `autorelease: tagged` description**
+
+Run:
+
+```bash
+gh label edit "autorelease: tagged" --description "Reserved for Release Please automation after a release PR has been tagged; do not apply or remove manually."
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 3: Verify release label descriptions**
+
+Run:
+
+```bash
+gh label list --json name,color,description --jq '.[] | select(.name=="autorelease: pending" or .name=="autorelease: tagged")'
+```
+
+Expected: both labels have color `ededed` and non-empty descriptions.
+
+## Task 5: Verify and Commit Implementation
+
+**Files:**
+
+- All files changed in Tasks 1-3
+
+- [ ] **Step 1: Verify Markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: exit code 0 and `Summary: 0 error(s)`.
+
+- [ ] **Step 2: Verify plugin versions**
+
+Run:
+
+```bash
+node scripts/check-plugin-versions.mjs
+```
+
+Expected: `check-plugin-versions: all manifests at 1.0.0`.
+
+- [ ] **Step 3: Verify commitlint rejects a missing issue**
+
+Run:
+
+```bash
+printf 'feat: bad\n' | pnpm exec commitlint
+```
+
+Expected: non-zero exit with `ticket-required` failure.
+
+- [ ] **Step 4: Verify commitlint accepts an issue-tagged title**
+
+Run:
+
+```bash
+printf 'docs: #47 align bootstrap baseline\n' | pnpm exec commitlint
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 5: Confirm already-aligned surfaces were preserved**
+
+Run:
+
+```bash
+git diff --name-only HEAD
+```
+
+Expected changed tracked files are limited to:
+
+```text
+.github/LABELS.md
+.github/pull_request_template.md
+.github/workflows/release.yml
+README.md
+RELEASING.md
+docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-plan.md
+```
+
+- [ ] **Step 6: Commit implementation**
+
+Run:
+
+```bash
+git add .github/LABELS.md .github/pull_request_template.md .github/workflows/release.yml README.md RELEASING.md docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-plan.md
+git commit -m "docs: #47 align superteam with bootstrap baseline"
+```
+
+Expected: commit succeeds after Husky runs markdownlint and plugin-version checks.
+
+## Self-Review
+
+- Spec coverage: Tasks 1-5 cover AC-47-1 through AC-47-6.
+- Red-flag scan: no incomplete implementation steps remain.
+- Type consistency: not applicable; this plan changes Markdown, YAML, and remote label metadata only.

--- a/docs/superpowers/specs/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-design.md
+++ b/docs/superpowers/specs/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-design.md
@@ -1,0 +1,124 @@
+# Design: Align superteam to the bootstrap baseline [#47](https://github.com/patinaproject/superteam/issues/47)
+
+## Intent
+
+Realign this repository with the current Patina Project bootstrap baseline without
+rewriting surfaces that already match the local `superteam` contract. The work
+should make future issue filing, release automation, and baseline audits more
+predictable.
+
+## Requirements
+
+- Preserve repository-specific `superteam` wording where it is an intentional
+  specialization of the generic bootstrap templates.
+- Add the missing label source-of-truth document required by the current
+  bootstrap audit flow.
+- Bring release-reserved label metadata into the documented baseline shape
+  without applying or removing those labels from issues or pull requests.
+- Keep GitHub repository settings checks explicit and evidence-backed.
+- Validate all Markdown and plugin-version checks before publish.
+- Use acceptance criteria IDs in the `AC-47-<n>` format.
+
+## Baseline Findings
+
+The repository already has the main agent-plugin baseline shape:
+
+- dual plugin manifests in `.claude-plugin/` and `.codex-plugin/`
+- Claude, Cursor, Windsurf, and Copilot agent surfaces
+- PNPM, Husky, commitlint, markdownlint, and plugin-version scripts
+- release-please configuration and Patina release workflow
+- `docs/superpowers/specs/` and `docs/superpowers/plans/`
+
+Verified drift:
+
+- `.github/LABELS.md` is missing, so agents must infer label meaning from
+  remote labels alone.
+- Remote `autorelease: pending` and `autorelease: tagged` labels exist with
+  color `ededed`, but their descriptions are empty.
+- `RELEASING.md` and `.github/workflows/release.yml` have older wording about
+  manual dispatch compared with the latest observed bootstrap guidance.
+- `README.md` still shows a Codex CLI install command pinned to
+  `patinaproject/superteam@v0.1.0`, even though the repo is at `1.0.0`.
+- `.github/pull_request_template.md` references `docs/ac-traceability.md`, but
+  that file is not present and `AGENTS.md` now defines AC ID format directly.
+
+Verified non-drift:
+
+- Default workflow permissions are `write`.
+- Tag rulesets returned no required-signature blockers.
+- Merge settings match the expected squash-only bootstrap settings.
+- Core issue templates, lint workflows, actionlint config, markdownlint config,
+  and plugin manifest versions are aligned.
+
+## Design
+
+### Repository files
+
+Add `.github/LABELS.md` as the durable, reviewable label policy. The file should
+include an alphabetized `## Labels` table for the standard labels and a
+tool-managed release subsection for `autorelease: pending` and
+`autorelease: tagged`. It should point readers back to `AGENTS.md` and
+`gh label list --json name,description` for the runtime inventory.
+
+Refresh release documentation only where it still describes a manual-dispatch
+release path. The repo should describe release-please as running on pushes to
+`main`, opening or updating the release PR after regular merges, and cutting the
+release after the release PR merge.
+
+Refresh install and contribution guidance where it points to stale or missing
+baseline references. The README should not pin new Codex CLI installs to an old
+plugin version, and the PR template should point AC authors at the existing
+`AGENTS.md` rule rather than a missing traceability document.
+
+Avoid broad template replacement. Existing repo-specific examples and
+`superteam` wording should remain unless they conflict with the baseline checks.
+
+### Remote metadata
+
+Update the two release-reserved GitHub labels so both have non-empty
+descriptions documenting that Release Please owns them. Do not apply or remove
+the labels from issues or PRs.
+
+Do not change repository merge settings because the checked values already
+match the baseline. Release immutability is UI-only and should be reported as a
+manual follow-up if it cannot be verified through the available APIs.
+
+### Verification
+
+Run the bootstrap-relevant local checks after file changes:
+
+- `pnpm lint:md`
+- `node scripts/check-plugin-versions.mjs`
+- commitlint positive and negative samples
+
+Also re-check the remote release labels after editing them. For workflow or
+release-doc changes, inspect the changed files directly and rely on existing
+workflow lint CI after publication.
+
+## Acceptance Criteria
+
+- **AC-47-1**: Given contributors or agents need to choose labels, when they
+  inspect the repository, then `.github/LABELS.md` documents the canonical
+  labels and release-managed labels in the bootstrap format.
+- **AC-47-2**: Given Release Please owns `autorelease: pending` and
+  `autorelease: tagged`, when remote label metadata is queried, then both labels
+  have non-empty descriptions that explain the reservation.
+- **AC-47-3**: Given the release workflow runs from pushes to `main`, when a
+  contributor reads `RELEASING.md` or `.github/workflows/release.yml`, then the
+  documented flow no longer depends on a manual dispatch path.
+- **AC-47-4**: Given the repo is being realigned rather than re-scaffolded, when
+  contributors read install or PR guidance, then README and PR-template
+  references do not point them to stale plugin versions or missing docs.
+- **AC-47-5**: Given the repo is being realigned rather than re-scaffolded, when
+  implementation completes, then already-aligned plugin, linting, workflow, and
+  agent surfaces remain intentionally preserved.
+- **AC-47-6**: Given the realignment touches Markdown and plugin metadata
+  guidance, when verification runs, then Markdown linting, plugin-version checks,
+  and commitlint sample checks pass.
+
+## Out of Scope
+
+- Replacing every repository file with bootstrap templates.
+- Changing issue or pull-request labels on existing items.
+- Changing merge settings that already match the baseline.
+- Proving release immutability through an API that does not expose it.


### PR DESCRIPTION
## Summary

- Add `.github/LABELS.md` as the tracked label policy and release-managed label reference.
- Refresh release, install, and PR guidance to match the current Bootstrap baseline.
- Update Release Please reserved label descriptions on GitHub.

## Linked issue

- Closes #47

## Acceptance criteria

### AC-47-1

`.github/LABELS.md` documents canonical labels and release-managed labels.

- [x] Local evidence — Codex CLI | macOS zsh | @tlmader | 2026-04-27T05:43:05Z

### AC-47-2

Release Please reserved labels have non-empty reservation descriptions.

- [x] Remote evidence — Codex CLI | GitHub API via gh | @tlmader | 2026-04-27T05:43:05Z

### AC-47-3

Release docs and workflow no longer depend on a manual dispatch path.

- [x] Local evidence — Codex CLI | macOS zsh | @tlmader | 2026-04-27T05:43:05Z

### AC-47-4

Install and PR guidance no longer point to stale plugin versions or missing docs.

- [x] Local evidence — Codex CLI | macOS zsh | @tlmader | 2026-04-27T05:43:05Z

### AC-47-5

Already-aligned plugin, linting, workflow, and agent surfaces were preserved.

- [x] Local evidence — Codex CLI | git diff review | @tlmader | 2026-04-27T05:43:05Z

### AC-47-6

Markdown linting, plugin-version checks, and commitlint samples pass.

- [x] Local evidence — Codex CLI | pnpm/commitlint | @tlmader | 2026-04-27T05:43:05Z

## Validation

- `pnpm lint:md`
- `node scripts/check-plugin-versions.mjs`
- `printf 'feat: bad\n' | pnpm exec commitlint` failed as expected with `ticket-required`
- `printf 'docs: #47 align bootstrap baseline\n' | pnpm exec commitlint`
- `git show --check --stat --oneline HEAD`
- `gh label list --json name,color,description --jq '.[] | select(.name=="autorelease: pending" or .name=="autorelease: tagged")'`
- `rg -n "workflow_dispatch|Run workflow|manual dispatch|gh workflow run Release|v0\.1\.0|docs/ac-traceability\.md|pin to a tag" .github/workflows/release.yml RELEASING.md README.md .github/pull_request_template.md` returned no matches

## Docs updated

- [x] Updated in this PR