### PR TITLE
docs: #50 add adversarial review gate

### DIFF
--- a/docs/superpowers/plans/2026-04-27-50-superteam-should-run-adversarial-design-review-before-planning-plan.md
+++ b/docs/superpowers/plans/2026-04-27-50-superteam-should-run-adversarial-design-review-before-planning-plan.md
@@ -1,0 +1,404 @@
+# Plan: Superteam should run adversarial design review before planning [#50](https://github.com/patinaproject/superteam/issues/50)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a pre-planning adversarial design-review gate to the Superteam workflow contract.
+
+**Architecture:** This is a workflow-contract documentation change. The canonical contract lives in `skills/superteam/SKILL.md`; delegated teammate prompt shape lives in `skills/superteam/agent-spawn-template.md`; portable behavioral pressure tests live in `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`.
+
+**Tech Stack:** Markdown, `markdownlint-cli2`, repo-local `pnpm` scripts, Git commit-message hooks.
+
+---
+
+## Source Documents
+
+- Design: `docs/superpowers/specs/2026-04-27-50-superteam-should-run-adversarial-design-review-before-planning-design.md`
+- Core contract: `skills/superteam/SKILL.md`
+- Delegation prompts: `skills/superteam/agent-spawn-template.md`
+- Pressure tests: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+- Repo rules: `AGENTS.md`
+
+## RED Baseline Evidence
+
+Before editing workflow surfaces, capture inspection-based baseline evidence
+against the unchanged contract at `e0c42068bff42abf563e47b79d9106864cec3391`.
+This establishes the failing state required by the design.
+
+- [ ] **Step 1: Confirm Gate 1 currently requires `concerns[]`, not adversarial review**
+
+Run:
+
+```bash
+sed -n '/^## Gate 1: Brainstormer approval/,/^## Routing table/p' skills/superteam/SKILL.md
+```
+
+Expected RED evidence: the output requires artifact path, intent summary, full
+requirement set, `concerns[]`, and `Remaining concerns: None`, but contains no
+`adversarial_review_findings[]`, `adversarial_review_status`, or clean-pass
+rationale.
+
+- [ ] **Step 2: Confirm Brainstormer done report lacks adversarial review fields**
+
+Run:
+
+```bash
+sed -n '/^### Brainstormer done report/,/^### Planner done report/p' skills/superteam/SKILL.md
+```
+
+Expected RED evidence: the output requires `design_doc_path`, `ac_ids[]`,
+`intent_summary`, `requirements[]`, `concerns[]`, and `handoff_commit_sha`, but
+contains no `adversarial_review_findings[]`.
+
+- [ ] **Step 3: Confirm existing pressure tests do not cover adversarial review**
+
+Run:
+
+```bash
+rg -n "adversarial_review_findings|adversarial review|clean-pass|Brainstormer-only findings" docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+Expected RED evidence: no matches.
+
+Record these three command outputs in the Executor completion evidence.
+
+## Task 1: Update Gate 1 Core Contract
+
+**Files:**
+
+- Modify: `skills/superteam/SKILL.md`
+
+- [ ] **Step 1: Replace `concerns[]` in Gate 1 approval requirements**
+
+In `## Gate 1: Brainstormer approval`, replace the current concerns-specific
+items:
+
+```markdown
+5. Always report `concerns[]` in the approval packet, including an explicit empty result when no approval-relevant concerns remain.
+6. Render the operator-facing no-concerns line exactly as `Remaining concerns: None`.
+7. Surface any remaining approval-relevant concerns that could materially affect the decision to approve, revise, or narrow the design.
+```
+
+with:
+
+```markdown
+5. Include `adversarial_review_findings[]` as the single approval-finding surface, including Brainstormer-originated concerns and adversarial-review findings.
+6. Preserve finding provenance with `source: brainstormer | adversarial-review`.
+7. Require an explicit adversarial-review result before approval can advance: `clean`, `findings dispositioned`, or `blocked`.
+8. Include `clean_pass_rationale` when no blocker or material findings remain.
+9. Halt approval when any blocker or material finding is still open.
+```
+
+- [ ] **Step 2: Add the adversarial review sequence to Gate 1**
+
+After the numbered list, add:
+
+```markdown
+Before Gate 1 approval is presented, `Team Lead` must run or dispatch an adversarial design review against the committed design artifact. Fresh-context or parallel specialist review is preferred for workflow-critical or broad designs when the runtime supports it; same-thread review is the portable fallback. Brainstormer-originated findings alone do not satisfy this gate.
+
+If adversarial review changes the design, `Brainstormer` must commit the revised artifact before approval. Material requirement, ownership, pressure-test, or gate-order changes require rerunning the affected review dimensions or recording why rerun is unnecessary.
+```
+
+- [ ] **Step 3: Update Team Lead contract**
+
+In `### Team Lead`, add bullets:
+
+```markdown
+- Before Gate 1 approval can advance, enforce adversarial design review against the committed design artifact.
+- Include `adversarial_review_status`, `adversarial_review_findings[]`, and `clean_pass_rationale` when applicable in Gate 1 approval packets.
+- Treat Brainstormer-originated findings as useful input but not proof that adversarial review occurred.
+```
+
+- [ ] **Step 4: Update Brainstormer contract**
+
+In `### Brainstormer`, replace the `concerns[]` bullets with:
+
+```markdown
+- Report `adversarial_review_findings[]` when requesting approval, including Brainstormer-originated concerns and adversarial-review findings.
+- Preserve `source: brainstormer | adversarial-review` on every finding.
+- Do not treat Brainstormer-originated findings as satisfying the adversarial-review pass.
+- Include the clean-pass rationale when the adversarial-review result is clean.
+- Commit any design changes caused by self-review or adversarial findings before reporting done or handing off to `Planner`.
+```
+
+- [ ] **Step 5: Update Brainstormer done-report contract**
+
+In `### Brainstormer done report`, replace the `concerns[]` field with:
+
+```markdown
+- `adversarial_review_status`: `clean` | `findings dispositioned` | `blocked`
+- `adversarial_review_findings[]`: findings relevant to approval, with `source`, `severity`, `location`, `finding`, and `disposition`
+- `clean_pass_rationale`: required when no blocker or material findings remain
+```
+
+- [ ] **Step 6: Add rationalization-table rows**
+
+Append rows to `## Rationalization table`:
+
+```markdown
+| "`adversarial_review_findings[]` already has Brainstormer entries, so review happened." | Brainstormer-originated findings are useful but not sufficient. Gate 1 requires an explicit adversarial-review pass against the committed artifact. |
+| "No findings means no review evidence is needed." | A clean adversarial-review result must include checked dimensions and `clean_pass_rationale`; silence is not evidence. |
+| "A finding changed the design, but the earlier review still applies." | Material requirement, ownership, pressure-test, or gate-order changes require rerunning affected review dimensions or recording why rerun is unnecessary. |
+```
+
+- [ ] **Step 7: Add red flags**
+
+Append bullets to `## Red flags`:
+
+```markdown
+- Gate 1 approval packet has `adversarial_review_findings[]` entries but no evidence that an adversarial-review pass occurred.
+- Adversarial review reports `clean` without checked dimensions or `clean_pass_rationale`.
+- `Planner` starts while a blocker or material `adversarial_review_findings[]` item remains open.
+- Brainstormer-originated findings are treated as a replacement for adversarial review.
+```
+
+- [ ] **Step 8: Verify Task 1 targeted checks**
+
+Run:
+
+```bash
+rg -n "adversarial_review_findings\\[\\]|adversarial_review_status|clean_pass_rationale|Brainstormer-originated findings" skills/superteam/SKILL.md
+```
+
+Expected: matches in Gate 1, Team Lead, Brainstormer, done report, rationalization table, and red flags.
+
+## Task 2: Update Delegated Prompt Contracts
+
+**Files:**
+
+- Modify: `skills/superteam/agent-spawn-template.md`
+
+- [ ] **Step 1: Update Team Lead role-specific approval packet**
+
+In the `### Team Lead` block, replace the `concerns[]` bullets with:
+
+```text
+- `adversarial_review_findings[]`, including Brainstormer-originated concerns and adversarial-review findings
+- `source: brainstormer | adversarial-review` on each finding
+- `adversarial_review_status`: `clean`, `findings dispositioned`, or `blocked`
+- `clean_pass_rationale` when no blocker or material findings remain
+```
+
+Add:
+
+```text
+Before Gate 1 approval can advance, run or dispatch adversarial design review against the committed artifact. Brainstormer-originated findings alone do not satisfy this gate.
+```
+
+- [ ] **Step 2: Update Brainstormer done-report contract**
+
+In the `### Brainstormer` block, replace the `concerns[]` done-report line with:
+
+```text
+- `adversarial_review_status`: `clean` | `findings dispositioned` | `blocked`
+- `adversarial_review_findings[]`: findings relevant to approval, with `source`, `severity`, `location`, `finding`, and `disposition`
+- `clean_pass_rationale`: required when no blocker or material findings remain
+```
+
+Add:
+
+```text
+Do not treat Brainstormer-originated findings as satisfying the adversarial-review pass. If adversarial review changes the design, commit the revised artifact before handoff.
+```
+
+- [ ] **Step 3: Verify Task 2 targeted checks**
+
+Run:
+
+```bash
+rg -n "adversarial_review_findings\\[\\]|adversarial_review_status|clean_pass_rationale|Brainstormer-originated findings" skills/superteam/agent-spawn-template.md
+```
+
+Expected: matches in Team Lead and Brainstormer role-specific blocks.
+
+## Task 3: Add Pressure Tests
+
+**Files:**
+
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+- [ ] **Step 1: Add skipped-review pressure test**
+
+Insert after the existing approval-packet concerns tests:
+
+```markdown
+## Gate 1 approval packet omits adversarial review evidence
+
+- Starting condition: Brainstormer requests Gate 1 approval with a design artifact path, intent summary, requirements, and `adversarial_review_findings[]`, but the packet has no `adversarial_review_status`, no reviewer context, and no evidence that an adversarial-review pass occurred.
+- Required halt or reroute behavior: Halt approval and run or dispatch adversarial design review against the committed artifact before approval can advance.
+- Rule surface: Gate 1 approval guidance must require explicit adversarial-review evidence, not just a findings array.
+```
+
+- [ ] **Step 2: Add Brainstormer-only findings pressure test**
+
+Insert:
+
+```markdown
+## Brainstormer-only findings treated as adversarial review
+
+- Starting condition: `adversarial_review_findings[]` contains only `source: brainstormer` entries, and no adversarial-review pass has run against the committed design artifact.
+- Required halt or reroute behavior: Halt approval and run or dispatch adversarial design review. Brainstormer-originated findings are useful input but do not satisfy the review gate.
+- Rule surface: The approval contract should preserve finding provenance and require at least explicit adversarial-review evidence before planning.
+```
+
+- [ ] **Step 3: Add clean-pass rationale pressure test**
+
+Insert:
+
+```markdown
+## Clean adversarial review omits checked dimensions or rationale
+
+- Starting condition: Gate 1 approval says adversarial review is clean, but the packet does not name checked dimensions or provide `clean_pass_rationale`.
+- Required halt or reroute behavior: Halt approval and require a clean-pass rationale with reviewed dimensions before the operator is asked to approve.
+- Rule surface: Clean adversarial review needs evidence before claims.
+```
+
+- [ ] **Step 4: Add open material finding pressure test**
+
+Insert:
+
+```markdown
+## Material adversarial review finding has no disposition
+
+- Starting condition: `adversarial_review_findings[]` contains a blocker or material finding with no disposition, or with `disposition: open`.
+- Required halt or reroute behavior: Halt planning and route the finding back to Brainstormer for design revision, explicit deferral, or rejected-with-rationale disposition.
+- Rule surface: Gate 1 must block on unresolved blocker or material findings.
+```
+
+- [ ] **Step 5: Add workflow-contract dimensions pressure test**
+
+Insert:
+
+```markdown
+## Workflow-contract design reviewed without writing-skills dimensions
+
+- Starting condition: The design touches `skills/**/*.md` or a workflow-contract surface, but adversarial review does not check RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths.
+- Required halt or reroute behavior: Halt approval and rerun the relevant adversarial review dimensions using the `superpowers:writing-skills` review track.
+- Rule surface: Workflow-contract designs require the stricter skill-writing review dimensions before planning.
+```
+
+- [ ] **Step 6: Add rerun pressure test**
+
+Insert:
+
+```markdown
+## Material design change after adversarial review does not rerun affected dimensions
+
+- Starting condition: Adversarial review finds a material issue, Brainstormer changes requirements, ownership, pressure-test obligations, or gate order, and Gate 1 approval proceeds without rerunning the affected review dimensions or recording why rerun is unnecessary.
+- Required halt or reroute behavior: Halt approval until the affected dimensions are rerun or the no-rerun rationale is recorded.
+- Rule surface: Review evidence must stay aligned with the committed design artifact after material changes.
+```
+
+- [ ] **Step 7: Add runtime overreach pressure test**
+
+Insert:
+
+```markdown
+## Fresh-context review treated as a hard runtime dependency
+
+- Starting condition: The host runtime cannot run fresh-context or parallel specialist review, but the workflow treats that missing capability as a blocker for every design, including small changes.
+- Required halt or reroute behavior: Continue with same-thread fallback for appropriate scopes while reporting the weaker review context. Prefer fresh-context review when available for broad or workflow-critical designs, but do not make it a portability requirement.
+- Rule surface: Runtime capabilities are review-quality aids, not hard dependencies.
+```
+
+- [ ] **Step 8: Verify Task 3 targeted checks**
+
+Run:
+
+```bash
+rg -n "Gate 1 approval packet omits adversarial review evidence|Brainstormer-only findings|Clean adversarial review|Material adversarial review finding|Workflow-contract design reviewed|Material design change after adversarial review|Fresh-context review treated" docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+Expected: seven matches, one for each new pressure test heading.
+
+## Task 4: GREEN Verification and Commit
+
+**Files:**
+
+- Modify: `skills/superteam/SKILL.md`
+- Modify: `skills/superteam/agent-spawn-template.md`
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+- [ ] **Step 1: Run targeted GREEN checks**
+
+Run:
+
+```bash
+rg -n "adversarial_review_findings\\[\\]|adversarial_review_status|clean_pass_rationale" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md
+rg -n "Gate 1 approval packet omits adversarial review evidence|Brainstormer-only findings|Clean adversarial review|Material adversarial review finding|Workflow-contract design reviewed|Material design change after adversarial review|Fresh-context review treated" docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+Expected: first command shows the new contract fields across core and delegated
+surfaces; second command shows all seven new pressure-test headings.
+
+- [ ] **Step 2: Run Markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: `Summary: 0 error(s)`.
+
+- [ ] **Step 3: Run plugin version check**
+
+Run:
+
+```bash
+node scripts/check-plugin-versions.mjs
+```
+
+Expected: `check-plugin-versions: all manifests at 1.1.0`.
+
+- [ ] **Step 4: Commit implementation**
+
+Run:
+
+```bash
+git add skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+git commit -m "docs: #50 add adversarial review gate"
+```
+
+Expected: commit succeeds through Husky hooks.
+
+## Task 5: Local Review Before Publish
+
+**Files:**
+
+- Review: all changed files on the branch
+
+- [ ] **Step 1: Inspect branch diff**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+```
+
+Expected: changed files are the design doc, plan doc, core skill, spawn
+template, and pressure-test doc; `git diff --check` exits 0.
+
+- [ ] **Step 2: Review acceptance criteria coverage**
+
+Run:
+
+```bash
+rg -n "AC-50-[1-7]|adversarial_review_findings\\[\\]|adversarial_review_status|clean_pass_rationale|Brainstormer-only findings|Fresh-context review" docs/superpowers/specs/2026-04-27-50-superteam-should-run-adversarial-design-review-before-planning-design.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+Expected: every AC has a corresponding contract or pressure-test reference.
+
+- [ ] **Step 3: If review finds issues, classify loopback**
+
+If review finds a missing requirement, classify it as `spec-level` and route to
+Brainstormer. If review finds plan ambiguity, classify it as `plan-level`. If
+review finds only implementation wording issues, fix in the edited files and
+rerun the relevant targeted checks.
+
+## Out of Scope
+
+- Adding executable tooling for adversarial review.
+- Creating a new durable adversarial-review artifact file.
+- Changing the canonical teammate roster.
+- Importing BMad or gstack.

--- a/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+++ b/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
@@ -26,23 +26,23 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Required halt or reroute behavior: Halt the revised approval request and resend it with only the changed content and changed requirements.
 - Rule surface: The revision approval prompt should require delta-only resubmission after revisions.
 
-## Approval request omits remaining approval-relevant concerns
+## Approval request omits approval-relevant findings
 
-- Starting condition: Brainstormer requests approval while real approval-relevant concerns still exist, but the approval packet does not surface them.
-- Required halt or reroute behavior: Halt approval and reissue the packet with the remaining approval-relevant concerns included, unless the concern is severe enough to block approval entirely.
-- Rule surface: The first-stage approval contract should require Brainstormer to surface real approval-relevant concerns when present.
+- Starting condition: Brainstormer requests approval while real approval-relevant findings still exist, but the approval packet does not surface them in `adversarial_review_findings[]`.
+- Required halt or reroute behavior: Halt approval and reissue the packet with the remaining approval-relevant findings included, unless the finding is severe enough to block approval entirely.
+- Rule surface: The first-stage approval contract should require Brainstormer to surface real approval-relevant findings when present.
 
-## Approval packet omits `concerns[]` entirely
+## Approval packet omits `adversarial_review_findings[]` entirely
 
-- Starting condition: Brainstormer requests approval, but the packet omits `concerns[]` instead of explicitly reporting concerns or an empty result.
-- Required halt or reroute behavior: Halt approval and reissue the packet with `concerns[]` present under the contract before planning can continue.
-- Rule surface: The approval-packet contract should require `concerns[]` on every Brainstormer approval request.
+- Starting condition: Brainstormer requests approval, but the packet omits `adversarial_review_findings[]` instead of explicitly reporting findings or an empty result.
+- Required halt or reroute behavior: Halt approval and reissue the packet with `adversarial_review_findings[]` present under the contract before planning can continue.
+- Rule surface: The approval-packet contract should require `adversarial_review_findings[]` on every Brainstormer approval request.
 
-## Approval packet with no concerns does not render `Remaining concerns: None`
+## Approval packet with no findings omits clean-pass rationale
 
-- Starting condition: The approval packet reaches the operator with no approval-relevant concerns remaining, but the no-concerns case is rendered as silence, an empty array, or some other wording.
-- Required halt or reroute behavior: Halt approval presentation and reissue the operator-facing packet with the no-concerns line rendered exactly as `Remaining concerns: None`.
-- Rule surface: The approval-packet rendering guidance should preserve the explicit empty `concerns[]` result under the contract while rendering the operator-facing no-concerns case exactly as `Remaining concerns: None`.
+- Starting condition: The approval packet reaches the operator with no blocker or material findings remaining, but the clean case is rendered as silence, an empty array, or some other wording without `clean_pass_rationale`.
+- Required halt or reroute behavior: Halt approval presentation and reissue the operator-facing packet with `clean_pass_rationale` and the checked adversarial-review dimensions.
+- Rule surface: The approval-packet rendering guidance should preserve the explicit empty `adversarial_review_findings[]` result under the contract while rendering the clean case with evidence.
 
 ## Gate 1 approval packet omits adversarial review evidence
 

--- a/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+++ b/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
@@ -44,6 +44,48 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Required halt or reroute behavior: Halt approval presentation and reissue the operator-facing packet with the no-concerns line rendered exactly as `Remaining concerns: None`.
 - Rule surface: The approval-packet rendering guidance should preserve the explicit empty `concerns[]` result under the contract while rendering the operator-facing no-concerns case exactly as `Remaining concerns: None`.
 
+## Gate 1 approval packet omits adversarial review evidence
+
+- Starting condition: Brainstormer requests Gate 1 approval with a design artifact path, intent summary, requirements, and `adversarial_review_findings[]`, but the packet has no `adversarial_review_status`, no reviewer context, and no evidence that an adversarial-review pass occurred.
+- Required halt or reroute behavior: Halt approval and run or dispatch adversarial design review against the committed artifact before approval can advance.
+- Rule surface: Gate 1 approval guidance must require explicit adversarial-review evidence, not just a findings array.
+
+## Brainstormer-only findings treated as adversarial review
+
+- Starting condition: `adversarial_review_findings[]` contains only `source: brainstormer` entries, and no adversarial-review pass has run against the committed design artifact.
+- Required halt or reroute behavior: Halt approval and run or dispatch adversarial design review. Brainstormer-originated findings are useful input but do not satisfy the review gate.
+- Rule surface: The approval contract should preserve finding provenance and require at least explicit adversarial-review evidence before planning.
+
+## Clean adversarial review omits checked dimensions or rationale
+
+- Starting condition: Gate 1 approval says adversarial review is clean, but the packet does not name checked dimensions or provide `clean_pass_rationale`.
+- Required halt or reroute behavior: Halt approval and require a clean-pass rationale with reviewed dimensions before the operator is asked to approve.
+- Rule surface: Clean adversarial review needs evidence before claims.
+
+## Material adversarial review finding has no disposition
+
+- Starting condition: `adversarial_review_findings[]` contains a blocker or material finding with no disposition, or with `disposition: open`.
+- Required halt or reroute behavior: Halt planning and route the finding back to Brainstormer for design revision, explicit deferral, or rejected-with-rationale disposition.
+- Rule surface: Gate 1 must block on unresolved blocker or material findings.
+
+## Workflow-contract design reviewed without writing-skills dimensions
+
+- Starting condition: The design touches `skills/**/*.md` or a workflow-contract surface, but adversarial review does not check RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths.
+- Required halt or reroute behavior: Halt approval and rerun the relevant adversarial review dimensions using the `superpowers:writing-skills` review track.
+- Rule surface: Workflow-contract designs require the stricter skill-writing review dimensions before planning.
+
+## Material design change after adversarial review does not rerun affected dimensions
+
+- Starting condition: Adversarial review finds a material issue, Brainstormer changes requirements, ownership, pressure-test obligations, or gate order, and Gate 1 approval proceeds without rerunning the affected review dimensions or recording why rerun is unnecessary.
+- Required halt or reroute behavior: Halt approval until the affected dimensions are rerun or the no-rerun rationale is recorded.
+- Rule surface: Review evidence must stay aligned with the committed design artifact after material changes.
+
+## Fresh-context review treated as a hard runtime dependency
+
+- Starting condition: The host runtime cannot run fresh-context or parallel specialist review, but the workflow treats that missing capability as a blocker for every design, including small changes.
+- Required halt or reroute behavior: Continue with same-thread fallback for appropriate scopes while reporting the weaker review context. Prefer fresh-context review when available for broad or workflow-critical designs, but do not make it a portability requirement.
+- Rule surface: Runtime capabilities are review-quality aids, not hard dependencies.
+
 ## Delegated prompts missing expected `superpowers` recommendations
 
 - Starting condition: A delegated teammate prompt omits the expected `superpowers` skill recommendations for that role.

--- a/docs/superpowers/specs/2026-04-27-50-superteam-should-run-adversarial-design-review-before-planning-design.md
+++ b/docs/superpowers/specs/2026-04-27-50-superteam-should-run-adversarial-design-review-before-planning-design.md
@@ -1,0 +1,374 @@
+# Design: Superteam should run adversarial design review before planning [#50](https://github.com/patinaproject/superteam/issues/50)
+
+## Intent
+
+Add a distinct adversarial design-review gate between `Brainstormer` design
+authoring and `Planner` planning. The gate should complement
+`superpowers:brainstorming`: keep Brainstormer's collaborative design work and
+existing `concerns[]` reporting, but require an explicit review-owned attack on
+the committed design artifact before Gate 1 approval can advance.
+
+The change should borrow the useful parts of BMad and gstack without importing
+either workflow wholesale:
+
+- a BMad-like posture that assumes material issues may exist and requires either
+  actionable findings or a clean-pass rationale
+- a gstack-like gate before planning, with fresh-context or specialist review
+  when the host runtime can provide it
+- Superpowers-native reuse of `superpowers:writing-skills`,
+  `superpowers:requesting-code-review`, `superpowers:receiving-code-review`,
+  `superpowers:writing-plans`, and `superpowers:verification-before-completion`
+
+## Problem Framing
+
+Today `Brainstormer` owns the design artifact and reports `concerns[]` in the
+Gate 1 approval packet. That catches approval-relevant uncertainty, but it is
+still author-local: the same teammate who authored the design decides which
+concerns to surface. Superteam can therefore proceed to planning with a coherent
+design that has not been attacked for missing requirements, weak assumptions,
+stage-gate bypasses, or plan-readiness gaps.
+
+The problem is sharpest for `skills/**/*.md` and workflow-contract changes.
+Those designs can sound complete while still missing RED/GREEN pressure-test
+obligations, rationalization closures, red flags, token-efficiency limits, or
+role-specific ownership rules. Once such gaps reach `Planner`, the plan either
+has to invent design authority or encode a weak contract into implementation
+tasks.
+
+## Requirements
+
+- Preserve `Brainstormer` as the owner of the design artifact.
+- Keep `concerns[]` in the approval packet as Brainstormer-owned
+  approval-relevant concerns.
+- Add a separate adversarial-review result that is review-owned and attacks the
+  committed design artifact.
+- Require the adversarial review before Gate 1 approval can advance to
+  `Planner`.
+- Require material findings to be dispositioned before planning.
+- Require clean reviews to explain what was checked and why no material findings
+  remain.
+- Prefer fresh-context or parallel specialist review when the runtime supports
+  it and the scope is large or workflow-critical.
+- Keep a portable fallback for runtimes without fresh-context review support.
+- For `skills/**/*.md` and workflow-contract surfaces, require the stricter
+  `superpowers:writing-skills` review dimensions.
+
+## Design
+
+### Gate 1 sequence
+
+Gate 1 should become a two-part approval gate:
+
+1. `Brainstormer` writes and commits the design artifact.
+2. `Brainstormer` runs the existing spec self-review for placeholders,
+   contradictions, scope, and ambiguity.
+3. `Team Lead` verifies the design artifact exists at the reported path.
+4. `Team Lead` runs or dispatches adversarial design review against the
+   committed artifact.
+5. `Brainstormer` dispositions any material adversarial findings.
+6. If the design materially changes, `Team Lead` reruns the relevant
+   adversarial review dimensions or records why rerun is unnecessary.
+7. `Team Lead` presents the Gate 1 approval packet with both `concerns[]` and
+   the adversarial-review result.
+8. Only explicit operator approval advances to `Planner`.
+
+The adversarial-review gate is not a replacement for user approval. It gives
+the operator a sharper packet to approve.
+
+If self-review or adversarial findings change the design after the initial
+commit, `Brainstormer` must commit the revised design before Gate 1 approval is
+presented. Downstream teammates rely on committed branch state, so a clean
+review of uncommitted changes is not enough for handoff.
+
+### Review ownership
+
+`Team Lead` owns enforcing the gate and selecting the review path.
+`Brainstormer` owns design changes that result from findings. The adversarial
+review itself may be performed by:
+
+- a fresh-context subagent, preferred when available for workflow-critical or
+  broad designs
+- parallel specialist passes when dimensions are naturally separable
+- a same-thread compact pass when no fresh-context runtime is available
+
+The same-thread path is a portability fallback, not a claim that fresh-context
+review is unnecessary.
+
+The review result is Team Lead-owned gate evidence, not a new teammate role.
+`Brainstormer` may report how findings were addressed, but `Team Lead` remains
+responsible for verifying that the review result exists and is fit for approval.
+
+### Review output
+
+The Gate 1 packet should add an adversarial-review block beside the existing
+Brainstormer fields:
+
+```markdown
+Adversarial review: <clean | findings dispositioned | blocked>
+Reviewer context: <fresh subagent | parallel specialists | same-thread fallback>
+Findings:
+- <severity> <artifact section/path> - <finding>
+  Disposition: <fixed in design | deferred/out of scope | rejected with rationale>
+Clean-pass rationale: <required when no material findings remain>
+```
+
+`concerns[]` remains Brainstormer-owned. Adversarial findings are review-owned.
+The two surfaces should not be collapsed into one generic "concerns" list.
+
+### Review dimensions
+
+All adversarial design reviews should check:
+
+- requirement completeness and acceptance-criteria clarity
+- weak or unstated assumptions
+- simpler or safer alternatives
+- failure modes and recovery paths
+- teammate ownership and stage-gate boundaries
+- plan readiness for `superpowers:writing-plans`
+- whether the approval packet would let an operator make an informed decision
+
+For `skills/**/*.md` and workflow-contract changes, the review must also check:
+
+- RED-phase baseline obligation
+- GREEN verification path
+- rationalization-table coverage
+- red-flag coverage
+- loophole closure for authority, deadline, stale-context, partial-artifact, and
+  "spirit not letter" evasions
+- token-efficiency targets and trigger-only skill descriptions
+- stage-gate bypass paths
+- role ownership for finding intake, remediation, and publish follow-through
+
+### Findings disposition
+
+Material findings must be dispositioned before planning:
+
+- `fixed in design`: the design changed and the finding is resolved
+- `deferred/out of scope`: the design records why the issue is intentionally not
+  part of this work
+- `rejected with rationale`: the finding is technically evaluated and rejected
+
+Dispositions should follow the spirit of `superpowers:receiving-code-review`:
+understand the finding, verify it against the repository, evaluate whether it is
+correct for this workflow, then act or push back with rationale.
+
+### Rerun rule
+
+When a finding causes a material design change, rerun the relevant review
+dimensions before Gate 1 approval. Tiny wording fixes can record why no rerun is
+needed, but requirement, ownership, pressure-test, or gate-order changes require
+a rerun.
+
+### Scope control
+
+The gate should be proportional:
+
+- small documentation or product changes: one compact adversarial pass
+- workflow-contract or skill changes: strict `superpowers:writing-skills`
+  dimensions
+- large or high-risk designs: prefer fresh-context or parallel specialist review
+  when available
+
+The contract should explicitly reject endless review loops. After material
+findings are fixed or dispositioned and no new material findings remain, the
+gate can advance to operator approval.
+
+## Surface Changes
+
+Update `skills/superteam/SKILL.md`:
+
+- Gate 1 requirements include adversarial design review before approval can
+  advance to `Planner`.
+- `Team Lead` owns enforcing the review gate and including the review block in
+  approval packets.
+- `Brainstormer` done reports include `adversarial_findings_addressed[]` when
+  findings caused design changes, or an explicit empty result when no design
+  changes were required by review.
+- Team Lead approval packets include `adversarial_review_status`,
+  `adversarial_findings[]`, and `clean_pass_rationale` when applicable.
+- Rationalization table and red flags close bypasses such as "concerns[] is the
+  same as review" and "same-thread review is always enough."
+
+Update `skills/superteam/agent-spawn-template.md`:
+
+- Team Lead approval packets require the adversarial-review block.
+- Brainstormer done reports include finding-addressed state for design changes
+  made in response to adversarial review.
+- Brainstormer prompts state that `concerns[]` does not satisfy adversarial
+  review.
+
+Update `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`:
+
+- Add pressure tests for skipped adversarial review, collapsed review/concerns,
+  clean pass without rationale, material findings without disposition, workflow
+  surfaces reviewed without `writing-skills` dimensions, material design changes
+  without rerun, and runtime support treated as a hard dependency.
+
+## Loophole-Closure Language
+
+The workflow must close these rationalizations:
+
+| Excuse | Reality |
+|--------|---------|
+| "`concerns[]` already covers review." | `concerns[]` is Brainstormer-owned. Adversarial design review is a separate review-owned attack on the committed artifact. |
+| "The operator can catch design gaps during approval." | Gate 1 should present an already-attacked design; operator approval is not a substitute for required review. |
+| "No findings means no review block is needed." | A clean pass must include the checked dimensions and a rationale for why no material findings remain. |
+| "Same-thread review is good enough even for workflow contracts." | Fresh-context review is preferred for workflow-critical or broad designs when available; same-thread review is only the portable fallback. |
+| "A finding was fixed, so the original review still applies." | Material design changes require rerunning the affected review dimensions or recording why rerun is unnecessary. |
+| "Adversarial review can become an endless loop." | Once material findings are fixed or dispositioned and no new material findings remain, the gate advances to operator approval. |
+
+## Red Flags
+
+- Gate 1 approval packet has `concerns[]` but no adversarial-review block.
+- Adversarial review reports "clean" without naming checked dimensions.
+- Material findings are listed without dispositions.
+- `Planner` starts from a design with unresolved material adversarial findings.
+- Skill or workflow-contract designs skip RED/GREEN pressure-test obligations.
+- Requirement, ownership, pressure-test, or gate-order changes land after review
+  without rerunning affected review dimensions.
+- Runtime fresh-context support is treated as mandatory for all runs, or ignored
+  when available for high-risk designs.
+
+## RED-Phase Baseline Obligation
+
+Before implementing the rule, capture evidence that the current contract allows
+Gate 1 to proceed without a distinct adversarial design-review result. The
+baseline may be live behavioral evidence or inspection-based evidence, but it
+must show all of the following against the unchanged contract:
+
+1. Gate 1 approval requires artifact path, intent summary, requirements,
+   `concerns[]`, and `Remaining concerns: None`, but not adversarial review.
+2. `Brainstormer` done reports require design path, AC IDs, requirements,
+   `concerns[]`, and handoff SHA, but not review findings or clean-pass
+   rationale.
+3. Existing pressure tests cover approval packet shape and `concerns[]`, but do
+   not fail a packet that omits adversarial review.
+
+The plan should record the baseline evidence before editing workflow surfaces.
+GREEN verification should then show the same scenarios now require the
+adversarial-review block and halt or reroute when it is missing.
+
+## Adversarial Review of This Design
+
+This section applies the proposed strategy to this design before planning. The
+review context is `same-thread fallback` because the issue is still in
+Brainstormer design drafting and no committed design artifact existed when the
+operator required the review. That is intentionally weaker than the desired
+fresh-context path, so the Gate 1 packet should report it plainly.
+
+Review dimensions checked:
+
+- requirement completeness and acceptance-criteria clarity
+- ownership boundaries between `Team Lead`, `Brainstormer`, `Planner`, and
+  local `Reviewer`
+- plan readiness for `superpowers:writing-plans`
+- workflow-contract pressure-test obligations from `superpowers:writing-skills`
+- loopholes around `concerns[]`, uncommitted artifacts, runtime dependency, and
+  endless review loops
+
+Findings:
+
+- High `## Gate 1 sequence` - The original sequence committed the design before
+  spec self-review and did not state that review-driven edits must be committed
+  before approval. That could let a clean review describe uncommitted state.
+  Disposition: fixed in design by requiring revised design commits before Gate
+  1 approval.
+- High `## Surface Changes` - The original done-report proposal put
+  `adversarial_review_status` on `Brainstormer`, which blurred the review-owned
+  gate evidence with Brainstormer-owned remediation. Disposition: fixed in
+  design by keeping review status on the Team Lead approval packet and limiting
+  Brainstormer to findings-addressed state.
+- Medium `## Review ownership` - The draft said review-owned, but did not say
+  whether this creates a new teammate or reuses existing ownership. Disposition:
+  fixed in design by naming the review result as Team Lead-owned gate evidence,
+  not a new teammate role.
+- Medium `## RED-Phase Baseline Obligation` - The design explains future
+  baseline evidence, but this first draft had no way to apply the new rule to
+  itself before a committed artifact existed. Disposition: fixed in design by
+  recording this same-thread fallback review and requiring the Gate 1 packet to
+  report that weaker context.
+- Low `## Scope control` - The design rejects endless review loops, but an
+  implementation plan could still over-specify repeated review. Disposition:
+  deferred to planning; the plan should include one bounded rerun rule and avoid
+  open-ended specialist loops.
+
+Self-analysis:
+
+- What works: the proposed strategy caught ownership and artifact-state bugs
+  that normal `concerns[]` reporting could easily miss. It forced traceable
+  dispositions and made the review context visible instead of pretending a
+  same-thread review has fresh-context strength.
+- What does not work yet: same-thread review is useful for bootstrapping, but it
+  is not the target quality bar for broad or workflow-critical designs. A later
+  implementation should prefer a fresh-context pass when the runtime supports
+  it.
+- Potential gap: requiring review before approval adds another gate that could
+  slow small changes. The proportionality rule and bounded rerun rule are
+  load-bearing and should be kept concise in implementation.
+- Potential gap: review findings can become a second requirements source if
+  dispositions are vague. The implementation should require requirement-bearing
+  findings to update the design first, then planning, preserving the spec-first
+  loop.
+
+## Acceptance Criteria
+
+### AC-50-1
+
+**Given** `Brainstormer` has authored and committed a design artifact,
+**When** `Team Lead` prepares Gate 1 approval,
+**Then** a distinct adversarial design-review result is required before
+planning can start.
+
+### AC-50-2
+
+**Given** the adversarial review finds material issues,
+**When** Gate 1 approval is presented,
+**Then** those findings are surfaced separately from `concerns[]` and each
+finding has a disposition before `Planner` is invoked.
+
+### AC-50-3
+
+**Given** the adversarial review reports no material issues,
+**When** Gate 1 approval is presented,
+**Then** the packet includes an explicit clean-pass rationale rather than
+silently omitting review findings.
+
+### AC-50-4
+
+**Given** a design touches `skills/**/*.md` or a workflow-contract surface,
+**When** adversarial review runs,
+**Then** it checks loophole closure, rationalization resistance, red-flag
+prompts, token-efficiency targets, RED/GREEN pressure-test obligations, role
+ownership, and stage-gate bypass paths.
+
+### AC-50-5
+
+**Given** a design is revised to address adversarial findings,
+**When** the changes are material,
+**Then** the workflow either reruns the relevant adversarial review dimensions
+or records why a rerun is unnecessary.
+
+### AC-50-6
+
+**Given** the host runtime supports suitable fresh-context or parallel
+specialist review,
+**When** the design review scope is large or workflow-critical,
+**Then** Superteam prefers that capability without making it a portability
+requirement.
+
+### AC-50-7
+
+**Given** the implementation changes workflow-contract guidance,
+**When** verification runs,
+**Then** the relevant pressure-test walkthroughs cover skipped review, collapsed
+review/concerns, missing clean-pass rationale, missing finding dispositions,
+missing workflow-contract dimensions, missing rerun after material changes, and
+runtime support overreach.
+
+## Out of Scope
+
+- Importing BMad or gstack as dependencies.
+- Replacing `superpowers:brainstorming`.
+- Moving implementation review into the design stage.
+- Changing the canonical teammate roster.
+- Requiring subagents in runtimes that do not provide them.

--- a/docs/superpowers/specs/2026-04-27-50-superteam-should-run-adversarial-design-review-before-planning-design.md
+++ b/docs/superpowers/specs/2026-04-27-50-superteam-should-run-adversarial-design-review-before-planning-design.md
@@ -5,8 +5,8 @@
 Add a distinct adversarial design-review gate between `Brainstormer` design
 authoring and `Planner` planning. The gate should complement
 `superpowers:brainstorming`: keep Brainstormer's collaborative design work and
-existing `concerns[]` reporting, but require an explicit review-owned attack on
-the committed design artifact before Gate 1 approval can advance.
+fold approval-relevant concerns into a single `adversarial_review_findings[]`
+concept before Gate 1 approval can advance.
 
 The change should borrow the useful parts of BMad and gstack without importing
 either workflow wholesale:
@@ -22,11 +22,11 @@ either workflow wholesale:
 ## Problem Framing
 
 Today `Brainstormer` owns the design artifact and reports `concerns[]` in the
-Gate 1 approval packet. That catches approval-relevant uncertainty, but it is
-still author-local: the same teammate who authored the design decides which
-concerns to surface. Superteam can therefore proceed to planning with a coherent
-design that has not been attacked for missing requirements, weak assumptions,
-stage-gate bypasses, or plan-readiness gaps.
+Gate 1 approval packet. That catches approval-relevant uncertainty, but the
+field is author-local and too soft: the same teammate who authored the design
+decides which concerns to surface, and the packet has no required signal that
+the design was attacked for missing requirements, weak assumptions, stage-gate
+bypasses, or plan-readiness gaps.
 
 The problem is sharpest for `skills/**/*.md` and workflow-contract changes.
 Those designs can sound complete while still missing RED/GREEN pressure-test
@@ -38,10 +38,11 @@ tasks.
 ## Requirements
 
 - Preserve `Brainstormer` as the owner of the design artifact.
-- Keep `concerns[]` in the approval packet as Brainstormer-owned
-  approval-relevant concerns.
-- Add a separate adversarial-review result that is review-owned and attacks the
-  committed design artifact.
+- Replace Gate 1 `concerns[]` with `adversarial_review_findings[]` as the
+  single approval-relevant finding concept.
+- Preserve finding provenance inside `adversarial_review_findings[]` so
+  Brainstormer-originated concerns and review-originated attacks remain
+  distinguishable without parallel lists.
 - Require the adversarial review before Gate 1 approval can advance to
   `Planner`.
 - Require material findings to be dispositioned before planning.
@@ -65,20 +66,22 @@ Gate 1 should become a two-part approval gate:
 3. `Team Lead` verifies the design artifact exists at the reported path.
 4. `Team Lead` runs or dispatches adversarial design review against the
    committed artifact.
-5. `Brainstormer` dispositions any material adversarial findings.
+5. `Brainstormer` dispositions any material
+   `adversarial_review_findings[]`.
 6. If the design materially changes, `Team Lead` reruns the relevant
    adversarial review dimensions or records why rerun is unnecessary.
-7. `Team Lead` presents the Gate 1 approval packet with both `concerns[]` and
-   the adversarial-review result.
+7. `Team Lead` presents the Gate 1 approval packet with
+   `adversarial_review_findings[]` and the clean-pass rationale when no material
+   findings remain.
 8. Only explicit operator approval advances to `Planner`.
 
 The adversarial-review gate is not a replacement for user approval. It gives
 the operator a sharper packet to approve.
 
-If self-review or adversarial findings change the design after the initial
-commit, `Brainstormer` must commit the revised design before Gate 1 approval is
-presented. Downstream teammates rely on committed branch state, so a clean
-review of uncommitted changes is not enough for handoff.
+If self-review or `adversarial_review_findings[]` change the design after the
+initial commit, `Brainstormer` must commit the revised design before Gate 1
+approval is presented. Downstream teammates rely on committed branch state, so
+a clean review of uncommitted changes is not enough for handoff.
 
 ### Review ownership
 
@@ -95,25 +98,31 @@ The same-thread path is a portability fallback, not a claim that fresh-context
 review is unnecessary.
 
 The review result is Team Lead-owned gate evidence, not a new teammate role.
-`Brainstormer` may report how findings were addressed, but `Team Lead` remains
-responsible for verifying that the review result exists and is fit for approval.
+`Brainstormer` may seed `adversarial_review_findings[]` with known concerns and
+report how findings were addressed, but `Team Lead` remains responsible for
+verifying that the adversarial-review pass occurred and that the findings list
+is fit for approval.
 
 ### Review output
 
-The Gate 1 packet should add an adversarial-review block beside the existing
-Brainstormer fields:
+The Gate 1 packet should replace `concerns[]` with one findings block:
 
 ```markdown
 Adversarial review: <clean | findings dispositioned | blocked>
 Reviewer context: <fresh subagent | parallel specialists | same-thread fallback>
-Findings:
-- <severity> <artifact section/path> - <finding>
+adversarial_review_findings[]:
+- source: <brainstormer | adversarial-review>
+  severity: <blocker | material | minor>
+  location: <artifact section/path>
+  finding: <finding>
   Disposition: <fixed in design | deferred/out of scope | rejected with rationale>
 Clean-pass rationale: <required when no material findings remain>
 ```
 
-`concerns[]` remains Brainstormer-owned. Adversarial findings are review-owned.
-The two surfaces should not be collapsed into one generic "concerns" list.
+`adversarial_review_findings[]` is the single approval-finding surface. The
+`source` field preserves whether a finding came from Brainstormer's own concern
+surfacing or the adversarial review pass. Gate 1 must not advance while any
+`blocker` or `material` finding is still open.
 
 ### Review dimensions
 
@@ -141,7 +150,7 @@ For `skills/**/*.md` and workflow-contract changes, the review must also check:
 
 ### Findings disposition
 
-Material findings must be dispositioned before planning:
+Material `adversarial_review_findings[]` must be dispositioned before planning:
 
 - `fixed in design`: the design changed and the finding is resolved
 - `deferred/out of scope`: the design records why the issue is intentionally not
@@ -181,28 +190,30 @@ Update `skills/superteam/SKILL.md`:
   advance to `Planner`.
 - `Team Lead` owns enforcing the review gate and including the review block in
   approval packets.
-- `Brainstormer` done reports include `adversarial_findings_addressed[]` when
-  findings caused design changes, or an explicit empty result when no design
-  changes were required by review.
+- `Brainstormer` done reports replace `concerns[]` with
+  `adversarial_review_findings[]`, including Brainstormer-originated concerns
+  when present.
 - Team Lead approval packets include `adversarial_review_status`,
-  `adversarial_findings[]`, and `clean_pass_rationale` when applicable.
-- Rationalization table and red flags close bypasses such as "concerns[] is the
-  same as review" and "same-thread review is always enough."
+  `adversarial_review_findings[]`, and `clean_pass_rationale` when applicable.
+- Rationalization table and red flags close bypasses such as
+  "`adversarial_review_findings[]` can be Brainstormer-only" and "same-thread
+  review is always enough."
 
 Update `skills/superteam/agent-spawn-template.md`:
 
 - Team Lead approval packets require the adversarial-review block.
-- Brainstormer done reports include finding-addressed state for design changes
-  made in response to adversarial review.
-- Brainstormer prompts state that `concerns[]` does not satisfy adversarial
-  review.
+- Brainstormer done reports use `adversarial_review_findings[]` instead of
+  `concerns[]`.
+- Brainstormer prompts state that Brainstormer-originated findings do not
+  satisfy the adversarial-review pass by themselves.
 
 Update `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`:
 
-- Add pressure tests for skipped adversarial review, collapsed review/concerns,
-  clean pass without rationale, material findings without disposition, workflow
-  surfaces reviewed without `writing-skills` dimensions, material design changes
-  without rerun, and runtime support treated as a hard dependency.
+- Add pressure tests for skipped adversarial review, Brainstormer-only findings
+  treated as sufficient, clean pass without rationale, material findings without
+  disposition, workflow surfaces reviewed without `writing-skills` dimensions,
+  material design changes without rerun, and runtime support treated as a hard
+  dependency.
 
 ## Loophole-Closure Language
 
@@ -210,7 +221,7 @@ The workflow must close these rationalizations:
 
 | Excuse | Reality |
 |--------|---------|
-| "`concerns[]` already covers review." | `concerns[]` is Brainstormer-owned. Adversarial design review is a separate review-owned attack on the committed artifact. |
+| "`adversarial_review_findings[]` already has Brainstormer entries, so review happened." | Brainstormer-originated findings are useful but not sufficient. Gate 1 also requires an explicit adversarial-review pass against the committed artifact. |
 | "The operator can catch design gaps during approval." | Gate 1 should present an already-attacked design; operator approval is not a substitute for required review. |
 | "No findings means no review block is needed." | A clean pass must include the checked dimensions and a rationale for why no material findings remain. |
 | "Same-thread review is good enough even for workflow contracts." | Fresh-context review is preferred for workflow-critical or broad designs when available; same-thread review is only the portable fallback. |
@@ -219,10 +230,12 @@ The workflow must close these rationalizations:
 
 ## Red Flags
 
-- Gate 1 approval packet has `concerns[]` but no adversarial-review block.
+- Gate 1 approval packet has `adversarial_review_findings[]` entries but no
+  evidence that an adversarial-review pass occurred.
 - Adversarial review reports "clean" without naming checked dimensions.
 - Material findings are listed without dispositions.
-- `Planner` starts from a design with unresolved material adversarial findings.
+- `Planner` starts from a design with unresolved material
+  `adversarial_review_findings[]`.
 - Skill or workflow-contract designs skip RED/GREEN pressure-test obligations.
 - Requirement, ownership, pressure-test, or gate-order changes land after review
   without rerunning affected review dimensions.
@@ -237,16 +250,19 @@ baseline may be live behavioral evidence or inspection-based evidence, but it
 must show all of the following against the unchanged contract:
 
 1. Gate 1 approval requires artifact path, intent summary, requirements,
-   `concerns[]`, and `Remaining concerns: None`, but not adversarial review.
+   `concerns[]`, and `Remaining concerns: None`, but not
+   `adversarial_review_findings[]` or adversarial review.
 2. `Brainstormer` done reports require design path, AC IDs, requirements,
-   `concerns[]`, and handoff SHA, but not review findings or clean-pass
-   rationale.
+   `concerns[]`, and handoff SHA, but not `adversarial_review_findings[]` or
+   clean-pass rationale.
 3. Existing pressure tests cover approval packet shape and `concerns[]`, but do
-   not fail a packet that omits adversarial review.
+   not fail a packet that omits `adversarial_review_findings[]` or adversarial
+   review evidence.
 
 The plan should record the baseline evidence before editing workflow surfaces.
 GREEN verification should then show the same scenarios now require the
-adversarial-review block and halt or reroute when it is missing.
+`adversarial_review_findings[]`, adversarial-review evidence, and halt or
+reroute when either is missing.
 
 ## Adversarial Review of This Design
 
@@ -263,8 +279,8 @@ Review dimensions checked:
   local `Reviewer`
 - plan readiness for `superpowers:writing-plans`
 - workflow-contract pressure-test obligations from `superpowers:writing-skills`
-- loopholes around `concerns[]`, uncommitted artifacts, runtime dependency, and
-  endless review loops
+- loopholes around Brainstormer-only findings, uncommitted artifacts, runtime
+  dependency, and endless review loops
 
 Findings:
 
@@ -276,8 +292,8 @@ Findings:
 - High `## Surface Changes` - The original done-report proposal put
   `adversarial_review_status` on `Brainstormer`, which blurred the review-owned
   gate evidence with Brainstormer-owned remediation. Disposition: fixed in
-  design by keeping review status on the Team Lead approval packet and limiting
-  Brainstormer to findings-addressed state.
+  design by keeping review status on the Team Lead approval packet while
+  allowing Brainstormer to seed and address `adversarial_review_findings[]`.
 - Medium `## Review ownership` - The draft said review-owned, but did not say
   whether this creates a new teammate or reuses existing ownership. Disposition:
   fixed in design by naming the review result as Team Lead-owned gate evidence,
@@ -291,13 +307,22 @@ Findings:
   implementation plan could still over-specify repeated review. Disposition:
   deferred to planning; the plan should include one bounded rerun rule and avoid
   open-ended specialist loops.
+- Medium `## Review output` - Operator feedback showed that two parallel
+  concepts, `concerns[]` and adversarial findings, add unnecessary cognitive
+  overhead. Disposition: fixed in design by merging them into
+  `adversarial_review_findings[]` with `source` metadata, while keeping the
+  explicit adversarial-review pass as required gate evidence.
 
 Self-analysis:
 
 - What works: the proposed strategy caught ownership and artifact-state bugs
-  that normal `concerns[]` reporting could easily miss. It forced traceable
+  that author-local finding reporting could easily miss. It forced traceable
   dispositions and made the review context visible instead of pretending a
   same-thread review has fresh-context strength.
+- What changed after operator review: the design now uses a single
+  `adversarial_review_findings[]` concept instead of separate `concerns[]` and
+  adversarial findings. This reduces approval-packet complexity while preserving
+  provenance through `source`.
 - What does not work yet: same-thread review is useful for bootstrapping, but it
   is not the target quality bar for broad or workflow-critical designs. A later
   implementation should prefer a fresh-context pass when the runtime supports
@@ -305,10 +330,10 @@ Self-analysis:
 - Potential gap: requiring review before approval adds another gate that could
   slow small changes. The proportionality rule and bounded rerun rule are
   load-bearing and should be kept concise in implementation.
-- Potential gap: review findings can become a second requirements source if
-  dispositions are vague. The implementation should require requirement-bearing
-  findings to update the design first, then planning, preserving the spec-first
-  loop.
+- Potential gap: `adversarial_review_findings[]` can become a second
+  requirements source if dispositions are vague. The implementation should
+  require requirement-bearing findings to update the design first, then
+  planning, preserving the spec-first loop.
 
 ## Acceptance Criteria
 
@@ -323,8 +348,9 @@ planning can start.
 
 **Given** the adversarial review finds material issues,
 **When** Gate 1 approval is presented,
-**Then** those findings are surfaced separately from `concerns[]` and each
-finding has a disposition before `Planner` is invoked.
+**Then** those findings are recorded in `adversarial_review_findings[]` with
+`source: adversarial-review`, and each material finding has a disposition before
+`Planner` is invoked.
 
 ### AC-50-3
 
@@ -361,9 +387,9 @@ requirement.
 **Given** the implementation changes workflow-contract guidance,
 **When** verification runs,
 **Then** the relevant pressure-test walkthroughs cover skipped review, collapsed
-review/concerns, missing clean-pass rationale, missing finding dispositions,
-missing workflow-contract dimensions, missing rerun after material changes, and
-runtime support overreach.
+Brainstormer-only findings treated as sufficient, missing clean-pass rationale,
+missing finding dispositions, missing workflow-contract dimensions, missing
+rerun after material changes, and runtime support overreach.
 
 ## Out of Scope
 

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -188,9 +188,15 @@ Before asking for approval:
 2. Return the exact artifact path under review.
 3. Include a concise intent summary of what the artifact changes or decides.
 4. Include the full requirement set currently under review.
-5. Always report `concerns[]` in the approval packet, including an explicit empty result when no approval-relevant concerns remain.
-6. Render the operator-facing no-concerns line exactly as `Remaining concerns: None`.
-7. Surface any remaining approval-relevant concerns that could materially affect the decision to approve, revise, or narrow the design.
+5. Include `adversarial_review_findings[]` as the single approval-finding surface, including Brainstormer-originated concerns and adversarial-review findings.
+6. Preserve finding provenance with `source: brainstormer | adversarial-review`.
+7. Require an explicit adversarial-review result before approval can advance: `clean`, `findings dispositioned`, or `blocked`.
+8. Include `clean_pass_rationale` when no blocker or material findings remain.
+9. Halt approval when any blocker or material finding is still open.
+
+Before Gate 1 approval is presented, `Team Lead` must run or dispatch an adversarial design review against the committed design artifact. Fresh-context or parallel specialist review is preferred for workflow-critical or broad designs when the runtime supports it; same-thread review is the portable fallback. Brainstormer-originated findings alone do not satisfy this gate.
+
+If adversarial review changes the design, `Brainstormer` must commit the revised artifact before approval. Material requirement, ownership, pressure-test, or gate-order changes require rerunning the affected review dimensions or recording why rerun is unnecessary.
 
 If the approval packet is too large to present cleanly, split it into multiple approval requests or sections. Do not collapse it into a vague fallback summary.
 
@@ -220,6 +226,9 @@ Headline behaviors:
 - Route work to the correct teammate.
 - Enforce gates and halt on unsatisfied contracts.
 - Route requirement-changing deltas back through `Brainstormer`.
+- Before Gate 1 approval can advance, enforce adversarial design review against the committed design artifact.
+- Include `adversarial_review_status`, `adversarial_review_findings[]`, and `clean_pass_rationale` when applicable in Gate 1 approval packets.
+- Treat Brainstormer-originated findings as useful input but not proof that adversarial review occurred.
 - Recommend `superpowers:using-superpowers`.
 - Also recommend `superpowers:dispatching-parallel-agents` when splitting bounded, independent work, and keep tightly coupled or interactive steps in the foreground.
 - During execute-phase delegation, bind directly to the chosen execution-mode skill (`superpowers:subagent-driven-development` for subagent-driven, or the host's native team-mode capability for team mode). Do NOT route execute-phase delegations through `superpowers:executing-plans` on default paths.
@@ -233,9 +242,11 @@ Headline behaviors:
 - Return the exact design doc path.
 - Return the ordered active AC list.
 - Report the concise intent summary and the full requirement set used for approval.
-- Always report `concerns[]` when requesting approval, including an explicit empty result when no approval-relevant concerns remain under the contract.
-- Render the operator-facing no-concerns line exactly as `Remaining concerns: None`.
-- Surface any remaining approval-relevant concerns when requesting approval.
+- Report `adversarial_review_findings[]` when requesting approval, including Brainstormer-originated concerns and adversarial-review findings.
+- Preserve `source: brainstormer | adversarial-review` on every finding.
+- Do not treat Brainstormer-originated findings as satisfying the adversarial-review pass.
+- Include the clean-pass rationale when the adversarial-review result is clean.
+- Commit any design changes caused by self-review or adversarial findings before reporting done or handing off to `Planner`.
 - Include the handoff commit SHA for the committed design artifact in the done report.
 - Determine the intended surface from the issue before authoring requirements. When the design under brainstorming will touch `skills/**/*.md` or any workflow-contract surface (the `superteam` skill itself, agent-spawn templates, PR-body templates, or other repository-owned workflow contracts), invoke `superpowers:writing-skills` BEFORE authoring requirements. If the issue plausibly targets those surfaces and the exact files are uncertain, invoke `superpowers:writing-skills` first or halt for clarification. This is unconditional on the trigger, not "consider"; once the design touches or plausibly targets a skill or workflow-contract surface, writing-skills is the load-bearing reference for what the design must contain (loophole-closure language, rationalization-table rows, red-flags bullets, token-efficiency targets, RED-phase baseline obligation). A `Brainstormer` who skips writing-skills at design time forces every downstream teammate to re-derive it. Not even when an authority claim is cited. Not even under deadline pressure.
 - Recommend `superpowers:brainstorming`.
@@ -325,7 +336,9 @@ Artifact-producing teammate done reports must anchor on committed handoff state 
 - `ac_ids[]`: ordered list of active AC IDs
 - `intent_summary`: concise summary of what the artifact changes or decides
 - `requirements[]`: full requirement set currently under review
-- `concerns[]`: remaining approval-relevant concerns that could materially affect approval, or an explicit empty result when none exist
+- `adversarial_review_status`: `clean` | `findings dispositioned` | `blocked`
+- `adversarial_review_findings[]`: findings relevant to approval, with `source`, `severity`, `location`, `finding`, and `disposition`
+- `clean_pass_rationale`: required when no blocker or material findings remain
 - `handoff_commit_sha`: commit containing the design artifact used for approval and planning
 
 ### Planner done report
@@ -419,13 +432,19 @@ Before resolving or replying to comments tied to a prior branch state:
 | "Dirty working tree? I can stash and continue." | The canonical `/github-flows:new-branch` algorithm refuses on a dirty working tree. `superteam` halts with `superteam halted at Team Lead: dirty working tree blocks auto-switch to issue branch`. Pre-flight does NOT stash on the operator's behalf. |
 | "Rebase conflict on the existing issue branch is fine; I'll abort and try again." | The canonical algorithm forbids `git rebase --abort` on the operator's behalf. `superteam` halts and surfaces the conflict. |
 | "We can re-implement the kebab + checkout + rebase logic inside `superteam` so we don't depend on `github-flows`." | `/github-flows:new-branch` is the authoritative algorithm. `superteam` references it; it does not fork it. Divergence between the two is a contract bug. |
+| "`adversarial_review_findings[]` already has Brainstormer entries, so review happened." | Brainstormer-originated findings are useful but not sufficient. Gate 1 requires an explicit adversarial-review pass against the committed artifact. |
+| "No findings means no review evidence is needed." | A clean adversarial-review result must include checked dimensions and `clean_pass_rationale`; silence is not evidence. |
+| "A finding changed the design, but the earlier review still applies." | Material requirement, ownership, pressure-test, or gate-order changes require rerunning affected review dimensions or recording why rerun is unnecessary. |
 
 ## Red flags
 
 - Using older stage-only language where the canonical teammate roster should be used.
 - Asking for design approval before verifying the cited artifact exists.
 - Approval requests that omit the artifact path, concise intent summary, or full requirement set.
-- Approval requests that omit `concerns[]` or render the no-concerns case as anything other than `Remaining concerns: None`.
+- Gate 1 approval packet has `adversarial_review_findings[]` entries but no evidence that an adversarial-review pass occurred.
+- Adversarial review reports `clean` without checked dimensions or `clean_pass_rationale`.
+- `Planner` starts while a blocker or material `adversarial_review_findings[]` item remains open.
+- Brainstormer-originated findings are treated as a replacement for adversarial review.
 - Oversized approval requests collapsed into a vague summary instead of split into clean sections.
 - Approval requests that hide real approval-relevant concerns.
 - Replaying already-approved content instead of sending delta-only approval after revisions.

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -446,7 +446,7 @@ Before resolving or replying to comments tied to a prior branch state:
 - `Planner` starts while a blocker or material `adversarial_review_findings[]` item remains open.
 - Brainstormer-originated findings are treated as a replacement for adversarial review.
 - Oversized approval requests collapsed into a vague summary instead of split into clean sections.
-- Approval requests that hide real approval-relevant concerns.
+- Approval requests that hide real approval-relevant findings.
 - Replaying already-approved content instead of sending delta-only approval after revisions.
 - Touching governed files without canonical-rule discovery from repository guidance.
 - Delegated teammate work that either ignores available background-agent execution for clearly bounded, independent work or forces background execution on tightly coupled, clarification-heavy work.

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -191,10 +191,13 @@ Before asking for approval:
 5. Include `adversarial_review_findings[]` as the single approval-finding surface, including Brainstormer-originated concerns and adversarial-review findings.
 6. Preserve finding provenance with `source: brainstormer | adversarial-review`.
 7. Require an explicit adversarial-review result before approval can advance: `clean`, `findings dispositioned`, or `blocked`.
-8. Include `clean_pass_rationale` when no blocker or material findings remain.
-9. Halt approval when any blocker or material finding is still open.
+8. Include `reviewer_context`: `fresh subagent`, `parallel specialists`, or `same-thread fallback`.
+9. Include `clean_pass_rationale` with checked dimensions when no blocker or material findings remain.
+10. Halt approval when any blocker or material finding is still open.
 
 Before Gate 1 approval is presented, `Team Lead` must run or dispatch an adversarial design review against the committed design artifact. Fresh-context or parallel specialist review is preferred for workflow-critical or broad designs when the runtime supports it; same-thread review is the portable fallback. Brainstormer-originated findings alone do not satisfy this gate.
+
+For designs that touch `skills/**/*.md` or any workflow-contract surface, the adversarial review must check the `superpowers:writing-skills` dimensions: RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths.
 
 If adversarial review changes the design, `Brainstormer` must commit the revised artifact before approval. Material requirement, ownership, pressure-test, or gate-order changes require rerunning the affected review dimensions or recording why rerun is unnecessary.
 
@@ -227,7 +230,7 @@ Headline behaviors:
 - Enforce gates and halt on unsatisfied contracts.
 - Route requirement-changing deltas back through `Brainstormer`.
 - Before Gate 1 approval can advance, enforce adversarial design review against the committed design artifact.
-- Include `adversarial_review_status`, `adversarial_review_findings[]`, and `clean_pass_rationale` when applicable in Gate 1 approval packets.
+- Include `adversarial_review_status`, `reviewer_context`, `adversarial_review_findings[]`, and `clean_pass_rationale` when applicable in Gate 1 approval packets.
 - Treat Brainstormer-originated findings as useful input but not proof that adversarial review occurred.
 - Recommend `superpowers:using-superpowers`.
 - Also recommend `superpowers:dispatching-parallel-agents` when splitting bounded, independent work, and keep tightly coupled or interactive steps in the foreground.
@@ -245,7 +248,7 @@ Headline behaviors:
 - Report `adversarial_review_findings[]` when requesting approval, including Brainstormer-originated concerns and adversarial-review findings.
 - Preserve `source: brainstormer | adversarial-review` on every finding.
 - Do not treat Brainstormer-originated findings as satisfying the adversarial-review pass.
-- Include the clean-pass rationale when the adversarial-review result is clean.
+- Include reviewer context and checked dimensions in the clean-pass rationale when the adversarial-review result is clean.
 - Commit any design changes caused by self-review or adversarial findings before reporting done or handing off to `Planner`.
 - Include the handoff commit SHA for the committed design artifact in the done report.
 - Determine the intended surface from the issue before authoring requirements. When the design under brainstorming will touch `skills/**/*.md` or any workflow-contract surface (the `superteam` skill itself, agent-spawn templates, PR-body templates, or other repository-owned workflow contracts), invoke `superpowers:writing-skills` BEFORE authoring requirements. If the issue plausibly targets those surfaces and the exact files are uncertain, invoke `superpowers:writing-skills` first or halt for clarification. This is unconditional on the trigger, not "consider"; once the design touches or plausibly targets a skill or workflow-contract surface, writing-skills is the load-bearing reference for what the design must contain (loophole-closure language, rationalization-table rows, red-flags bullets, token-efficiency targets, RED-phase baseline obligation). A `Brainstormer` who skips writing-skills at design time forces every downstream teammate to re-derive it. Not even when an authority claim is cited. Not even under deadline pressure.
@@ -337,8 +340,9 @@ Artifact-producing teammate done reports must anchor on committed handoff state 
 - `intent_summary`: concise summary of what the artifact changes or decides
 - `requirements[]`: full requirement set currently under review
 - `adversarial_review_status`: `clean` | `findings dispositioned` | `blocked`
+- `reviewer_context`: `fresh subagent` | `parallel specialists` | `same-thread fallback`
 - `adversarial_review_findings[]`: findings relevant to approval, with `source`, `severity`, `location`, `finding`, and `disposition`
-- `clean_pass_rationale`: required when no blocker or material findings remain
+- `clean_pass_rationale`: required with checked dimensions when no blocker or material findings remain
 - `handoff_commit_sha`: commit containing the design artifact used for approval and planning
 
 ### Planner done report
@@ -433,7 +437,8 @@ Before resolving or replying to comments tied to a prior branch state:
 | "Rebase conflict on the existing issue branch is fine; I'll abort and try again." | The canonical algorithm forbids `git rebase --abort` on the operator's behalf. `superteam` halts and surfaces the conflict. |
 | "We can re-implement the kebab + checkout + rebase logic inside `superteam` so we don't depend on `github-flows`." | `/github-flows:new-branch` is the authoritative algorithm. `superteam` references it; it does not fork it. Divergence between the two is a contract bug. |
 | "`adversarial_review_findings[]` already has Brainstormer entries, so review happened." | Brainstormer-originated findings are useful but not sufficient. Gate 1 requires an explicit adversarial-review pass against the committed artifact. |
-| "No findings means no review evidence is needed." | A clean adversarial-review result must include checked dimensions and `clean_pass_rationale`; silence is not evidence. |
+| "No findings means no review evidence is needed." | A clean adversarial-review result must include `reviewer_context`, checked dimensions, and `clean_pass_rationale`; silence is not evidence. |
+| "This is a workflow-contract design, but a generic review is enough." | Designs touching `skills/**/*.md` or workflow-contract surfaces require the `superpowers:writing-skills` review dimensions: RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths. |
 | "A finding changed the design, but the earlier review still applies." | Material requirement, ownership, pressure-test, or gate-order changes require rerunning affected review dimensions or recording why rerun is unnecessary. |
 
 ## Red flags
@@ -442,9 +447,10 @@ Before resolving or replying to comments tied to a prior branch state:
 - Asking for design approval before verifying the cited artifact exists.
 - Approval requests that omit the artifact path, concise intent summary, or full requirement set.
 - Gate 1 approval packet has `adversarial_review_findings[]` entries but no evidence that an adversarial-review pass occurred.
-- Adversarial review reports `clean` without checked dimensions or `clean_pass_rationale`.
+- Adversarial review reports `clean` without `reviewer_context`, checked dimensions, or `clean_pass_rationale`.
 - `Planner` starts while a blocker or material `adversarial_review_findings[]` item remains open.
 - Brainstormer-originated findings are treated as a replacement for adversarial review.
+- Workflow-contract design approval proceeds without the `superpowers:writing-skills` adversarial-review dimensions.
 - Oversized approval requests collapsed into a vague summary instead of split into clean sections.
 - Approval requests that hide real approval-relevant findings.
 - Replaying already-approved content instead of sending delta-only approval after revisions.

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -52,8 +52,10 @@ Each approval packet must include:
 - `adversarial_review_findings[]`, including Brainstormer-originated concerns and adversarial-review findings
 - `source: brainstormer | adversarial-review` on each finding
 - `adversarial_review_status`: `clean`, `findings dispositioned`, or `blocked`
-- `clean_pass_rationale` when no blocker or material findings remain
+- `reviewer_context`: `fresh subagent`, `parallel specialists`, or `same-thread fallback`
+- `clean_pass_rationale` with checked dimensions when no blocker or material findings remain
 Before Gate 1 approval can advance, run or dispatch adversarial design review against the committed artifact. Brainstormer-originated findings alone do not satisfy this gate.
+For designs that touch `skills/**/*.md` or workflow-contract surfaces, the adversarial review must check the `superpowers:writing-skills` dimensions: RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths.
 If the approval packet is too large, split it instead of collapsing it.
 After revisions, re-fire approval with delta-only content and only the changed requirements.
 ```
@@ -78,8 +80,9 @@ Done-report contract:
 - `intent_summary`: concise summary of what the artifact changes or decides
 - `requirements[]`: full requirement set currently under review
 - `adversarial_review_status`: `clean` | `findings dispositioned` | `blocked`
+- `reviewer_context`: `fresh subagent` | `parallel specialists` | `same-thread fallback`
 - `adversarial_review_findings[]`: findings relevant to approval, with `source`, `severity`, `location`, `finding`, and `disposition`
-- `clean_pass_rationale`: required when no blocker or material findings remain
+- `clean_pass_rationale`: required with checked dimensions when no blocker or material findings remain
 - Do not treat Brainstormer-originated findings as satisfying the adversarial-review pass. If adversarial review changes the design, commit the revised artifact before handoff.
 - `handoff_commit_sha`: commit containing the design artifact used for approval and planning
 ```

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -49,9 +49,11 @@ Each approval packet must include:
 - exact artifact path
 - concise intent summary
 - full requirement set under review
-- `concerns[]`, including an explicit empty result when none exist under the contract
-- operator-facing no-concerns rendering exactly as `Remaining concerns: None`
-- remaining approval-relevant concerns when they exist
+- `adversarial_review_findings[]`, including Brainstormer-originated concerns and adversarial-review findings
+- `source: brainstormer | adversarial-review` on each finding
+- `adversarial_review_status`: `clean`, `findings dispositioned`, or `blocked`
+- `clean_pass_rationale` when no blocker or material findings remain
+Before Gate 1 approval can advance, run or dispatch adversarial design review against the committed artifact. Brainstormer-originated findings alone do not satisfy this gate.
 If the approval packet is too large, split it instead of collapsing it.
 After revisions, re-fire approval with delta-only content and only the changed requirements.
 ```
@@ -75,8 +77,10 @@ Done-report contract:
 - `ac_ids[]`: ordered list of active AC IDs
 - `intent_summary`: concise summary of what the artifact changes or decides
 - `requirements[]`: full requirement set currently under review
-- `concerns[]`: remaining approval-relevant concerns that could materially affect approval, or an explicit empty result when none exist
-Operator-facing approval packets must render the no-concerns case exactly as `Remaining concerns: None`.
+- `adversarial_review_status`: `clean` | `findings dispositioned` | `blocked`
+- `adversarial_review_findings[]`: findings relevant to approval, with `source`, `severity`, `location`, `finding`, and `disposition`
+- `clean_pass_rationale`: required when no blocker or material findings remain
+- Do not treat Brainstormer-originated findings as satisfying the adversarial-review pass. If adversarial review changes the design, commit the revised artifact before handoff.
 - `handoff_commit_sha`: commit containing the design artifact used for approval and planning
 ```
 


### PR DESCRIPTION
## Summary

- Adds a Superteam Gate 1 adversarial design-review requirement before planning.
- Replaces `concerns[]` with `adversarial_review_findings[]` as the single approval-finding surface.
- Adds pressure-test scenarios for missing review evidence, unresolved findings, missing clean-pass rationale, workflow-contract dimensions, reruns, and runtime fallback.

## Linked issue

- Closes #50

## Acceptance criteria

### AC-50-1

Gate 1 now requires a distinct adversarial design-review result before planning can start.

- [x] Local evidence — Codex CLI | macOS worktree | @tlmader | 2026-04-27T08:21:29Z

### AC-50-2

Material adversarial findings are recorded in `adversarial_review_findings[]` with provenance and dispositions before `Planner` can run.

- [x] Local evidence — Codex CLI | macOS worktree | @tlmader | 2026-04-27T08:21:29Z

### AC-50-3

Clean adversarial review requires `clean_pass_rationale` instead of silent omission.

- [x] Local evidence — Codex CLI | macOS worktree | @tlmader | 2026-04-27T08:21:29Z

### AC-50-4

Workflow-contract designs now have stricter adversarial-review pressure-test coverage for writing-skills dimensions.

- [x] Local evidence — Codex CLI | macOS worktree | @tlmader | 2026-04-27T08:21:29Z

### AC-50-5

Material design changes after adversarial review require rerunning affected review dimensions or recording why no rerun is needed.

- [x] Local evidence — Codex CLI | macOS worktree | @tlmader | 2026-04-27T08:21:29Z

### AC-50-6

Fresh-context or parallel specialist review is preferred for broad or workflow-critical scope without becoming a portability requirement.

- [x] Local evidence — Codex CLI | macOS worktree | @tlmader | 2026-04-27T08:21:29Z

### AC-50-7

Pressure-test walkthrough coverage was added for skipped review, Brainstormer-only findings, missing clean-pass rationale, missing dispositions, missing workflow-contract dimensions, missing rerun after material changes, and runtime overreach.

- [x] Local evidence — Codex CLI | macOS worktree | @tlmader | 2026-04-27T08:21:29Z

## Validation

- `pnpm lint:md`
- `node scripts/check-plugin-versions.mjs`
- `git diff --check origin/main...HEAD`
- Targeted `rg` checks for `adversarial_review_findings[]`, `adversarial_review_status`, `clean_pass_rationale`, and the new pressure-test headings

## Docs updated

- [x] Updated in this PR
