### PR TITLE
docs: #49 use complete company name

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ A run is only complete when the published branch state is stable enough to hand 
 
 ### Claude Code
 
-1. Register the Patina marketplace:
+1. Register the Patina Project marketplace:
 
    ```text
    /plugin marketplace add patinaproject/skills
@@ -143,7 +143,7 @@ Agent Teams is optional. If you do not enable it, Superteam still works with the
 
 ### OpenAI Codex CLI
 
-1. Register the Patina marketplace:
+1. Register the Patina Project marketplace:
 
    ```bash
    codex plugin marketplace add patinaproject/skills
@@ -231,5 +231,5 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`AGENTS.md`](./AGENTS.md).
 ## Related
 
 - [`skills/superteam/SKILL.md`](./skills/superteam/SKILL.md) — skill contract.
-- [`patinaproject/skills`](https://github.com/patinaproject/skills) — marketplace distributing Patina plugins.
+- [`patinaproject/skills`](https://github.com/patinaproject/skills) — marketplace distributing Patina Project plugins.
 - [`patinaproject/bootstrap`](https://github.com/patinaproject/bootstrap) — scaffolding skill that emitted this repo's baseline.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,7 +79,7 @@ Wire it into `.github/workflows/release.yml` by replacing the `token:` input on 
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 ```
 
-The default code path stays `secrets.GITHUB_TOKEN` in the emitted template so forks outside Patina don't need to provision a Patina-specific secret.
+The default code path stays `secrets.GITHUB_TOKEN` in the emitted template so forks outside Patina Project don't need to provision a Patina Project-specific secret.
 
 ### Tag ruleset caution
 
@@ -126,7 +126,7 @@ Determined from commit types — no human choice:
 
 ## Distribution via `patinaproject/skills`
 
-When a release is published **and the repository owner is `patinaproject`**, the release workflow automatically dispatches `plugin-release-bump.yml` on `patinaproject/skills`. That marketplace repo opens (or updates) a PR bumping this plugin's pinned `ref` across every Patina marketplace manifest.
+When a release is published **and the repository owner is `patinaproject`**, the release workflow automatically dispatches `plugin-release-bump.yml` on `patinaproject/skills`. That marketplace repo opens (or updates) a PR bumping this plugin's pinned `ref` across every Patina Project marketplace manifest.
 
 No per-repo opt-in is required — the `github.repository_owner == 'patinaproject'` check on the `notify-patinaproject-skills` job gates this behavior. Forks in other orgs skip the job entirely and don't need any of the setup below.
 

--- a/docs/superpowers/plans/2026-04-27-49-use-patina-project-as-the-complete-company-name-plan.md
+++ b/docs/superpowers/plans/2026-04-27-49-use-patina-project-as-the-complete-company-name-plan.md
@@ -34,7 +34,7 @@ verify no protected identifiers were renamed.
   Run:
 
   ```bash
-  rg -n '"Patina marketplace"|"Patina plugins"|"outside Patina"|"Patina marketplace manifest"' README.md RELEASING.md
+  rg -n 'Patina marketplace|Patina plugins|outside Patina|Patina marketplace manifest' README.md RELEASING.md
   ```
 
   Expected before implementation: output includes the known affected
@@ -83,7 +83,7 @@ verify no protected identifiers were renamed.
   Run:
 
   ```bash
-  ! rg -n '"Patina marketplace"|"Patina plugins"|"outside Patina"|"Patina marketplace manifest"' README.md RELEASING.md
+  ! rg -n -P 'Patina marketplace|Patina plugins|outside Patina(?! Project)|Patina marketplace manifest' README.md RELEASING.md
   ```
 
   Expected after implementation: command succeeds because the old
@@ -94,7 +94,7 @@ verify no protected identifiers were renamed.
   Run:
 
   ```bash
-  rg -n '"Patina Project marketplace"|"Patina Project plugins"|"outside Patina Project"|"Patina Project marketplace manifest"' README.md RELEASING.md
+  rg -n 'Patina Project marketplace|Patina Project plugins|outside Patina Project|Patina Project marketplace manifest' README.md RELEASING.md
   ```
 
   Expected after implementation: output includes the replacement phrases.

--- a/docs/superpowers/plans/2026-04-27-49-use-patina-project-as-the-complete-company-name-plan.md
+++ b/docs/superpowers/plans/2026-04-27-49-use-patina-project-as-the-complete-company-name-plan.md
@@ -1,0 +1,129 @@
+# Plan: Use Patina Project as the complete company name [#49](https://github.com/patinaproject/superteam/issues/49)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update public-facing docs prose so the company is displayed as
+`Patina Project` while preserving all `patina` identifiers.
+
+**Architecture:** This is a documentation-only change. Use targeted search
+commands as acceptance tests, edit only `README.md` and `RELEASING.md`, then
+verify no protected identifiers were renamed.
+
+**Tech Stack:** Markdown, `rg`, `pnpm lint:md`.
+
+---
+
+## File Structure
+
+- Modify `README.md`: public installation and related-repository prose.
+- Modify `RELEASING.md`: release fallback and marketplace prose.
+- Do not modify machine-readable metadata, workflows, package files, URLs,
+  domains, repository slugs, or generated changelog content.
+
+## Task 1: Prove Current Public-Facing Short Name Usage
+
+**Files:**
+
+- Inspect: `README.md`
+- Inspect: `RELEASING.md`
+
+- [ ] **Step 1: Run the failing acceptance search**
+
+  Run:
+
+  ```bash
+  rg -n '"Patina marketplace"|"Patina plugins"|"outside Patina"|"Patina marketplace manifest"' README.md RELEASING.md
+  ```
+
+  Expected before implementation: output includes the known affected
+  public-facing `Patina` phrases from issue #49.
+
+## Task 2: Update Public-Facing Prose
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `RELEASING.md`
+
+- [ ] **Step 1: Replace only public-facing company-display prose**
+
+  Update the matched prose as follows:
+
+  ```text
+  Register the Patina marketplace
+  -> Register the Patina Project marketplace
+
+  marketplace distributing Patina plugins
+  -> marketplace distributing Patina Project plugins
+
+  forks outside Patina
+  -> forks outside Patina Project
+
+  Patina marketplace manifest
+  -> Patina Project marketplace manifest
+  ```
+
+  Leave identifier-shaped strings unchanged, including
+  `patinaproject/skills`, `patinaproject/superteam`,
+  `patina-project-automation`, `PATINAPROJECT_AUTOMATION_APP_ID`, URLs, and
+  email domains.
+
+## Task 3: Verify Acceptance Criteria
+
+**Files:**
+
+- Inspect: `README.md`
+- Inspect: `RELEASING.md`
+- Inspect: repository Markdown
+
+- [ ] **Step 1: Verify old public-facing phrases are gone**
+
+  Run:
+
+  ```bash
+  ! rg -n '"Patina marketplace"|"Patina plugins"|"outside Patina"|"Patina marketplace manifest"' README.md RELEASING.md
+  ```
+
+  Expected after implementation: command succeeds because the old
+  public-facing phrases are absent.
+
+- [ ] **Step 2: Verify new public-facing phrases exist**
+
+  Run:
+
+  ```bash
+  rg -n '"Patina Project marketplace"|"Patina Project plugins"|"outside Patina Project"|"Patina Project marketplace manifest"' README.md RELEASING.md
+  ```
+
+  Expected after implementation: output includes the replacement phrases.
+
+- [ ] **Step 3: Verify protected identifiers remain**
+
+  Run:
+
+  ```bash
+  rg -n 'patinaproject/skills|patinaproject/superteam|patina-project-automation|PATINAPROJECT_AUTOMATION_APP_ID|patinaproject.com' README.md RELEASING.md .claude-plugin .codex-plugin package.json .github
+  ```
+
+  Expected after implementation: output still includes the protected
+  identifier-shaped strings.
+
+- [ ] **Step 4: Run Markdown lint**
+
+  Run:
+
+  ```bash
+  pnpm lint:md
+  ```
+
+  Expected after implementation: `Summary: 0 error(s)`.
+
+## Self-Review
+
+- AC-49-1 is covered by Task 1, Task 2, and Task 3 steps 1-2.
+- AC-49-2 is covered by Task 2 and Task 3 step 3.
+- The plan intentionally avoids generated changelog content and historical
+  planning artifacts.
+- No placeholder steps remain.

--- a/docs/superpowers/specs/2026-04-27-49-use-patina-project-as-the-complete-company-name-design.md
+++ b/docs/superpowers/specs/2026-04-27-49-use-patina-project-as-the-complete-company-name-design.md
@@ -1,0 +1,65 @@
+# Design: Use Patina Project as the complete company name [#49](https://github.com/patinaproject/superteam/issues/49)
+
+## Intent
+
+Update public-facing documentation so display references to the company use the
+complete name, `Patina Project`, while preserving machine-readable
+`patina`/`patinaproject` identifiers exactly as they are.
+
+## Requirements
+
+- Replace public-facing prose that names the company as `Patina` with
+  `Patina Project`.
+- Preserve repository owners, repository slugs, URLs, domains, package names,
+  command examples, GitHub App names, bot identities, secrets, and other
+  machine-readable identifiers.
+- Audit the known affected files, `README.md` and `RELEASING.md`, plus adjacent
+  repository documentation surfaces found by text search.
+- Keep the change documentation-only and avoid unrelated wording rewrites.
+- Use acceptance criteria IDs in the `AC-49-<n>` format.
+
+## Design
+
+### Documentation wording
+
+Update the visible prose in `README.md` where the marketplace is described as
+the `Patina marketplace` or as distributing `Patina plugins`. These should read
+as the `Patina Project marketplace` and `Patina Project plugins`.
+
+Update the visible prose in `RELEASING.md` where forks outside the company and
+marketplace manifests are described with the shortened company name. Those
+sentences should refer to `Patina Project` while retaining the surrounding
+release and marketplace meaning.
+
+Do not expand lowercase or identifier-shaped uses such as `patinaproject`,
+`patinaproject/skills`, `patinaproject/superteam`,
+`patina-project-automation`, `PATINAPROJECT_AUTOMATION_APP_ID`, email domains,
+or GitHub URLs. Those strings are identifiers rather than company-display prose.
+
+### Verification
+
+Verification should prove both sides of the issue:
+
+- remaining uppercase `Patina` prose is either already `Patina Project` or a
+  deliberate identifier/name context such as `patina-project-automation`
+- lowercase `patina` and `patinaproject` identifiers remain present and
+  unchanged
+- Markdown linting passes after the documentation edits
+
+Use targeted search output before and after the edit, then run
+`pnpm lint:md`.
+
+## Acceptance Criteria
+
+- **AC-49-1**: Given a public-facing docs sentence refers to the company as
+  `Patina`, when the wording is updated, then it uses `Patina Project` instead.
+- **AC-49-2**: Given a repository slug, URL, package name, or identifier
+  contains `patina`, when the audit is performed, then that identifier is
+  preserved.
+
+## Out of Scope
+
+- Renaming the `patinaproject` GitHub owner or repository references.
+- Renaming domains, email addresses, package names, secrets, GitHub App names,
+  bot identities, or workflow identifiers.
+- Editing generated changelog content or historical planning artifacts.


### PR DESCRIPTION
# Pull Request

PR title rule for squash merges: use the exact commitlint/commitizen format for the PR title so the squash commit can be reused unchanged.

`type: #123 short description`

Examples:

- `docs: #12 add superteam skill guide`
- `chore: #34 bootstrap commit hooks`

This title rule applies to pull requests only. GitHub issue titles should stay plain-language and should not use conventional-commit prefixes.

## Summary

- Updates public-facing README and release documentation to use `Patina Project` as the complete company name.
- Preserves `patina` and `patinaproject` identifiers, slugs, URLs, package references, secrets, and app names.
- Adds superteam design and plan artifacts for issue #49.

## Linked issue

- Closes #49

## Acceptance criteria

### AC-49-1

Public-facing docs prose that previously used the shortened company name now uses `Patina Project`.

- [x] CLI evidence — Codex | local worktree | @tlmader | 2026-04-27T08:33:50Z
  - `! rg -n -P '\bPatina\b(?! Project|-project)' README.md RELEASING.md`
  - `rg -n 'Patina Project marketplace|Patina Project plugins|outside Patina Project|Patina Project marketplace manifest' README.md RELEASING.md`

### AC-49-2

Identifier-shaped `patina` and `patinaproject` references were preserved.

- [x] CLI evidence — Codex | local worktree | @tlmader | 2026-04-27T08:33:50Z
  - `rg -n 'patinaproject/skills|patinaproject/superteam|patina-project-automation|PATINAPROJECT_AUTOMATION_APP_ID|patinaproject.com' README.md RELEASING.md .claude-plugin .codex-plugin package.json .github`

## Validation

- `pnpm lint:md`
- `pnpm check:versions`
- Local Reviewer pass: no implementation-level, plan-level, or spec-level findings.

## Docs updated

- [x] Updated in this PR
