### PR TITLE
docs: #53 clarify Superpowers prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ A run is only complete when the published branch state is stable enough to hand 
 
 ## Installation
 
-`superteam` ships as a Claude Code + Codex plugin. Other supported editors read the repository-level files this plugin emits (`AGENTS.md`, `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md`) directly. Install Superpowers first by following the setup instructions in [`obra/superpowers`](https://github.com/obra/superpowers).
+`superteam` ships as a Claude Code + Codex plugin. Other supported editors read the repository-level files this plugin emits (`AGENTS.md`, `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md`) directly.
+
+### Prerequisite: Install Superpowers
+
+Superteam depends on the separate [`obra/superpowers`](https://github.com/obra/superpowers) plugin. Install or enable Superpowers in the same runtime where you plan to use Superteam before installing this plugin, then continue with the Superteam steps for your runtime below.
 
 ### Claude Code
 


### PR DESCRIPTION
# Pull Request

PR title rule for squash merges: use the exact commitlint/commitizen format for the PR title so the squash commit can be reused unchanged.

`type: #123 short description`

Examples:

- `docs: #12 add superteam skill guide`
- `chore: #34 bootstrap commit hooks`

This title rule applies to pull requests only. GitHub issue titles should stay plain-language and should not use conventional-commit prefixes.

## Summary

- Adds a dedicated README prerequisite note for the separate `obra/superpowers` plugin.
- Links to the Superpowers repo instead of duplicating its runtime-specific install instructions.

## Linked issue

- Closes #53

## Acceptance criteria

### AC-53-1

The README identifies Superpowers as a separate prerequisite and directs users to the upstream repo before Superteam setup.

- [x] Markdown evidence — Codex CLI | local worktree | @codex | 2026-04-27T09:20:00Z
- [ ] Manual test: 1. Open the README Installation section. 2. Confirm the Superpowers prerequisite appears before the Superteam install steps. 3. Confirm the prerequisite links to `obra/superpowers` without duplicating upstream install commands.

## Validation

- `pnpm lint:md`
- Commit hook: `markdownlint-cli2` on staged README changes
- Commit hook: `pnpm check:versions`

## Docs updated

- [ ] Not needed
- [x] Updated in this PR