### PR TITLE
feat: #47 align bootstrap 1.3 release guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: Release
 
-# Triggered on every push to `main`. release-please is idempotent: on regular
-# feature/fix merges it opens or refreshes the standing release PR; on the
-# release-PR merge it sees the merged PR (label `autorelease: pending`) and
-# cuts the tag, publishes the release, and dispatches the marketplace bump on
-# patinaproject/skills. A single trigger covers both flows. See RELEASING.md.
+# Triggered on every push to `main`, with workflow_dispatch available as a
+# recovery escape hatch. release-please is idempotent: on regular feature/fix
+# merges it opens or refreshes the standing release PR; on the release-PR merge
+# it sees the merged PR (label `autorelease: pending`) and cuts the tag,
+# publishes the release, and dispatches the marketplace bump on
+# patinaproject/skills. Manual dispatch runs the same path. See RELEASING.md.
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,21 @@ Commits are enforced with Husky + commitlint. Use conventional commits with no s
 
 Scopes like `feat(repo): ...` are rejected. Keep the subject within 72 characters.
 
+### Commit type selection
+
+Choose the commit type by product impact, not by file extension.
+
+| Change | Type |
+|--------|------|
+| Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
+| Corrects broken shipped behavior in those same product surfaces | `fix:` |
+| Explains the product without changing shipped behavior or release semantics | `docs:` |
+| Performs maintenance that does not alter user-facing behavior | `chore:` |
+
+Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Use `docs:` for those files only when the change is clearly explanatory-only and does not alter installed skill behavior.
+
+Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`. Use the release-triggering type that matches the product impact.
+
 Pull requests should include a short summary, linked issue, validation notes, and any updated docs when structure or workflow changes.
 
 For squash-and-merge workflows, PR titles must exactly match the commit format. Use the final intended squash commit title as the PR title.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,19 @@ Examples:
 - `feat: #42 add a feature`
 - `docs: #17 clarify install steps`
 
+Choose the commit type by product impact, not by file extension.
+
+| Change | Type |
+|--------|------|
+| Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
+| Corrects broken shipped behavior in those same product surfaces | `fix:` |
+| Explains the product without changing shipped behavior or release semantics | `docs:` |
+| Performs maintenance that does not alter user-facing behavior | `chore:` |
+
+Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Use `docs:` for those files only when the change is clearly explanatory-only and does not alter installed skill behavior.
+
+Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`. Use the release-triggering type that matches the product impact.
+
 The `commit-msg` hook enforces this. PR titles follow the same format so the squash commit can be reused verbatim.
 
 ## Markdown

--- a/README.md
+++ b/README.md
@@ -214,7 +214,18 @@ pnpm check:versions    # enforce package.json ↔ plugin manifests lockstep
 pnpm commitlint        # one-off commit-message validation
 ```
 
-Commits and PR titles follow `type: #<issue> short description`.
+Commits and PR titles follow `type: #<issue> short description`. See
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) for the full rule; choose the commit type
+by product impact, not by file extension.
+
+| Change | Type |
+|--------|------|
+| Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
+| Corrects broken shipped behavior in those same product surfaces | `fix:` |
+| Explains the product without changing shipped behavior or release semantics | `docs:` |
+| Performs maintenance that does not alter user-facing behavior | `chore:` |
+
+Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`.
 
 Releases are driven by [release-please](https://github.com/googleapis/release-please) — merge the standing release PR to cut a new `vX.Y.Z`. See [`RELEASING.md`](./RELEASING.md).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,9 +4,9 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-The `Release` workflow runs on every push to `main`. There is no separate UI-triggered release path. Cutting a release is the natural by-product of merging PRs:
+The `Release` workflow runs on every push to `main`. Cutting a release is the natural by-product of merging PRs:
 
-1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens, or updates, a standing **"chore: release X.Y.Z"** PR that:
+1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
 
    - Bumps `package.json` version.
    - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
@@ -14,9 +14,23 @@ The `Release` workflow runs on every push to `main`. There is no separate UI-tri
 
    Release-please attaches the `autorelease: pending` label to this PR. If there are no releasable commits since the last tag, the run no-ops.
 
-2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
+2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and (on `patinaproject` plugin repos) dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
 
-The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No `gh workflow run` step is required.
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No manual step is required during the normal flow.
+
+## Manual recovery dispatch
+
+Manual dispatch is an escape hatch, not the normal release path. Use it only when the latest automatic `Release` run was skipped, cancelled, failed for transient reasons, or needs to be retried after permissions or repository settings were fixed.
+
+Start the same workflow from the GitHub Actions UI, or run:
+
+```bash
+gh workflow run Release
+```
+
+The manual run performs the same release-please evaluation as a push-triggered run. If releasable commits exist, it opens or refreshes the standing release PR. If the release PR has already been merged and the repository state calls for a release, it can cut the tag and GitHub Release. If there is nothing to release, it no-ops.
+
+Do not use manual dispatch as the ordinary release process. Do not perform manual version bumps or local release commands.
 
 ## Prerequisites (one-time settings)
 
@@ -107,11 +121,14 @@ When enabled, GitHub refuses to run workflows that `uses:` an action by tag or b
 
 ## Semver decision
 
-Determined from commit types — no human choice:
+Determined from releasable Conventional Commit types — no human choice:
 
 - `fix:` → patch
 - `feat:` → minor
-- `feat!:` or `BREAKING CHANGE:` footer → major
+- `<type>!:` or `BREAKING CHANGE:` footer → major
+- `docs:`, `chore:`, and other non-releasable types → no version bump under this baseline
+
+If a change should produce a release, do not use a non-bumping type. For example, a Markdown-only edit to `skills/**/SKILL.md` that changes installed skill behavior should use `feat:` or `fix:`, not `docs:`.
 
 ## Keeping versions aligned between releases
 
@@ -146,5 +163,6 @@ If either secret is missing on a `patinaproject` plugin repo, the `Mint patina-p
 ## Writing commits for a clean changelog
 
 - Use Conventional Commits: `feat: #<issue> …`, `fix: #<issue> …`, etc.
+- Choose release-triggering types for product changes. Release Please can no-op when product changes are misclassified as `docs:` or `chore:`, which can skip downstream marketplace bump automation.
 - Breaking changes: prefix the type with `!` (e.g. `feat!: #123 rename foo to bar`) **and** include a `BREAKING CHANGE: …` footer in the PR body.
 - Squash-merge flow: PR titles must themselves be conventional-commit-shaped so the squash commit lands with the correct type/scope. Enforced by the `Lint PR` workflow.

--- a/docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-plan.md
+++ b/docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-plan.md
@@ -6,6 +6,12 @@
 
 **Architecture:** This is a targeted repository realignment, not a scaffold rewrite. File changes are limited to the missing label policy and stale guidance, while remote label metadata is updated through `gh label edit`.
 
+**Bootstrap 1.3.0 follow-up:** The original plan covered the bootstrap version
+available at the time. Bootstrap `1.3.0` supersedes the release-flow guidance:
+`workflow_dispatch` should be present as a recovery escape hatch, and
+contributor docs should explain release-triggering commit types by product
+impact.
+
 **Tech Stack:** Markdown, GitHub Actions YAML, GitHub CLI, PNPM, Husky, commitlint, markdownlint-cli2.
 
 ---
@@ -13,11 +19,16 @@
 ## File Structure
 
 - Create `.github/LABELS.md`: tracked source of truth for label selection and release-managed labels.
-- Modify `.github/workflows/release.yml`: remove the manual-dispatch trigger and refresh the release-flow comment.
-- Modify `RELEASING.md`: replace the manual-dispatch release flow with the push-to-main and release-PR merge flow.
+- Modify `.github/workflows/release.yml`: keep the push trigger and expose
+  `workflow_dispatch` as a recovery escape hatch.
+- Modify `RELEASING.md`: describe the push-to-main release flow and the manual
+  recovery dispatch path.
 - Modify `README.md`: remove the stale `@v0.1.0` Codex CLI install pin from the default install command.
 - Modify `.github/pull_request_template.md`: replace the missing `docs/ac-traceability.md` reference with the existing `AGENTS.md` convention.
 - Remote-only update: edit `autorelease: pending` and `autorelease: tagged` label descriptions.
+- Bootstrap `1.3.0` follow-up: modify `.github/workflows/release.yml`,
+  `RELEASING.md`, `AGENTS.md`, `CONTRIBUTING.md`, and `README.md` for recovery
+  dispatch and commit-type guidance.
 
 ## Task 1: Add Label Policy Document
 
@@ -75,31 +86,33 @@ Expected: output includes the `## Labels` heading, `bug`, `enhancement`, and the
 - Modify: `.github/workflows/release.yml`
 - Modify: `RELEASING.md`
 
-- [ ] **Step 1: Update `.github/workflows/release.yml` trigger comment and remove `workflow_dispatch`**
+- [x] **Step 1: Update `.github/workflows/release.yml` trigger comment and keep recovery dispatch**
 
 Replace the current top comment and `on:` block with:
 
 ```yaml
 name: Release
 
-# Triggered on every push to `main`. release-please is idempotent: on regular
-# feature/fix merges it opens or refreshes the standing release PR; on the
-# release-PR merge it sees the merged PR (label `autorelease: pending`) and
-# cuts the tag, publishes the release, and dispatches the marketplace bump on
-# patinaproject/skills. A single trigger covers both flows. See RELEASING.md.
+# Triggered on every push to `main`, with workflow_dispatch available as a
+# recovery escape hatch. release-please is idempotent: on regular feature/fix
+# merges it opens or refreshes the standing release PR; on the release-PR merge
+# it sees the merged PR (label `autorelease: pending`) and cuts the tag,
+# publishes the release, and dispatches the marketplace bump on
+# patinaproject/skills. Manual dispatch runs the same path. See RELEASING.md.
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 ```
 
-- [ ] **Step 2: Update `RELEASING.md` "How it works" section**
+- [x] **Step 2: Update `RELEASING.md` release flow and recovery section**
 
 Replace only the numbered list under `## How it works` before `## Prerequisites (one-time settings)` with:
 
 ```markdown
-The `Release` workflow runs on every push to `main`. There is no manual dispatch. Cutting a release is the natural by-product of merging PRs:
+The `Release` workflow runs on every push to `main`. Cutting a release is the natural by-product of merging PRs:
 
-1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens, or updates, a standing **"chore: release X.Y.Z"** PR that:
+1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
 
    - Bumps `package.json` version.
    - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
@@ -107,20 +120,34 @@ The `Release` workflow runs on every push to `main`. There is no manual dispatch
 
    Release-please attaches the `autorelease: pending` label to this PR. If there are no releasable commits since the last tag, the run no-ops.
 
-2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
+2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and (on `patinaproject` plugin repos) dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
 
-The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No `gh workflow run` step is required.
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No manual step is required during the normal flow.
+
+## Manual recovery dispatch
+
+Manual dispatch is an escape hatch, not the normal release path. Use it only when the latest automatic `Release` run was skipped, cancelled, failed for transient reasons, or needs to be retried after permissions or repository settings were fixed.
+
+Start the same workflow from the GitHub Actions UI, or run:
+
+```bash
+gh workflow run Release
 ```
 
-- [ ] **Step 3: Verify manual-dispatch wording is gone**
+The manual run performs the same release-please evaluation as a push-triggered run. If releasable commits exist, it opens or refreshes the standing release PR. If the release PR has already been merged and the repository state calls for a release, it can cut the tag and GitHub Release. If there is nothing to release, it no-ops.
+
+Do not use manual dispatch as the ordinary release process. Do not perform manual version bumps or local release commands.
+
+- [x] **Step 3: Verify recovery dispatch wording is present**
 
 Run:
 
 ```bash
-rg -n "workflow_dispatch|Run workflow|manual dispatch|gh workflow run Release" .github/workflows/release.yml RELEASING.md
+rg -n "workflow_dispatch|Manual recovery dispatch|gh workflow run Release" .github/workflows/release.yml RELEASING.md
 ```
 
-Expected: no output and exit code 1.
+Expected: output includes `workflow_dispatch`, the recovery section, and the
+manual recovery command.
 
 ## Task 3: Refresh Install and PR Guidance
 
@@ -227,7 +254,7 @@ Run:
 node scripts/check-plugin-versions.mjs
 ```
 
-Expected: `check-plugin-versions: all manifests at 1.0.0`.
+Expected: `check-plugin-versions: all manifests at 1.1.0`.
 
 - [ ] **Step 3: Verify commitlint rejects a missing issue**
 
@@ -244,7 +271,7 @@ Expected: non-zero exit with `ticket-required` failure.
 Run:
 
 ```bash
-printf 'docs: #47 align bootstrap baseline\n' | pnpm exec commitlint
+printf 'feat: #47 align bootstrap 1.3 release guidance\n' | pnpm exec commitlint
 ```
 
 Expected: exit code 0.
@@ -263,8 +290,11 @@ Expected changed tracked files are limited to:
 .github/LABELS.md
 .github/pull_request_template.md
 .github/workflows/release.yml
+AGENTS.md
+CONTRIBUTING.md
 README.md
 RELEASING.md
+docs/superpowers/specs/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-design.md
 docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-plan.md
 ```
 
@@ -273,8 +303,8 @@ docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-p
 Run:
 
 ```bash
-git add .github/LABELS.md .github/pull_request_template.md .github/workflows/release.yml README.md RELEASING.md docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-plan.md
-git commit -m "docs: #47 align superteam with bootstrap baseline"
+git add .github/workflows/release.yml AGENTS.md CONTRIBUTING.md README.md RELEASING.md docs/superpowers/specs/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-design.md docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-plan.md
+git commit -m "feat: #47 align bootstrap 1.3 release guidance"
 ```
 
 Expected: commit succeeds after Husky runs markdownlint and plugin-version checks.
@@ -284,3 +314,55 @@ Expected: commit succeeds after Husky runs markdownlint and plugin-version check
 - Spec coverage: Tasks 1-5 cover AC-47-1 through AC-47-6.
 - Red-flag scan: no incomplete implementation steps remain.
 - Type consistency: not applicable; this plan changes Markdown, YAML, and remote label metadata only.
+
+## Task 6: Apply Bootstrap 1.3.0 Follow-up
+
+**Files:**
+
+- Modify: `.github/workflows/release.yml`
+- Modify: `RELEASING.md`
+- Modify: `AGENTS.md`
+- Modify: `CONTRIBUTING.md`
+- Modify: `README.md`
+- Modify: `docs/superpowers/specs/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-design.md`
+- Modify: `docs/superpowers/plans/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-plan.md`
+
+- [x] **Step 1: Restore release recovery dispatch**
+
+Update `.github/workflows/release.yml` so the `Release` workflow has both
+`push` and `workflow_dispatch` triggers. The workflow comment should state that
+manual dispatch is a recovery escape hatch and runs the same release-please path.
+
+- [x] **Step 2: Document manual recovery dispatch**
+
+Update `RELEASING.md` with a `## Manual recovery dispatch` section. It should
+say manual dispatch is not the normal release path, show `gh workflow run
+Release`, and explain the run is idempotent.
+
+- [x] **Step 3: Document release-triggering commit types**
+
+Update `AGENTS.md`, `CONTRIBUTING.md`, and `README.md` so contributors choose
+commit types by product impact rather than file extension. Product/runtime
+changes should use `feat:` or `fix:` even when the diff is Markdown-only.
+
+- [x] **Step 4: Verify follow-up changes**
+
+Run:
+
+```bash
+pnpm lint:md
+node scripts/check-plugin-versions.mjs
+printf 'feat: bad\n' | pnpm exec commitlint
+printf 'feat: #47 align bootstrap 1.3 release guidance\n' | pnpm exec commitlint
+```
+
+Expected: Markdown lint and plugin-version checks pass; commitlint rejects the
+missing-issue sample and accepts the issue-tagged sample.
+
+## Follow-up Self-Review
+
+- Spec coverage: Task 6 covers the bootstrap `1.3.0` delta and adds AC-47-7.
+- Red-flag scan: The release workflow now keeps manual dispatch only as a
+  recovery path, not as the ordinary release process.
+- Type consistency: This branch intentionally uses a release-triggering type
+  because it changes workflow behavior and contributor runtime guidance.

--- a/docs/superpowers/specs/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-design.md
+++ b/docs/superpowers/specs/2026-04-27-47-align-superteam-to-the-bootstrap-baseline-design.md
@@ -18,6 +18,8 @@ predictable.
 - Keep GitHub repository settings checks explicit and evidence-backed.
 - Validate all Markdown and plugin-version checks before publish.
 - Use acceptance criteria IDs in the `AC-47-<n>` format.
+- Apply bootstrap `1.3.0` release-flow guidance as the current baseline,
+  including manual recovery dispatch and product-impact commit type guidance.
 
 ## Baseline Findings
 
@@ -41,6 +43,10 @@ Verified drift:
   `patinaproject/superteam@v0.1.0`, even though the repo is at `1.0.0`.
 - `.github/pull_request_template.md` references `docs/ac-traceability.md`, but
   that file is not present and `AGENTS.md` now defines AC ID format directly.
+- Follow-up drift after bootstrap `1.3.0`: the release workflow no longer
+  exposes `workflow_dispatch` as a recovery escape hatch, release docs do not
+  describe the recovery path, and contributor docs do not explain that commit
+  types are selected by product impact rather than file extension.
 
 Verified non-drift:
 
@@ -60,15 +66,21 @@ tool-managed release subsection for `autorelease: pending` and
 `autorelease: tagged`. It should point readers back to `AGENTS.md` and
 `gh label list --json name,description` for the runtime inventory.
 
-Refresh release documentation only where it still describes a manual-dispatch
-release path. The repo should describe release-please as running on pushes to
-`main`, opening or updating the release PR after regular merges, and cutting the
-release after the release PR merge.
+Refresh release documentation to match bootstrap `1.3.0`. The repo should
+describe release-please as running on pushes to `main`, opening or updating the
+release PR after regular merges, and cutting the release after the release PR
+merge. It should also keep `workflow_dispatch` available as a manual recovery
+escape hatch and document that manual dispatch is not the ordinary release path.
 
 Refresh install and contribution guidance where it points to stale or missing
 baseline references. The README should not pin new Codex CLI installs to an old
 plugin version, and the PR template should point AC authors at the existing
 `AGENTS.md` rule rather than a missing traceability document.
+
+Refresh commit-type guidance in `AGENTS.md`, `CONTRIBUTING.md`, and `README.md`
+so product-impact changes use release-triggering commit types even when the diff
+is Markdown-only. This prevents release-please from no-oping on shipped behavior
+changes misclassified as `docs:` or `chore:`.
 
 Avoid broad template replacement. Existing repo-specific examples and
 `superteam` wording should remain unless they conflict with the baseline checks.
@@ -105,10 +117,14 @@ workflow lint CI after publication.
   have non-empty descriptions that explain the reservation.
 - **AC-47-3**: Given the release workflow runs from pushes to `main`, when a
   contributor reads `RELEASING.md` or `.github/workflows/release.yml`, then the
-  documented flow no longer depends on a manual dispatch path.
+  normal flow is push-triggered and `workflow_dispatch` is documented only as a
+  manual recovery escape hatch.
 - **AC-47-4**: Given the repo is being realigned rather than re-scaffolded, when
   contributors read install or PR guidance, then README and PR-template
   references do not point them to stale plugin versions or missing docs.
+- **AC-47-7**: Given release-please derives releases from commit types, when
+  contributors read `AGENTS.md`, `CONTRIBUTING.md`, or `README.md`, then they
+  can tell which product-impact changes require release-triggering commit types.
 - **AC-47-5**: Given the repo is being realigned rather than re-scaffolded, when
   implementation completes, then already-aligned plugin, linting, workflow, and
   agent surfaces remain intentionally preserved.


### PR DESCRIPTION
## Summary

- Aligns `superteam` with bootstrap `1.3.0` release-flow guidance by restoring `workflow_dispatch` as a recovery escape hatch.
- Documents release-triggering commit type selection by product impact across contributor-facing guidance.
- Updates the #47 design and plan artifacts with the accepted bootstrap `1.3.0` delta.

## Linked issue

- Closes #47

## Acceptance criteria

### AC-47-3

The normal release flow remains push-triggered, and `workflow_dispatch` is documented only as a manual recovery escape hatch.

- [x] Local evidence - Codex CLI | macOS arm64 | @tlmader | 2026-04-27T15:38:40Z
- [ ] Manual test: 1. Open the Release workflow in GitHub Actions. 2. Confirm the manual run control is available. 3. Confirm `RELEASING.md` says manual dispatch is only for recovery.

### AC-47-6

Markdown linting, plugin-version checks, and commitlint samples pass locally.

- [x] Local evidence - Codex CLI | macOS arm64 | @tlmader | 2026-04-27T15:38:40Z
- [ ] Manual test: 1. Review the validation commands below. 2. Confirm the successful CI checks match the local verification.

### AC-47-7

Contributor guidance now explains that release-triggering commit types are chosen by product impact, not file extension.

- [x] Local evidence - Codex CLI | macOS arm64 | @tlmader | 2026-04-27T15:38:40Z
- [ ] Manual test: 1. Read `AGENTS.md`, `CONTRIBUTING.md`, and `README.md`. 2. Confirm each surface describes product-impact commit type selection.

## Validation

- `pnpm lint:md`
- `node scripts/check-plugin-versions.mjs`
- `printf 'feat: bad\n' | pnpm exec commitlint` exits non-zero with `ticket-required`
- `printf 'feat: #47 align bootstrap 1.3 release guidance\n' | pnpm exec commitlint`
- `git diff --check`

## Docs updated

- [x] Updated in this PR
