### PR TITLE
feat: #58 naturalize Superteam operator output

### DIFF
--- a/docs/superpowers/plans/2026-04-28-58-remove-status-report-templates-across-superteam-output-plan.md
+++ b/docs/superpowers/plans/2026-04-28-58-remove-status-report-templates-across-superteam-output-plan.md
@@ -1,0 +1,355 @@
+# Plan: Remove status report templates across Superteam output [#58](https://github.com/patinaproject/superteam/issues/58)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. The execution mode is pre-selected by `Team Lead`; do not ask the operator to choose inline execution.
+
+**Goal:** Update Superteam so operator-facing chat uses natural, decision-focused prose while durable workflow evidence remains structured and inspectable.
+
+**Architecture:** This is a workflow-contract documentation change. The core contract lives in `skills/superteam/SKILL.md`, delegated teammate prompt shaping lives in `skills/superteam/agent-spawn-template.md`, and behavioral pressure scenarios live in `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`.
+
+**Tech Stack:** Markdown, `markdownlint-cli2`, repo-local `pnpm` scripts, Git hooks.
+
+---
+
+## Source Documents
+
+- Design: `docs/superpowers/specs/2026-04-28-58-remove-status-report-templates-across-superteam-output-design.md`
+- Core contract: `skills/superteam/SKILL.md`
+- Delegation prompts: `skills/superteam/agent-spawn-template.md`
+- Pressure tests: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+- Repo rules: `AGENTS.md`
+
+## File Structure
+
+- Modify `skills/superteam/SKILL.md`: add the invariant-over-template rendering rule, preserve durable evidence rules, soften Gate 1 and teammate reporting language, and add rationalization/red-flag coverage.
+- Modify `skills/superteam/agent-spawn-template.md`: teach delegated teammates to separate internal done-report data from operator-facing prose while preserving role contracts.
+- Modify `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`: add RED/GREEN-oriented pressure scenarios for robotic output, hidden blockers, resolved findings replay, evidence loss, and Finisher readiness masking.
+- Do not modify `skills/superteam/pr-body-template.md` unless execution discovers chat-output-specific wording there that directly conflicts with the design.
+
+## RED Baseline Evidence
+
+- [ ] **Step 1: Capture fixed Gate 1 approval packet pressure**
+
+Run:
+
+```bash
+sed -n '/^## Gate 1: Brainstormer approval/,/^## Routing table/p' skills/superteam/SKILL.md
+```
+
+Expected RED evidence: Gate 1 requires a fixed packet with exact artifact path,
+intent summary, full requirement set, `adversarial_review_findings[]`,
+`adversarial_review_status`, `reviewer_context`, and `clean_pass_rationale`,
+but does not distinguish required gate evidence from natural operator-facing
+rendering.
+
+- [ ] **Step 2: Capture delegated report-shape pressure**
+
+Run:
+
+```bash
+sed -n '/^### Team Lead/,/^### Planner/p' skills/superteam/agent-spawn-template.md
+sed -n '/^### Executor/,/^### Finisher/p' skills/superteam/agent-spawn-template.md
+```
+
+Expected RED evidence: role blocks require field-heavy approval packets and
+done-report contracts, but do not tell teammates that the exact chat response
+can be natural prose as long as the durable handoff data exists.
+
+- [ ] **Step 3: Capture missing behavioral pressure tests**
+
+Run:
+
+```bash
+rg -n "robotic status|natural prose|resolved findings|durable evidence|operator-facing|status-report" docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+Expected RED evidence: no scenarios directly test robotic report output,
+natural prose hiding a blocker, resolved findings replayed by default, or
+durable evidence removed under the banner of natural output.
+
+- [ ] **Step 4: Record behavioral RED scenarios in completion evidence**
+
+Use these scenario summaries as the RED baseline:
+
+- Gate 1 with no active findings still emits a report-shaped approval packet
+  and can replay dispositioned findings because the contract requires rendering
+  the full review block.
+- A teammate completion handoff is incentivized to dump the done-report fields
+  into chat because the prompt does not separate internal handoff data from
+  operator-facing prose.
+- A natural-sounding response that omits an active blocker is not directly
+  rejected by the existing pressure tests because they focus on missing fields,
+  not hidden decisions.
+
+## Task 1: Add The Core Output-Invariant Contract
+
+**Files:**
+
+- Modify: `skills/superteam/SKILL.md`
+
+- [ ] **Step 1: Add an operator-facing output section**
+
+Insert a new section after `## Artifact handoff authority`:
+
+```markdown
+## Operator-facing output
+
+Superteam chat output should satisfy workflow invariants rather than render a fixed status-report template by default. Teammates should write the shortest natural response that makes the current state, requested operator action, active blocker, or next step clear.
+
+Structured bullets and headings are allowed when they help the operator act. They are not mandatory report shells.
+
+Separate durable workflow data from chat rendering:
+
+- Keep required evidence, done-report fields, review findings, AC verification, loopback state, PR state, and shutdown evidence in durable artifacts, explicit handoff data, PR surfaces, or other inspectable records when downstream teammates or future sessions depend on them.
+- Do not rely on volatile agent context as the only home for required evidence.
+- Do not dump every durable field into the operator-facing response unless those fields affect the current decision.
+- Surface active blockers, active findings, requested approvals, requested feedback, and next steps clearly.
+- Do not enumerate closed, resolved, or dispositioned findings in normal operator-facing output unless they affect the current operator decision.
+```
+
+- [ ] **Step 2: Soften Gate 1 rendering language without dropping evidence**
+
+In `## Gate 1: Brainstormer approval`, keep the required evidence list, then
+add this paragraph after the numbered list:
+
+```markdown
+The evidence above is required gate data, not a required chat template. The operator-facing approval request should read naturally and focus on the decision being requested. It may summarize a clean review as no approval-blocking findings remaining instead of replaying closed or dispositioned findings.
+```
+
+- [ ] **Step 3: Update Team Lead contract**
+
+Add bullets in `### Team Lead`:
+
+```markdown
+- Render operator-facing handoffs as natural prose that satisfies the current workflow invariants instead of dumping every internal field as a status report.
+- Keep required gate and handoff evidence durable even when the chat response is concise.
+- Surface only findings that require current operator feedback; keep resolved finding history in artifacts or explicit handoff data.
+```
+
+- [ ] **Step 4: Update all teammate contracts**
+
+Add a short bullet to each of `### Brainstormer`, `### Planner`,
+`### Executor`, `### Reviewer`, and `### Finisher`:
+
+```markdown
+- Separate durable done-report or review data from operator-facing prose; the data must remain inspectable, but the chat handoff should be as natural and decision-focused as the situation allows.
+```
+
+For `### Finisher`, also add:
+
+```markdown
+- Natural prose must not hide publish-state blockers, pending checks, unresolved review feedback, or shutdown evidence.
+```
+
+- [ ] **Step 5: Add rationalization rows**
+
+Append rows to `## Rationalization table`:
+
+```markdown
+| "Natural prose means we can omit required Gate 1 evidence." | Natural prose changes rendering, not evidence. Required review status, reviewer context, checked dimensions, and clean-pass rationale must still exist before planning. |
+| "The operator might want audit history, so replay every closed finding." | Audit history stays available in durable artifacts or handoff data. Normal operator-facing output should show actionable findings and current decisions. |
+| "Done-report contracts are status templates, so we can delete them." | Done reports are durable handoff data. The change separates internal data contracts from chat rendering. |
+| "A friendly paragraph is enough even if it hides a blocker." | Operator-facing prose must clearly state blockers, required decisions, and next steps. Vague warmth is still a contract failure. |
+```
+
+- [ ] **Step 6: Add red flags**
+
+Append bullets to `## Red flags`:
+
+```markdown
+- Operator-facing output repeats closed or dispositioned findings when no operator action is required.
+- Natural prose omits the artifact, decision, active finding, blocker, or next action the operator needs.
+- A change deletes durable done-report or review evidence instead of separating it from chat rendering.
+- Finisher presents a conversational update that hides pending checks, unresolved feedback, mergeability problems, or PR metadata blockers.
+```
+
+## Task 2: Update Delegated Prompt Contracts
+
+**Files:**
+
+- Modify: `skills/superteam/agent-spawn-template.md`
+
+- [ ] **Step 1: Add global prompt guidance**
+
+Add this paragraph before `HARD RULES:` in the top-level `Agent({ ... })`
+prompt:
+
+```text
+Write operator-facing handoffs in natural prose that satisfies the workflow invariants instead of dumping a fixed status report. Keep required done-report fields, evidence, and review state in durable or explicit handoff data, but only surface the parts the operator needs for the current decision, blocker, or next step.
+```
+
+- [ ] **Step 2: Update Team Lead role-specific guidance**
+
+After the approval packet evidence list in the `### Team Lead` block, add:
+
+```text
+Those approval items are required gate evidence, not a required chat template. Render the operator-facing request naturally, focus on the decision needed, and do not replay closed findings when no operator feedback is required.
+```
+
+- [ ] **Step 3: Update Brainstormer and Planner guidance**
+
+In the `### Brainstormer` and `### Planner` blocks, add:
+
+```text
+Treat the done-report fields as durable handoff data. The operator-facing handoff may be concise natural prose when it clearly states what is ready and what happens next.
+```
+
+- [ ] **Step 4: Update Executor and Reviewer guidance**
+
+In the `### Executor` and `### Reviewer` blocks, add:
+
+```text
+Do not turn completion evidence or review data into a robotic chat report by default. Preserve the data for downstream teammates, and surface only the active findings, verification gaps, or next actions the operator needs.
+```
+
+- [ ] **Step 5: Update Finisher guidance**
+
+In the `### Finisher` block, add:
+
+```text
+Use natural prose for status updates when possible, but never hide latest-head blockers. Pending checks, failed checks, unresolved feedback, mergeability problems, metadata violations, and shutdown blockers must remain clear and inspectable.
+```
+
+## Task 3: Add Pressure Tests
+
+**Files:**
+
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+- [ ] **Step 1: Add robotic Gate 1 output scenario**
+
+Insert near the approval-packet scenarios:
+
+```markdown
+## Gate 1 clean review rendered as robotic status report
+
+- Starting condition: Gate 1 has a committed design artifact, required adversarial review evidence, and no findings requiring operator feedback. Prior findings were dispositioned and are recorded in the design artifact.
+- Required halt or reroute behavior: Re-render the operator-facing approval request as a natural decision prompt that identifies the artifact and requested approval without enumerating closed findings or dumping every internal review field.
+- Rule surface: Gate evidence remains required, but operator-facing output should satisfy invariants instead of replaying a status-report template.
+```
+
+- [ ] **Step 2: Add natural prose hiding blocker scenario**
+
+Insert near the same approval-packet scenarios:
+
+```markdown
+## Natural prose hides required operator decision or blocker
+
+- Starting condition: A teammate writes a friendly handoff that says the work is "basically ready" but omits an active blocker, requested approval, unresolved finding, or next operator decision.
+- Required halt or reroute behavior: Halt or rerender the handoff so the active blocker, finding, approval request, or next action is explicit.
+- Rule surface: Natural operator-facing prose is allowed only when it preserves the workflow invariants needed for the current decision.
+```
+
+- [ ] **Step 3: Add done-report data dumped into chat scenario**
+
+Insert near malformed done-report scenarios:
+
+```markdown
+## Done-report fields dumped into operator chat by default
+
+- Starting condition: A role-specific done report contains all required durable fields, but the operator-facing response mechanically dumps every field even though most of them are only needed by downstream teammates.
+- Required halt or reroute behavior: Keep the durable done-report data inspectable, but render the operator-facing handoff as concise prose focused on what is ready, what changed, and what happens next.
+- Rule surface: Done-report contracts are durable handoff data, not mandatory chat templates.
+```
+
+- [ ] **Step 4: Add durable evidence deleted scenario**
+
+Insert near artifact handoff scenarios:
+
+```markdown
+## Natural output deletes required durable evidence
+
+- Starting condition: A workflow-contract change removes required review evidence, done-report fields, AC verification, PR state, or shutdown evidence while claiming the chat output is now more natural.
+- Required halt or reroute behavior: Reject the change until required evidence remains in durable artifacts, explicit handoff data, PR surfaces, or other inspectable records.
+- Rule surface: Natural prose changes presentation only; it does not remove evidence required by future teammates, reviewers, or sessions.
+```
+
+- [ ] **Step 5: Add Finisher blocker masking scenario**
+
+Insert near Finisher shutdown scenarios:
+
+```markdown
+## Finisher conversational update hides latest-head blocker
+
+- Starting condition: Finisher writes a friendly status update after PR publication, but required checks are pending or failing, mergeability is broken, metadata is invalid, or unresolved review feedback remains.
+- Required halt or reroute behavior: Rerender the update so the latest-head blocker and next Finisher action are explicit, and do not allow shutdown readiness until the normal checks pass.
+- Rule surface: Natural prose must not hide publish-state blockers or shutdown evidence.
+```
+
+## Task 4: Verify And Commit Implementation
+
+**Files:**
+
+- Test: `skills/superteam/SKILL.md`
+- Test: `skills/superteam/agent-spawn-template.md`
+- Test: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+- [ ] **Step 1: Verify invariant language exists**
+
+Run:
+
+```bash
+rg -n "Operator-facing output|workflow invariants|fixed status-report template|closed, resolved, or dispositioned findings|durable workflow data|chat rendering" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md
+```
+
+Expected: matches in the core skill and delegated prompt template.
+
+- [ ] **Step 2: Verify pressure tests exist**
+
+Run:
+
+```bash
+rg -n "Gate 1 clean review rendered as robotic status report|Natural prose hides required operator decision or blocker|Done-report fields dumped into operator chat by default|Natural output deletes required durable evidence|Finisher conversational update hides latest-head blocker" docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+Expected: all five pressure-test scenario headings are present.
+
+- [ ] **Step 3: Verify required evidence language remains**
+
+Run:
+
+```bash
+rg -n "adversarial_review_status|reviewer_context|clean_pass_rationale|handoff_commit_sha|verification\\[\\]|pressure_test_results\\[\\]|final unresolved blocking-feedback counts" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md
+```
+
+Expected: required gate, handoff, review, verification, and Finisher evidence still exist.
+
+- [ ] **Step 4: Run markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: markdownlint reports 0 errors.
+
+- [ ] **Step 5: Run diff whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 6: Commit implementation**
+
+Run:
+
+```bash
+git add skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+git commit -m "feat: #58 naturalize Superteam operator output"
+```
+
+Expected: commit succeeds after markdownlint and version checks.
+
+## Review Guidance
+
+Reviewer must invoke `superpowers:writing-skills` for this workflow-contract change and walk through the pressure scenarios added in Task 3. A clean review requires confirming that the change does both things at once: removes mandatory status-report rendering and preserves durable evidence.
+
+## Planner Self-Review
+
+- Spec coverage: AC-58-1 through AC-58-6 map to Tasks 1 through 4. Task 1 covers the core contract; Task 2 covers delegated prompts; Task 3 covers pressure tests; Task 4 covers verification.
+- Placeholder scan: no TODO/TBD placeholders are present.
+- Scope: `pr-body-template.md` is intentionally out of scope unless execution finds direct chat-output wording there.

--- a/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+++ b/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
@@ -68,6 +68,18 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Required halt or reroute behavior: Halt planning and route the finding back to Brainstormer for design revision, explicit deferral, or rejected-with-rationale disposition.
 - Rule surface: Gate 1 must block on unresolved blocker or material findings.
 
+## Gate 1 clean review rendered as robotic status report
+
+- Starting condition: Gate 1 has a committed design artifact, required adversarial review evidence, and no findings requiring operator feedback. Prior findings were dispositioned and are recorded in the design artifact.
+- Required halt or reroute behavior: Re-render the operator-facing approval request as a natural decision prompt that identifies the artifact and requested approval without enumerating closed findings or dumping every internal review field.
+- Rule surface: Gate evidence remains required, but operator-facing output should satisfy invariants instead of replaying a status-report template.
+
+## Natural prose hides required operator decision or blocker
+
+- Starting condition: A teammate writes a friendly handoff that says the work is "basically ready" but omits an active blocker, requested approval, unresolved finding, or next operator decision.
+- Required halt or reroute behavior: Halt or rerender the handoff so the active blocker, finding, approval request, or next action is explicit.
+- Rule surface: Natural operator-facing prose is allowed only when it preserves the workflow invariants needed for the current decision.
+
 ## Workflow-contract design reviewed without writing-skills dimensions
 
 - Starting condition: The design touches `skills/**/*.md` or a workflow-contract surface, but adversarial review does not check RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths.
@@ -141,6 +153,12 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Required halt or reroute behavior: Halt the handoff and return it to the owning teammate until the required done-report fields are present in the expected shape.
 - Rule surface: Each teammate-specific done contract should define the minimum stable fields needed for downstream handoff.
 
+## Done-report fields dumped into operator chat by default
+
+- Starting condition: A role-specific done report contains all required durable fields, but the operator-facing response mechanically dumps every field even though most of them are only needed by downstream teammates.
+- Required halt or reroute behavior: Keep the durable done-report data inspectable, but render the operator-facing handoff as concise prose focused on what is ready, what changed, and what happens next.
+- Rule surface: Done-report contracts are durable handoff data, not mandatory chat templates.
+
 ## Brainstormer hands off an uncommitted design artifact
 
 - Starting condition: `Brainstormer` writes or updates the design doc, but the artifact exists only as uncommitted workspace state when handoff to `Planner` is attempted.
@@ -164,6 +182,12 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Starting condition: `Reviewer` or `Finisher` completes stage responsibilities without materially changing durable artifacts.
 - Required halt or reroute behavior: Do not require a commit solely to satisfy the handoff-commit rule.
 - Rule surface: The artifact-producing handoff rule should apply to artifact-producing roles and artifact-producing changes, not become a ritual for every stage.
+
+## Natural output deletes required durable evidence
+
+- Starting condition: A workflow-contract change removes required review evidence, done-report fields, AC verification, PR state, or shutdown evidence while claiming the chat output is now more natural.
+- Required halt or reroute behavior: Reject the change until required evidence remains in durable artifacts, explicit handoff data, PR surfaces, or other inspectable records.
+- Rule surface: Natural prose changes presentation only; it does not remove evidence required by future teammates, reviewers, or sessions.
 
 ## Reviewer findings missing feedback classification
 
@@ -224,6 +248,12 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Starting condition: The workflow creates or updates the PR, reports a single status snapshot, and then stops even though mergeability, CI, PR metadata correction, or external feedback handling still requires Finisher-owned follow-through.
 - Required halt or reroute behavior: Do not present the run as complete. Continue the Finisher loop until publish-state follow-through is stable enough to hand off cleanly or an explicit blocker is reported.
 - Rule surface: The Finisher contract should state that PR publication is a milestone rather than the end of the workflow.
+
+## Finisher conversational update hides latest-head blocker
+
+- Starting condition: Finisher writes a friendly status update after PR publication, but required checks are pending or failing, mergeability is broken, metadata is invalid, or unresolved review feedback remains.
+- Required halt or reroute behavior: Rerender the update so the latest-head blocker and next Finisher action are explicit, and do not allow shutdown readiness until the normal checks pass.
+- Rule surface: Natural prose must not hide publish-state blockers or shutdown evidence.
 
 ## Finisher keeps monitoring while required checks on the latest pushed head are pending
 

--- a/docs/superpowers/specs/2026-04-28-58-remove-status-report-templates-across-superteam-output-design.md
+++ b/docs/superpowers/specs/2026-04-28-58-remove-status-report-templates-across-superteam-output-design.md
@@ -45,9 +45,13 @@ they help. They should stop being the default voice of the system.
 - Surface only actionable findings or blockers in normal operator-facing
   output.
 - Keep closed, resolved, or dispositioned findings available in artifacts,
-  internal context, or done-report evidence without replaying them by default.
+  explicit handoff data, or done-report evidence without replaying them by
+  default.
 - Preserve explicit evidence requirements for Gate 1, Reviewer pressure tests,
   and Finisher shutdown; do not let natural prose hide missing evidence.
+- Keep required evidence durable whenever future teammates, future sessions, PR
+  reviewers, or audit/debugging workflows depend on it. Volatile agent context
+  may supplement that evidence, but must not be its only home.
 - Update delegated teammate prompts so subagents are encouraged to write like
   collaborators while still satisfying role-specific contracts.
 - Add pressure tests that catch robotic status-template output and the opposite
@@ -102,8 +106,10 @@ external PR feedback once they are no longer relevant to the current decision.
 If findings require operator feedback, they must be visible and specific enough
 to act on. If findings are closed or dispositioned, the response may summarize
 the result briefly, such as "no approval-blocking findings remain." The detailed
-history can stay in the design artifact, plan, review report, PR discussion, or
-agent context.
+history should stay in a durable surface when later teammates or reviewers may
+need it: the design artifact, plan, review report, PR discussion, explicit
+handoff data, or Finisher state. Volatile agent context can help during the
+current run, but it is not enough for required evidence.
 
 This should not remove required evidence. Gate 1 still needs adversarial review
 status, reviewer context, checked dimensions, and clean-pass rationale before
@@ -155,8 +161,20 @@ The baseline should show at least:
    not catch robotic status-report output or natural prose that hides required
    actions.
 
-GREEN verification should then show the same surfaces distinguish required
-workflow data from natural operator-facing rendering.
+The baseline cannot be inspection-only. Before changing the workflow contract,
+the plan should include behavioral pressure scenarios that demonstrate current
+failure. At minimum, capture RED behavior for:
+
+1. a Gate 1 approval prompt that replays dispositioned findings into
+   operator-facing output when no operator feedback is needed
+2. a teammate handoff or Finisher update that is forced into report shape even
+   though a concise natural handoff would satisfy the operator need
+3. a counter-pressure case where natural prose sounds pleasant but omits an
+   actionable blocker, requested decision, or required next step
+
+GREEN verification should rerun those same scenario classes after the contract
+edits and show that Superteam distinguishes required workflow data from natural
+operator-facing rendering without hiding blockers.
 
 ### Loophole-Closure Language
 
@@ -170,6 +188,7 @@ The workflow must close these rationalizations:
 | "Done-report contracts are templates, so we can delete them." | Done reports are durable handoff data. The change separates internal data contracts from chat rendering. |
 | "A friendly paragraph is enough even if it hides a blocker." | Operator-facing prose must clearly state blockers, required decisions, and next steps. Vague warmth is still a contract failure. |
 | "Finisher can avoid status details because status reports are discouraged." | Finisher still owns latest-head readiness, monitoring, blockers, and shutdown evidence; only unnecessary report boilerplate is discouraged. |
+| "The evidence is in agent context, so it is traceable enough." | Required evidence must live in durable artifacts, explicit handoff data, PR state, or other inspectable surfaces when future teammates or reviewers depend on it. |
 
 ## Red Flags
 
@@ -231,8 +250,9 @@ to respond.
 **Given** Superteam needs traceability for audit, future teammates, or
 debugging,
 **When** structured workflow state exists internally,
-**Then** that state remains available in artifacts, done-report data, PR
-surfaces, or agent context without forcing chat output into a status report.
+**Then** required evidence remains available in durable artifacts, done-report
+data, explicit handoff state, PR surfaces, or other inspectable records without
+forcing chat output into a status report.
 
 ### AC-58-6
 
@@ -257,8 +277,36 @@ blockers.
   prose hiding required decisions; resolved findings replayed by default;
   durable evidence removed under the banner of natural output; and Finisher
   status updates hiding latest-head blockers.
+- Capture RED behavior with realistic pressure scenarios before editing the
+  workflow surfaces, then rerun matching GREEN scenarios after edits.
 - Run `rg` checks for status-report-template terms and new invariant language.
 - Run `pnpm lint:md`.
+
+## Adversarial Review
+
+Reviewer context: fresh subagent.
+
+Dimensions checked: requirement completeness, AC clarity, RED/GREEN baseline
+obligations, rationalization resistance, red flags, token-efficiency targets,
+role ownership, stage-gate bypass paths, plan readiness, and the risk that
+natural prose could either lose evidence or hide actionable blockers.
+
+Findings:
+
+- `source: adversarial-review`, material finding: the first draft allowed an
+  inspection-only RED/GREEN baseline. Disposition: fixed in design by requiring
+  behavioral pressure-test baselines for Gate 1 replaying closed findings,
+  report-shaped handoffs, and natural prose hiding blockers, plus matching
+  GREEN reruns.
+- `source: adversarial-review`, material finding: the first draft allowed
+  required traceability to live in ephemeral agent context. Disposition: fixed
+  in design by tightening the requirements, findings presentation, AC-58-5, and
+  rationalization table so required evidence remains in durable or explicit
+  handoff surfaces when future teammates or reviewers depend on it.
+
+Rerun note: these findings changed baseline obligations and traceability
+requirements. The affected review dimensions must be rerun against the revised
+committed artifact before Gate 1 approval.
 
 ## Out Of Scope
 

--- a/docs/superpowers/specs/2026-04-28-58-remove-status-report-templates-across-superteam-output-design.md
+++ b/docs/superpowers/specs/2026-04-28-58-remove-status-report-templates-across-superteam-output-design.md
@@ -1,0 +1,270 @@
+# Design: Remove status report templates across Superteam output [#58](https://github.com/patinaproject/superteam/issues/58)
+
+## Intent
+
+Replace Superteam's operator-facing status-report style with a clearer
+contract: teammates must communicate the decision, blocker, handoff, or next
+step the operator needs, but they should not be forced to emit a fixed report
+template when natural prose would be better.
+
+This is a workflow-contract change. It should preserve durable internal state,
+done-report fields, acceptance criteria, review evidence, and Finisher shutdown
+checks. The change is about presentation and prompt contracts, not about making
+Superteam less rigorous.
+
+## Problem Framing
+
+Superteam currently carries many fixed output shapes: approval packets, done
+reports, Finisher status, review findings, and role-specific spawn guidance all
+encourage field-heavy prose. Those fields are useful as internal handoff data,
+but they can leak into normal operator-facing output as robotic status reports.
+
+The motivating example was a Gate 1 approval prompt that was ready for operator
+approval, yet still highlighted `findings dispositioned` and replayed closed
+review findings. That made resolved process state feel like active work. The
+broader problem is the same across the workflow: rigid templates can turn every
+handoff into a report even when the operator only needs a calm explanation of
+what changed, what is blocked, or what decision is requested.
+
+The fix should move Superteam from template-first output to invariant-first
+output. Structured bullets, headings, and explicit fields remain available when
+they help. They should stop being the default voice of the system.
+
+## Requirements
+
+- Preserve the canonical teammate workflow, artifact ownership, stage gates,
+  loopback routing, and publish-state shutdown requirements.
+- Keep machine-readable and teammate-to-teammate handoff fields where later
+  workflow steps depend on them.
+- Remove or soften guidance that tells teammates to render fixed
+  operator-facing status report templates by default.
+- Define output invariants for each major operator-facing moment instead of a
+  universal field list.
+- Require operator-facing responses to state the requested decision, feedback,
+  approval, next action, or blocker when one exists.
+- Surface only actionable findings or blockers in normal operator-facing
+  output.
+- Keep closed, resolved, or dispositioned findings available in artifacts,
+  internal context, or done-report evidence without replaying them by default.
+- Preserve explicit evidence requirements for Gate 1, Reviewer pressure tests,
+  and Finisher shutdown; do not let natural prose hide missing evidence.
+- Update delegated teammate prompts so subagents are encouraged to write like
+  collaborators while still satisfying role-specific contracts.
+- Add pressure tests that catch robotic status-template output and the opposite
+  failure mode: vague prose that omits required decisions or blockers.
+
+## Design
+
+### Output Contract: Invariants Over Templates
+
+Superteam should distinguish two surfaces:
+
+1. durable workflow data used by teammates and future sessions
+2. operator-facing prose shown in chat
+
+Durable workflow data can remain structured. Design docs, plans, done reports,
+review evidence, AC verification, loopback trailers, PR bodies, and shutdown
+checks need stable shapes because later teammates rely on them.
+
+Operator-facing prose should satisfy invariants rather than templates. A
+response is acceptable when it makes the current state and required operator
+action clear. It can use a short paragraph, bullets, or headings based on the
+moment, but it should not render every available internal field as a report.
+
+### Natural Operator-Facing Moments
+
+The implementation should identify and update the normal places where
+Superteam talks to the operator:
+
+- Gate 1 approval and revision prompts
+- Brainstormer, Planner, Executor, Reviewer, and Finisher handoffs
+- local review loopback routing
+- Finisher publish-state updates
+- explicit blockers and halt messages
+- delegated teammate prompt guidance that shapes later replies
+
+Each moment should keep its invariant:
+
+- approval prompts ask for a clear decision and identify the artifact under
+  review
+- handoffs state what is ready, what changed, and what happens next
+- blocker reports name the blocker and the safest next action
+- review routing reports actionable findings and loopback ownership
+- Finisher updates distinguish ready, monitoring, triage, and blocked states
+  without turning every update into a full status table
+
+### Findings Presentation
+
+Normal operator-facing output should not enumerate resolved findings by
+default. This applies to Gate 1 review findings, local review findings, and
+external PR feedback once they are no longer relevant to the current decision.
+
+If findings require operator feedback, they must be visible and specific enough
+to act on. If findings are closed or dispositioned, the response may summarize
+the result briefly, such as "no approval-blocking findings remain." The detailed
+history can stay in the design artifact, plan, review report, PR discussion, or
+agent context.
+
+This should not remove required evidence. Gate 1 still needs adversarial review
+status, reviewer context, checked dimensions, and clean-pass rationale before
+planning can start. The change is that the operator-facing prose should not
+replay closed findings merely because the internal evidence exists.
+
+### Done Reports And Handoff Data
+
+Role-specific done-report contracts should remain enforceable. They are
+handoff data, not necessarily the exact chat prose.
+
+The contract should say that a teammate may satisfy the done-report fields as
+structured data for the Team Lead while the Team Lead renders the operator
+handoff naturally. When a later teammate or future session needs a precise
+field, the field must exist. When the operator only needs the current decision
+or next step, the response should not dump the entire field list.
+
+### Scope Of Repository Changes
+
+The likely implementation surface is:
+
+- `skills/superteam/SKILL.md`
+- `skills/superteam/agent-spawn-template.md`
+- `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+The implementation should avoid broad rewrites of the workflow. It should focus
+on removing status-report-template pressure from operator-facing output while
+protecting the contract requirements that make Superteam resumable and
+auditable.
+
+`skills/superteam/pr-body-template.md` should remain mostly out of scope unless
+an instruction there directly forces chat output to become a status report. PR
+bodies are durable review artifacts and benefit from stable structure.
+
+### RED-Phase Baseline Obligation
+
+Before implementation edits the workflow surfaces, capture inspection-based
+baseline evidence that the current contract encourages fixed operator-facing
+status templates.
+
+The baseline should show at least:
+
+1. Gate 1 approval instructions require a fixed approval packet with explicit
+   fields that can force internal review state into chat output.
+2. `agent-spawn-template.md` tells Team Lead and teammate roles to produce
+   field-heavy approval or done-report output without distinguishing internal
+   handoff data from operator-facing prose.
+3. Existing pressure tests catch missing fields and skipped evidence, but do
+   not catch robotic status-report output or natural prose that hides required
+   actions.
+
+GREEN verification should then show the same surfaces distinguish required
+workflow data from natural operator-facing rendering.
+
+### Loophole-Closure Language
+
+The workflow must close these rationalizations:
+
+| Excuse | Reality |
+|--------|---------|
+| "Natural prose means we can omit required Gate 1 evidence." | Natural prose changes rendering, not gate evidence. Required review status, reviewer context, checked dimensions, and clean-pass rationale still exist before planning. |
+| "The operator might want audit history, so replay every closed finding." | Audit history stays available in artifacts or context. Normal operator-facing output should show actionable findings and current decisions. |
+| "Removing templates means no bullets or headings." | Structure is allowed when it helps the operator act. The rule removes mandatory report shape, not useful formatting. |
+| "Done-report contracts are templates, so we can delete them." | Done reports are durable handoff data. The change separates internal data contracts from chat rendering. |
+| "A friendly paragraph is enough even if it hides a blocker." | Operator-facing prose must clearly state blockers, required decisions, and next steps. Vague warmth is still a contract failure. |
+| "Finisher can avoid status details because status reports are discouraged." | Finisher still owns latest-head readiness, monitoring, blockers, and shutdown evidence; only unnecessary report boilerplate is discouraged. |
+
+## Red Flags
+
+- Operator-facing Superteam output repeats closed or dispositioned findings
+  when no operator action is required.
+- A prompt requires fields such as status, branch, findings, rationale, or
+  verification to be rendered in chat even when the operator only needs a
+  concise decision prompt.
+- A teammate uses "natural prose" to omit the artifact, decision, blocker,
+  active finding, or next action the operator needs.
+- Implementation deletes durable done-report fields instead of separating them
+  from chat rendering.
+- Finisher presents an easygoing update while required checks, review threads,
+  mergeability, or PR metadata are still pending or blocked.
+- Pressure tests only verify that rigid fields exist and never test whether the
+  output is unnecessarily report-like.
+
+## Token-Efficiency Targets
+
+- Prefer short invariant bullets over long reusable output templates.
+- Keep role guidance focused on when to use natural prose and what must still
+  be clear.
+- Avoid adding a new universal response format to replace the old report
+  format.
+- Keep examples brief and contrast-oriented: robotic report shape versus
+  acceptable natural handoff.
+
+## Acceptance Criteria
+
+### AC-58-1
+
+**Given** any Superteam phase or handoff output can satisfy its workflow
+invariants with natural prose,
+**When** the teammate reports to the operator,
+**Then** the contract does not require a fixed status-report template.
+
+### AC-58-2
+
+**Given** Superteam output needs operator action,
+**When** the response is presented,
+**Then** the requested decision, feedback, approval, next step, or blocker is
+clear without relying on boilerplate status fields.
+
+### AC-58-3
+
+**Given** active blockers or findings require operator feedback,
+**When** Superteam reports them,
+**Then** the actionable items are surfaced with enough context for the operator
+to respond.
+
+### AC-58-4
+
+**Given** findings are resolved, closed, or otherwise dispositioned,
+**When** they do not affect the current operator decision,
+**Then** normal operator-facing output does not enumerate them by default.
+
+### AC-58-5
+
+**Given** Superteam needs traceability for audit, future teammates, or
+debugging,
+**When** structured workflow state exists internally,
+**Then** that state remains available in artifacts, done-report data, PR
+surfaces, or agent context without forcing chat output into a status report.
+
+### AC-58-6
+
+**Given** the implementation changes `skills/**/*.md` or workflow-contract
+guidance,
+**When** verification runs,
+**Then** it includes pressure tests for robotic status-template output,
+actionable findings still being shown, resolved findings being quiet by
+default, durable evidence remaining available, and natural prose not hiding
+blockers.
+
+## Verification Strategy
+
+- Inspect `skills/superteam/SKILL.md` for output-invariant language and the
+  preserved stage-gate evidence requirements.
+- Inspect `skills/superteam/agent-spawn-template.md` for delegated prompt
+  guidance that separates internal done-report contracts from natural
+  operator-facing prose.
+- Add pressure tests to
+  `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` for:
+  robotic status report output when no operator feedback is needed; natural
+  prose hiding required decisions; resolved findings replayed by default;
+  durable evidence removed under the banner of natural output; and Finisher
+  status updates hiding latest-head blockers.
+- Run `rg` checks for status-report-template terms and new invariant language.
+- Run `pnpm lint:md`.
+
+## Out Of Scope
+
+- Changing the canonical teammate roster.
+- Removing done-report contracts, AC verification, loopback trailers, or
+  Finisher shutdown evidence.
+- Redesigning the PR body template as conversational prose.
+- Replacing Superteam's phase-detection or routing model.
+- Requiring a specific friendly voice or adding a new mandatory prose template.

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -178,6 +178,20 @@ Handoffs that depend on uncommitted durable artifact changes are incomplete unle
 
 For artifact-producing handoffs, the workflow should trust committed branch state rather than dirty workspace state. Downstream teammates should be able to rely on inspectable commits instead of inferring intent from uncommitted local changes.
 
+## Operator-facing output
+
+Superteam chat output should satisfy workflow invariants rather than render a fixed status-report template by default. Teammates should write the shortest natural response that makes the current state, requested operator action, active blocker, or next step clear.
+
+Structured bullets and headings are allowed when they help the operator act. They are not mandatory report shells.
+
+Separate durable workflow data from chat rendering:
+
+- Keep required evidence, done-report fields, review findings, AC verification, loopback state, PR state, and shutdown evidence in durable artifacts, explicit handoff data, PR surfaces, or other inspectable records when downstream teammates or future sessions depend on them.
+- Do not rely on volatile agent context as the only home for required evidence.
+- Do not dump every durable field into the operator-facing response unless those fields affect the current decision.
+- Surface active blockers, active findings, requested approvals, requested feedback, and next steps clearly.
+- Do not enumerate closed, resolved, or dispositioned findings in normal operator-facing output unless they affect the current operator decision.
+
 ## Gate 1: Brainstormer approval
 
 Advancement from `Brainstormer` to `Planner` requires explicit approval of the design artifact. Silence, ambiguity, or partial replies are non-approval.
@@ -194,6 +208,8 @@ Before asking for approval:
 8. Include `reviewer_context`: `fresh subagent`, `parallel specialists`, or `same-thread fallback`.
 9. Include `clean_pass_rationale` with checked dimensions when no blocker or material findings remain.
 10. Halt approval when any blocker or material finding is still open.
+
+The evidence above is required gate data, not a required chat template. The operator-facing approval request should read naturally and focus on the decision being requested. It may summarize a clean review as no approval-blocking findings remaining instead of replaying closed or dispositioned findings.
 
 Before Gate 1 approval is presented, `Team Lead` must run or dispatch an adversarial design review against the committed design artifact. Fresh-context or parallel specialist review is preferred for workflow-critical or broad designs when the runtime supports it; same-thread review is the portable fallback. Brainstormer-originated findings alone do not satisfy this gate.
 
@@ -232,6 +248,9 @@ Headline behaviors:
 - Before Gate 1 approval can advance, enforce adversarial design review against the committed design artifact.
 - Include `adversarial_review_status`, `reviewer_context`, `adversarial_review_findings[]`, and `clean_pass_rationale` when applicable in Gate 1 approval packets.
 - Treat Brainstormer-originated findings as useful input but not proof that adversarial review occurred.
+- Render operator-facing handoffs as natural prose that satisfies the current workflow invariants instead of dumping every internal field as a status report.
+- Keep required gate and handoff evidence durable even when the chat response is concise.
+- Surface only findings that require current operator feedback; keep resolved finding history in artifacts or explicit handoff data.
 - Recommend `superpowers:using-superpowers`.
 - Also recommend `superpowers:dispatching-parallel-agents` when splitting bounded, independent work, and keep tightly coupled or interactive steps in the foreground.
 - During execute-phase delegation, bind directly to the chosen execution-mode skill (`superpowers:subagent-driven-development` for subagent-driven, or the host's native team-mode capability for team mode). Do NOT route execute-phase delegations through `superpowers:executing-plans` on default paths.
@@ -251,6 +270,7 @@ Headline behaviors:
 - Include reviewer context and checked dimensions in the clean-pass rationale when the adversarial-review result is clean.
 - Commit any design changes caused by self-review or adversarial findings before reporting done or handing off to `Planner`.
 - Include the handoff commit SHA for the committed design artifact in the done report.
+- Separate durable done-report or review data from operator-facing prose; the data must remain inspectable, but the chat handoff should be as natural and decision-focused as the situation allows.
 - Determine the intended surface from the issue before authoring requirements. When the design under brainstorming will touch `skills/**/*.md` or any workflow-contract surface (the `superteam` skill itself, agent-spawn templates, PR-body templates, or other repository-owned workflow contracts), invoke `superpowers:writing-skills` BEFORE authoring requirements. If the issue plausibly targets those surfaces and the exact files are uncertain, invoke `superpowers:writing-skills` first or halt for clarification. This is unconditional on the trigger, not "consider"; once the design touches or plausibly targets a skill or workflow-contract surface, writing-skills is the load-bearing reference for what the design must contain (loophole-closure language, rationalization-table rows, red-flags bullets, token-efficiency targets, RED-phase baseline obligation). A `Brainstormer` who skips writing-skills at design time forces every downstream teammate to re-derive it. Not even when an authority claim is cited. Not even under deadline pressure.
 - Recommend `superpowers:brainstorming`.
 
@@ -260,6 +280,7 @@ Headline behaviors:
 - Commit the implementation plan change before reporting done or handing off to `Executor`.
 - Produce the implementation plan or halt with a blocker.
 - Include the handoff commit SHA for the committed implementation plan in the done report.
+- Separate durable done-report or review data from operator-facing prose; the data must remain inspectable, but the chat handoff should be as natural and decision-focused as the situation allows.
 - Recommend `superpowers:writing-plans`.
 
 ### Executor
@@ -269,6 +290,7 @@ Headline behaviors:
 - Commit the completed implementation and test changes before reporting done or handing off to `Reviewer`.
 - Report completion against explicit task IDs.
 - Include concrete completion evidence, SHAs, and verification evidence before claiming completion.
+- Separate durable done-report or review data from operator-facing prose; the data must remain inspectable, but the chat handoff should be as natural and decision-focused as the situation allows.
 - `Executor` completion is not workflow completion. After local implementation work is complete, the run must either continue into `Reviewer` and then `Finisher`, or halt explicitly as `superteam halted at <teammate or gate>: <reason>`.
 - Never push, rebase, or open a PR.
 - Recommend `superpowers:test-driven-development` as the ATDD execution skill.
@@ -288,6 +310,7 @@ Headline behaviors:
 - If later fixes change those same workflow-contract surfaces again after an earlier review pass, rerun the relevant pressure-test walkthrough before handing the run back to `Finisher`.
 - Report pressure-test pass/fail results and any loopholes found for skill or workflow-contract changes.
 - Report local findings with `feedback_classification` (`implementation-level` | `plan-level` | `spec-level`) and an owner before routing.
+- Separate durable done-report or review data from operator-facing prose; the data must remain inspectable, but the chat handoff should be as natural and decision-focused as the situation allows.
 - Keep findings local; do not take ownership of external review feedback.
 
 ### Finisher
@@ -295,6 +318,8 @@ Headline behaviors:
 - Own push, branch publication, PR updates, PR body rendering, CI triage, and external review/comment handling.
 - Own receiving and interpreting external post-publish PR feedback.
 - Report pushed SHAs, current branch state on origin, PR state, and CI state.
+- Separate durable done-report or review data from operator-facing prose; the data must remain inspectable, but the chat handoff should be as natural and decision-focused as the situation allows.
+- Natural prose must not hide publish-state blockers, pending checks, unresolved review feedback, or shutdown evidence.
 - When a project-owned PR template or PR-body rule exists, satisfy it first and treat the `superteam` PR template as fallback/default guidance rather than as an override.
 - When a real issue number is available for the canonical single-issue workflow and nothing in the current run says the work is partial, follow-up, or otherwise non-closing, render `Closes #<issue-number>` in the PR body.
 - When the issue is related but the run is not issue-completing, render a non-closing issue reference plus a brief explanation.
@@ -428,6 +453,10 @@ Before resolving or replying to comments tied to a prior branch state:
 | "No findings means no review evidence is needed." | A clean adversarial-review result must include `reviewer_context`, checked dimensions, and `clean_pass_rationale`; silence is not evidence. |
 | "This is a workflow-contract design, but a generic review is enough." | Designs touching `skills/**/*.md` or workflow-contract surfaces require the `superpowers:writing-skills` review dimensions: RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths. |
 | "A finding changed the design, but the earlier review still applies." | Material requirement, ownership, pressure-test, or gate-order changes require rerunning affected review dimensions or recording why rerun is unnecessary. |
+| "Natural prose means we can omit required Gate 1 evidence." | Natural prose changes rendering, not evidence. Required review status, reviewer context, checked dimensions, and clean-pass rationale must still exist before planning. |
+| "The operator might want audit history, so replay every closed finding." | Audit history stays available in durable artifacts or handoff data. Normal operator-facing output should show actionable findings and current decisions. |
+| "Done-report contracts are status templates, so we can delete them." | Done reports are durable handoff data. The change separates internal data contracts from chat rendering. |
+| "A friendly paragraph is enough even if it hides a blocker." | Operator-facing prose must clearly state blockers, required decisions, and next steps. Vague warmth is still a contract failure. |
 
 ## Red flags
 
@@ -477,6 +506,10 @@ Before resolving or replying to comments tied to a prior branch state:
 - `pre-flight.md` documenting kebab-casing, default-branch resolution, fetch, checkout, or rebase steps inline instead of referencing `/github-flows:new-branch`.
 - `Team Lead` silently continuing on the default branch after `gh repo view` fails to resolve the default branch.
 - A `superteam` run authoring `docs/superpowers/specs/...` on the default branch.
+- Operator-facing output repeats closed or dispositioned findings when no operator action is required.
+- Natural prose omits the artifact, decision, active finding, blocker, or next action the operator needs.
+- A change deletes durable done-report or review evidence instead of separating it from chat rendering.
+- `Finisher` presents a conversational update that hides pending checks, unresolved feedback, mergeability problems, or PR metadata blockers.
 
 ## Shutdown
 

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -22,6 +22,7 @@ Agent({
            skill is unavailable in the current environment, state that explicitly in this
            delegated prompt and carry the same warning into your work so the operator and
            teammate can both see the gap at dispatch time.
+           Write operator-facing handoffs in natural prose that satisfies the workflow invariants instead of dumping a fixed status report. Keep required done-report fields, evidence, and review state in durable or explicit handoff data, but only surface the parts the operator needs for the current decision, blocker, or next step.
            HARD RULES:
            1. Write only to the artifact path owned by your teammate role unless the approved plan says otherwise.
            2. Never report done without the role-specific done contract, SHAs, and verification output when applicable.
@@ -54,6 +55,7 @@ Each approval packet must include:
 - `adversarial_review_status`: `clean`, `findings dispositioned`, or `blocked`
 - `reviewer_context`: `fresh subagent`, `parallel specialists`, or `same-thread fallback`
 - `clean_pass_rationale` with checked dimensions when no blocker or material findings remain
+Those approval items are required gate evidence, not a required chat template. Render the operator-facing request naturally, focus on the decision needed, and do not replay closed findings when no operator feedback is required.
 Before Gate 1 approval can advance, run or dispatch adversarial design review against the committed artifact. Brainstormer-originated findings alone do not satisfy this gate.
 For designs that touch `skills/**/*.md` or workflow-contract surfaces, the adversarial review must check the `superpowers:writing-skills` dimensions: RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths.
 If the approval packet is too large, split it instead of collapsing it.
@@ -85,6 +87,7 @@ Done-report contract:
 - `clean_pass_rationale`: required with checked dimensions when no blocker or material findings remain
 - Do not treat Brainstormer-originated findings as satisfying the adversarial-review pass. If adversarial review changes the design, commit the revised artifact before handoff.
 - `handoff_commit_sha`: commit containing the design artifact used for approval and planning
+Treat the done-report fields as durable handoff data. The operator-facing handoff may be concise natural prose when it clearly states what is ready and what happens next.
 ```
 
 ### Planner
@@ -106,6 +109,7 @@ Done-report contract:
 - `workstreams[]`: short summary of planned batches or workstreams
 - `blockers[]`: any blockers preventing execution, or an explicit empty result when none exist
 - `handoff_commit_sha`: commit containing the approved implementation plan used for execution
+Treat the done-report fields as durable handoff data. The operator-facing handoff may be concise natural prose when it clearly states what is ready and what happens next.
 ```
 
 ### Executor
@@ -135,6 +139,7 @@ Done-report contract:
 - `completion_evidence[]`: concrete evidence per completed task
 - `head_sha`: current HEAD SHA for the committed implementation and test state being handed to `Reviewer`
 - `verification[]`: verification commands and outcomes
+Do not turn completion evidence or review data into a robotic chat report by default. Preserve the data for downstream teammates, and surface only the active findings, verification gaps, or next actions the operator needs.
 ```
 
 ### Reviewer
@@ -157,6 +162,7 @@ Done-report contract:
   - each finding entry includes `summary`, `feedback_classification` (`implementation-level` | `plan-level` | `spec-level`), and `owner`
 - `verification_gaps[]`: any missing or invalid verification
 - `pressure_test_results[]`: for skill or workflow-contract changes, the scenarios checked and their pass/fail outcomes, or an explicit empty result when not applicable
+Do not turn completion evidence or review data into a robotic chat report by default. Preserve the data for downstream teammates, and surface only the active findings, verification gaps, or next actions the operator needs.
 Do not take ownership of external PR comments or bot feedback.
 ```
 
@@ -200,6 +206,7 @@ If blocking work remains, continue the `Finisher`-owned handling loop and re-che
 If a new push lands while you are monitoring, treat prior completion assumptions as stale and re-check review state, checks, mergeability, and PR metadata on the new head before reporting success.
 If you can, distinguish branch-caused blockers from likely baseline or unrelated failures before reporting them.
 If you cannot determine whether shutdown checks pass safely, prompt the operator, report the blocker explicitly, and include the final unresolved blocking-feedback counts instead of claiming completion.
+Use natural prose for status updates when possible, but never hide latest-head blockers. Pending checks, failed checks, unresolved feedback, mergeability problems, metadata violations, and shutdown blockers must remain clear and inspectable.
 Before resolving or replying to a comment tied to a file, commit, or line, verify it against the current branch state and the prior state the comment referred to.
 If feedback adds or changes requirements, route it through `Brainstormer`, then `Planner`, then `Executor`.
 Done-report contract:


### PR DESCRIPTION
# Pull Request

PR title rule for squash merges: use the exact commitlint/commitizen format for the PR title so the squash commit can be reused unchanged.

`type: #123 short description`

Examples:

- `docs: #12 add superteam skill guide`
- `chore: #34 bootstrap commit hooks`

This title rule applies to pull requests only. GitHub issue titles should stay plain-language and should not use conventional-commit prefixes.

## Summary

- Adds an operator-facing output contract that favors natural, decision-focused prose over fixed status-report templates.
- Keeps required evidence durable in artifacts, explicit handoff data, PR surfaces, and shutdown state.
- Adds pressure tests for robotic output, hidden blockers, resolved findings replay, evidence loss, and Finisher blocker masking.

## Linked issue

- Closes #58

## Acceptance criteria

### AC-58-1

Superteam phase and handoff output is no longer required to render a fixed status-report template when workflow invariants can be satisfied with natural prose.

- [x] Markdown/workflow evidence — pnpm lint:md + rg invariant checks + pressure-test walkthrough | local | @tlmader | 2026-04-28T02:59:43Z
- [ ] Manual test: 1. Read the updated `Operator-facing output` section. 2. Confirm it permits concise natural prose without deleting required evidence. 3. Confirm no fixed universal chat template was added.

### AC-58-2

The contract requires operator-facing output to keep requested decisions, feedback, approvals, next steps, and blockers clear.

- [x] Markdown/workflow evidence — rg invariant checks + live pressure scenario for hidden blockers | local | @tlmader | 2026-04-28T02:59:43Z
- [ ] Manual test: 1. Inspect the `Natural prose hides required operator decision or blocker` pressure test. 2. Confirm the required behavior rejects vague handoffs.

### AC-58-3

Active blockers or findings still surface with enough context for operator response.

- [x] Markdown/workflow evidence — rg evidence-preservation checks + pressure-test walkthrough | local | @tlmader | 2026-04-28T02:59:43Z
- [ ] Manual test: 1. Inspect Team Lead, Reviewer, and Finisher guidance. 2. Confirm active findings/blockers remain required in operator-facing output.

### AC-58-4

Resolved, closed, or dispositioned findings are quiet by default unless they affect the current operator decision.

- [x] Markdown/workflow evidence — live Gate 1 clean-review pressure scenario | local | @tlmader | 2026-04-28T02:59:43Z
- [ ] Manual test: 1. Inspect the Gate 1 rendering guidance. 2. Confirm closed findings are not replayed by default.

### AC-58-5

Required traceability remains durable without forcing chat output into a status report.

- [x] Markdown/workflow evidence — rg durable-evidence checks + live evidence-loss pressure scenario | local | @tlmader | 2026-04-28T02:59:43Z
- [ ] Manual test: 1. Inspect the durable workflow data bullets. 2. Confirm required evidence cannot live only in volatile agent context.

### AC-58-6

Workflow-contract verification now includes pressure tests for robotic output, actionable findings, resolved findings, durable evidence, and blocker visibility.

- [x] Markdown/workflow evidence — new pressure-test headings verified with rg and reviewed by fresh subagent | local | @tlmader | 2026-04-28T02:59:43Z
- [ ] Manual test: 1. Inspect the five new pressure-test scenarios. 2. Confirm they cover both too-robotic and too-vague output failures.

## Validation

- `pnpm lint:md`
- `git diff --check`
- `rg` checks for invariant language, pressure-test scenarios, and preserved evidence fields
- Fresh Reviewer pass found no findings
- Live pressure test pass compared `HEAD~1` to `HEAD` across the five new scenarios

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
