### PR TITLE
feat: #62 add superteam skill review loop

### DIFF
--- a/docs/superpowers/plans/2026-04-28-62-use-trail-of-bits-skill-review-loops-to-harden-superteam-plan.md
+++ b/docs/superpowers/plans/2026-04-28-62-use-trail-of-bits-skill-review-loops-to-harden-superteam-plan.md
@@ -380,7 +380,7 @@ Expected: matches for all four new scenarios.
 Run:
 
 ```bash
-rg -n "Loopback: spec-level|Loopback: plan-level|Loopback: implementation-level" docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md skills/superteam docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+git diff -- docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md skills/superteam/skill-quality-review.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md | rg "Loopback: spec-level|Loopback: plan-level|Loopback: implementation-level"
 ```
 
 Expected: no output and exit code 1.
@@ -436,4 +436,5 @@ Reviewer must use `superpowers:requesting-code-review`, `superpowers:receiving-c
 - Spec coverage: Requirements 1-9 map to Tasks 1-5. AC-62-1 through AC-62-5 map to the review artifact, skill-quality guide, contract wiring, pressure tests, and PR evidence requirements.
 - Placeholder scan: Task 1 includes concrete RED observations from the pre-implementation state.
 - Type and naming consistency: The new guide is consistently named `skills/superteam/skill-quality-review.md`; the durable review artifact is consistently named `docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md`.
+- Plan adjustment: Task 5 checks the current diff for forbidden `Loopback:` trailer revival so existing historical pressure-test text does not create a false failure.
 - Blockers: none known.

--- a/docs/superpowers/plans/2026-04-28-62-use-trail-of-bits-skill-review-loops-to-harden-superteam-plan.md
+++ b/docs/superpowers/plans/2026-04-28-62-use-trail-of-bits-skill-review-loops-to-harden-superteam-plan.md
@@ -1,0 +1,439 @@
+# Plan: Use Trail of Bits skill review loops to harden Superteam [#62](https://github.com/patinaproject/superteam/issues/62)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a repeatable, evidence-producing Trail of Bits-inspired skill review loop to Superteam's workflow-contract surfaces.
+
+**Architecture:** This is a workflow-contract documentation change. Add one concise Superteam-owned review-loop guide, link it from the canonical skill, require the loop in relevant delegated role prompts, and extend pressure tests so the new discipline has RED/GREEN coverage without making Trail of Bits plugins a shipped dependency.
+
+**Tech Stack:** Markdown, GitHub CLI, `markdownlint-cli2`, repo-local `pnpm` scripts, Git commit-message hooks.
+
+---
+
+## Source Documents
+
+- Issue: `#62`
+- Design: `docs/superpowers/specs/2026-04-28-62-use-trail-of-bits-skill-review-loops-to-harden-superteam-design.md`
+- Core contract: `skills/superteam/SKILL.md`
+- Delegation prompts: `skills/superteam/agent-spawn-template.md`
+- Pressure tests: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+- Trail of Bits workflow design skill: `workflow-skill-design/designing-workflow-skills`
+- Trail of Bits workflow reviewer agent: `workflow-skill-design/workflow-skill-reviewer`
+- Trail of Bits skill improver skill: `skill-improver/skill-improver`
+- Repo rules: `AGENTS.md`
+
+## File Structure
+
+- Create `skills/superteam/skill-quality-review.md`: concise, repo-owned review-loop contract adapted from Trail of Bits workflow-skill reviewer and skill-improver guidance.
+- Create `docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md`: durable review evidence for this issue, including RED baseline, findings, minor finding evaluation, and conflict disposition.
+- Modify `skills/superteam/SKILL.md`: link the review-loop guide, require it for skill/workflow-contract changes, and add rationalization and red-flag coverage.
+- Modify `skills/superteam/agent-spawn-template.md`: make Executor and Reviewer prompts carry the new review-loop guidance for workflow-contract changes.
+- Modify `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`: add scenarios proving the loop cannot be skipped, findings cannot be vague, minor findings cannot be applied blindly, and local contracts win over external guidance.
+- Modify `.github/pull_request_template.md` only if execution discovers the template cannot express AC-62 evidence clearly. The current template already supports AC evidence, so this is expected to remain unchanged.
+
+## RED Baseline Evidence
+
+Before editing workflow surfaces, capture the unchanged state from the current branch after the design commit.
+
+- [ ] **Step 1: Confirm no Superteam-owned skill-quality review guide exists**
+
+Run:
+
+```bash
+test ! -f skills/superteam/skill-quality-review.md
+```
+
+Expected RED evidence: exit code 0, proving no repeatable Superteam-owned Trail of Bits adaptation guide exists.
+
+- [ ] **Step 2: Confirm current Superteam references do not name Trail of Bits review loops**
+
+Run:
+
+```bash
+rg -n "Trail of Bits|workflow-skill-reviewer|skill-improver|skill-quality-review" skills/superteam docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+Expected RED evidence: no output and exit code 1, proving the current workflow does not name the requested review/improvement loop.
+
+- [ ] **Step 3: Confirm pressure tests lack the requested evidence contract**
+
+Run:
+
+```bash
+rg -n "minor findings|severity.*disposition|skill-quality review|Trail of Bits" docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+Expected RED evidence: no output and exit code 1, proving the pressure-test suite does not yet cover severity/disposition, minor finding evaluation, or Trail of Bits adaptation.
+
+Record these command outputs in `docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md`.
+
+## Task 1: Add Durable Review Evidence
+
+**Files:**
+
+- Create: `docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md`
+
+- [ ] **Step 1: Create the review evidence file**
+
+Create the file with this content:
+
+```markdown
+# Review: Trail of Bits skill loop hardening [#62](https://github.com/patinaproject/superteam/issues/62)
+
+## Purpose
+
+Record the adapted Trail of Bits workflow-skill review and skill-improver evidence for Superteam issue #62.
+
+## RED Baseline
+
+| Check | Command | Expected RED result | Observed |
+| --- | --- | --- | --- |
+| Missing local review guide | `test ! -f skills/superteam/skill-quality-review.md` | Exit code 0 | RED confirmed before implementation: exit code 0, no stdout |
+| Missing Trail of Bits loop references | `rg -n "Trail of Bits\|workflow-skill-reviewer\|skill-improver\|skill-quality-review" skills/superteam docs/superpowers/pressure-tests/superteam-orchestration-contract.md` | Exit code 1, no output | RED confirmed before implementation: exit code 1, no stdout |
+| Missing pressure tests | `rg -n "minor findings\|severity.*disposition\|skill-quality review\|Trail of Bits" docs/superpowers/pressure-tests/superteam-orchestration-contract.md` | Exit code 1, no output | RED confirmed before implementation: exit code 1, no stdout |
+
+## Adapted Review Sources
+
+- Trail of Bits `workflow-skill-reviewer`: structural analysis, workflow pattern analysis, content quality, tool assignment, and anti-pattern scan.
+- Trail of Bits `skill-improver`: critical and major findings must be fixed or explicitly dispositioned; minor findings are evaluated before applying.
+- Superteam local contract: review evidence feeds Brainstormer, Planner, Executor, Reviewer, and Finisher; it does not replace them.
+
+## Findings
+
+| ID | Severity | Surface | Finding | Disposition | Verification |
+| --- | --- | --- | --- | --- | --- |
+| F-62-1 | major | `skills/superteam` | No repo-owned adaptation guide currently tells Superteam reviewers how to run or record the Trail of Bits workflow-skill review loop. | Fix by adding `skills/superteam/skill-quality-review.md`. | `rg -n "skill-quality-review|Trail of Bits" skills/superteam` |
+| F-62-2 | major | `skills/superteam/SKILL.md` and `skills/superteam/agent-spawn-template.md` | Skill/workflow-contract changes do not yet require severity, disposition, and minor-finding evaluation from the adapted loop. | Fix by linking the review guide and updating role guidance. | `rg -n "severity|disposition|minor findings" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md` |
+| F-62-3 | major | `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` | Existing pressure tests do not fail the shortcuts introduced by this issue. | Fix by adding pressure tests for skipped loop, vague findings, blind minor fixes, and local-contract conflicts. | `rg -n "Trail of Bits|minor findings|local contract" docs/superpowers/pressure-tests/superteam-orchestration-contract.md` |
+
+## Minor Finding Evaluation
+
+No minor findings are accepted by default. During execution, add one row per minor finding discovered by the adapted review loop.
+
+| ID | Surface | Finding | Evaluation | Decision |
+| --- | --- | --- | --- | --- |
+
+## Conflict Disposition
+
+Trail of Bits guidance is advisory when it conflicts with Superteam's local contracts. Superteam preserves committed design and plan artifacts, visible-state resume, Reviewer before Finisher, latest-head Finisher shutdown, and the prohibition on `Loopback:` trailers or hidden workflow-state markers.
+
+## Completion Marker
+
+The adapted skill-improver loop is complete only when no critical or major finding remains open, and all minor findings have been evaluated for usefulness.
+```
+
+- [ ] **Step 2: Verify baseline observations are specific**
+
+Read the `## RED Baseline` table and confirm each row contains an observed exit code.
+
+- [ ] **Step 3: Verify RED observations are present**
+
+Run:
+
+```bash
+rg -n "RED confirmed before implementation" docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md
+```
+
+Expected: three matches in the `## RED Baseline` table.
+
+## Task 2: Add the Superteam Skill-Quality Review Guide
+
+**Files:**
+
+- Create: `skills/superteam/skill-quality-review.md`
+
+- [ ] **Step 1: Create the guide**
+
+Create `skills/superteam/skill-quality-review.md` with this content:
+
+```markdown
+# Skill Quality Review
+
+Use this guide when a Superteam run changes `skills/superteam/SKILL.md`, `skills/superteam/*.md`, `docs/superpowers/pressure-tests/*.md`, or another repository-owned workflow-contract surface.
+
+The guide adapts Trail of Bits workflow-skill review and skill-improver discipline into Superteam's local workflow. It is a review method, not a runtime dependency.
+
+## Review Sequence
+
+1. Confirm the changed surfaces and read the governing repository rules.
+2. Apply the workflow-skill review categories:
+   - frontmatter and trigger description quality
+   - workflow pattern and phase/gate clarity
+   - progressive disclosure and reference size
+   - file-reference integrity
+   - tool or agent portability
+   - anti-patterns, especially reference dumps, hidden state, and unbounded delegation
+3. Categorize findings:
+   - `critical`: blocks loading, references missing files, or makes the workflow impossible to execute
+   - `major`: materially weakens triggering, gates, role ownership, verification, or handoff safety
+   - `minor`: polish, style, or optional clarity improvement
+4. Fix or explicitly disposition every critical and major finding.
+5. Evaluate every minor finding before applying it. Apply only when it improves execution reliability, evidence quality, or operator clarity.
+6. Record evidence in an issue-specific review artifact or PR acceptance-criteria section.
+
+## Required Evidence
+
+Each finding needs:
+
+- severity: `critical`, `major`, or `minor`
+- affected surface
+- finding summary
+- disposition: `fixed`, `not applicable`, `deferred with rationale`, or `accepted minor`
+- verification command, pressure-test scenario, or review evidence
+
+## Local Contract Priority
+
+When Trail of Bits guidance conflicts with Superteam's local contracts, keep the local contract and record the decision. Local contracts include committed design and plan artifacts, visible-state resume, no hidden routing markers, Reviewer before Finisher, and latest-head Finisher shutdown.
+
+## Completion Criteria
+
+The adapted loop is complete when:
+
+- no critical or major finding remains open
+- every minor finding has been evaluated for usefulness
+- pressure tests cover any new workflow discipline rule
+- the PR body maps acceptance criteria to review evidence that actually ran
+```
+
+- [ ] **Step 2: Verify the guide covers required terms**
+
+Run:
+
+```bash
+rg -n "critical|major|minor|disposition|Local Contract Priority|Completion Criteria" skills/superteam/skill-quality-review.md
+```
+
+Expected: matches in the categorization, evidence, local contract, and completion sections.
+
+## Task 3: Wire the Guide into Superteam Contracts
+
+**Files:**
+
+- Modify: `skills/superteam/SKILL.md`
+- Modify: `skills/superteam/agent-spawn-template.md`
+
+- [ ] **Step 1: Add a skill-quality review section to `SKILL.md`**
+
+Insert this section after `## Canonical rule discovery`:
+
+```markdown
+## Skill-quality review loop
+
+When a run changes `skills/superteam/SKILL.md`, adjacent `skills/superteam/*.md` workflow-contract files, or repo-owned pressure tests for this workflow, use `skill-quality-review.md` as the local adaptation of Trail of Bits workflow-skill review and skill-improver discipline.
+
+This loop feeds Superteam's normal teammate workflow. It does not replace `Brainstormer`, `Planner`, `Executor`, `Reviewer`, or `Finisher`.
+
+Required outcomes:
+
+- Record each finding with severity, affected surface, disposition, and verification evidence.
+- Fix or explicitly disposition every critical and major finding before publish.
+- Evaluate minor findings for usefulness before applying them.
+- Preserve local contracts when external skill-review guidance conflicts with Superteam.
+- Keep review evidence in durable artifacts, PR acceptance criteria, or other inspectable records rather than volatile chat context.
+```
+
+- [ ] **Step 2: Add Reviewer contract guidance**
+
+In `### Reviewer`, after the existing `superpowers:writing-skills` recommendation, add:
+
+```markdown
+- For Superteam workflow-contract changes, apply `skill-quality-review.md` before publish and verify critical/major findings are fixed or dispositioned.
+- Evaluate minor findings for usefulness instead of applying them blindly.
+- Treat the Trail of Bits-inspired review loop as evidence for local review, not as a replacement for local review ownership.
+```
+
+- [ ] **Step 3: Add Executor contract guidance**
+
+In `### Executor`, after the existing skill recommendations, add:
+
+```markdown
+- When implementing a workflow-contract change, produce or update the issue-specific review evidence required by `skill-quality-review.md`.
+```
+
+- [ ] **Step 4: Add rationalization rows**
+
+Append these rows to `## Rationalization table`:
+
+```markdown
+| "The Trail of Bits loop ran, so Reviewer and Finisher can be skipped." | The loop is evidence for Superteam's local stages, not a replacement for Reviewer or latest-head Finisher follow-through. |
+| "A minor skill-review finding came from a reviewer, so we should apply it automatically." | Minor findings can be false positives or style preferences. Evaluate usefulness before applying. |
+| "The upstream plugin is unavailable, so we can omit the evidence." | `skill-quality-review.md` is the repo-owned adaptation. Use it and record any upstream-tool limitation. |
+```
+
+- [ ] **Step 5: Add red flags**
+
+Append these bullets to `## Red flags`:
+
+```markdown
+- Superteam workflow-contract changes publish without `skill-quality-review.md` evidence.
+- Critical or major skill-review findings remain open without a blocker or explicit disposition.
+- Minor skill-review findings are applied automatically without usefulness evaluation.
+- Trail of Bits guidance overrides a local Superteam contract without a recorded conflict disposition.
+```
+
+- [ ] **Step 6: Link the guide in Supporting files**
+
+Append this bullet to `## Supporting files`:
+
+```markdown
+- [skill-quality-review.md](./skill-quality-review.md): local Trail of Bits-inspired skill review and improvement loop
+```
+
+- [ ] **Step 7: Update `agent-spawn-template.md` Reviewer block**
+
+In the `### Reviewer` role-specific block, after the existing `superpowers:writing-skills` recommendation, add:
+
+```text
+For Superteam workflow-contract changes, apply `skills/superteam/skill-quality-review.md` before publish. Verify critical and major findings are fixed or explicitly dispositioned, evaluate minor findings for usefulness, and keep evidence durable in an issue-specific review artifact, PR acceptance criteria, or another inspectable record.
+```
+
+- [ ] **Step 8: Update `agent-spawn-template.md` Executor block**
+
+In the `### Executor` role-specific block, after the existing `superpowers:writing-skills` recommendation, add:
+
+```text
+When implementation changes Superteam workflow-contract surfaces, produce or update the issue-specific review evidence required by `skills/superteam/skill-quality-review.md`.
+```
+
+- [ ] **Step 9: Verify contract wiring**
+
+Run:
+
+```bash
+rg -n "skill-quality-review|critical.*major|minor findings|Trail of Bits" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md
+```
+
+Expected: matches in the new skill-quality review section, Reviewer and Executor guidance, rationalization table, red flags, supporting files, and delegated prompt blocks.
+
+## Task 4: Add Pressure-Test Coverage
+
+**Files:**
+
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+- [ ] **Step 1: Add skipped-loop pressure test**
+
+Append this scenario:
+
+```markdown
+## Superteam workflow-contract change skips Trail of Bits-inspired review loop
+
+- Starting condition: A run changes `skills/superteam/SKILL.md`, adjacent `skills/superteam/*.md`, or Superteam pressure tests, but no `skill-quality-review.md` evidence exists in a durable artifact, PR acceptance criteria, or other inspectable record.
+- Required halt or reroute behavior: Halt publish readiness and route back through local `Reviewer` until the adapted review loop has run or the blocker is explicitly reported.
+- Rule surface: Superteam workflow-contract changes require the repo-owned Trail of Bits-inspired skill-quality review loop before publish.
+```
+
+- [ ] **Step 2: Add vague-finding pressure test**
+
+Append this scenario:
+
+```markdown
+## Skill-quality review findings lack severity or disposition
+
+- Starting condition: A skill-quality review says the Superteam skill was reviewed, but findings lack severity, affected surface, disposition, or verification evidence.
+- Required halt or reroute behavior: Halt the handoff and require the review evidence to classify each finding before publish.
+- Rule surface: `skill-quality-review.md` requires severity, affected surface, disposition, and verification evidence for every finding.
+```
+
+- [ ] **Step 3: Add minor-finding pressure test**
+
+Append this scenario:
+
+```markdown
+## Minor skill-review findings applied blindly
+
+- Starting condition: A reviewer reports minor skill-quality findings and Executor applies them without evaluating whether they improve execution reliability, evidence quality, or operator clarity.
+- Required halt or reroute behavior: Halt or reroute the change until each minor finding is evaluated and either accepted with rationale or rejected as not useful.
+- Rule surface: The adapted skill-improver loop requires minor findings to be evaluated before implementation.
+```
+
+- [ ] **Step 4: Add local-contract conflict pressure test**
+
+Append this scenario:
+
+```markdown
+## External skill-review guidance conflicts with Superteam local contracts
+
+- Starting condition: Trail of Bits-inspired guidance suggests a change that would bypass committed design/plan artifacts, visible-state resume, local Reviewer ownership, latest-head Finisher shutdown, or the prohibition on hidden routing markers.
+- Required halt or reroute behavior: Preserve the Superteam local contract and record the conflict disposition before publish.
+- Rule surface: `skill-quality-review.md` treats Trail of Bits guidance as an adapted review method, not a higher-priority runtime contract.
+```
+
+- [ ] **Step 5: Verify pressure tests**
+
+Run:
+
+```bash
+rg -n "Trail of Bits-inspired|severity or disposition|Minor skill-review findings|local contracts" docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+Expected: matches for all four new scenarios.
+
+## Task 5: Verify, Commit, and Hand Off to Reviewer
+
+**Files:**
+
+- All files changed in Tasks 1-4
+
+- [ ] **Step 1: Verify forbidden hidden-state trailers were not revived**
+
+Run:
+
+```bash
+rg -n "Loopback: spec-level|Loopback: plan-level|Loopback: implementation-level" docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md skills/superteam docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+Expected: no output and exit code 1.
+
+- [ ] **Step 2: Verify targeted AC evidence**
+
+Run:
+
+```bash
+rg -n "F-62-|critical|major|minor|disposition|skill-quality-review|Trail of Bits-inspired" docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md skills/superteam docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+Expected: matches in the review artifact, skill-quality guide, Superteam contract, delegated prompts, and pressure tests.
+
+- [ ] **Step 3: Run Markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: exit code 0 and `Summary: 0 error(s)`.
+
+- [ ] **Step 4: Verify plugin versions**
+
+Run:
+
+```bash
+node scripts/check-plugin-versions.mjs
+```
+
+Expected: `check-plugin-versions: all manifests at 1.3.0`.
+
+- [ ] **Step 5: Commit implementation**
+
+Run:
+
+```bash
+git status --short
+git add docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md skills/superteam/skill-quality-review.md skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+git commit -m "feat: #62 add superteam skill review loop"
+```
+
+Expected: commit succeeds after pre-commit lint and version checks.
+
+- [ ] **Step 6: Hand off to Reviewer**
+
+Reviewer must use `superpowers:requesting-code-review`, `superpowers:receiving-code-review` when interpreting any disputed finding, and `superpowers:writing-skills` for the changed skill/workflow-contract surfaces. Reviewer must also apply `skills/superteam/skill-quality-review.md` and rerun the relevant pressure-test walkthrough before Finisher publishes.
+
+## Plan Self-Review
+
+- Spec coverage: Requirements 1-9 map to Tasks 1-5. AC-62-1 through AC-62-5 map to the review artifact, skill-quality guide, contract wiring, pressure tests, and PR evidence requirements.
+- Placeholder scan: Task 1 includes concrete RED observations from the pre-implementation state.
+- Type and naming consistency: The new guide is consistently named `skills/superteam/skill-quality-review.md`; the durable review artifact is consistently named `docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md`.
+- Blockers: none known.

--- a/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+++ b/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
@@ -441,3 +441,27 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Starting condition: A required check is failing after the latest push, but the workflow reports the failure without attempting to distinguish whether it was introduced by the branch or appears unrelated baseline noise.
 - Required halt or reroute behavior: Keep the issue in the Finisher loop, inspect enough evidence to make the best branch-caused vs baseline distinction available, and report the result explicitly. If the distinction still cannot be made safely, prompt the operator instead of guessing.
 - Rule surface: The Finisher contract should require explicit blocker reporting and branch-aware CI triage before handoff or halt.
+
+## Superteam workflow-contract change skips Trail of Bits-inspired review loop
+
+- Starting condition: A run changes `skills/superteam/SKILL.md`, adjacent `skills/superteam/*.md`, or Superteam pressure tests, but no `skill-quality-review.md` evidence exists in a durable artifact, PR acceptance criteria, or other inspectable record.
+- Required halt or reroute behavior: Halt publish readiness and route back through local `Reviewer` until the adapted review loop has run or the blocker is explicitly reported.
+- Rule surface: Superteam workflow-contract changes require the repo-owned Trail of Bits-inspired skill-quality review loop before publish.
+
+## Skill-quality review findings lack severity or disposition
+
+- Starting condition: A skill-quality review says the Superteam skill was reviewed, but findings lack severity, affected surface, disposition, or verification evidence.
+- Required halt or reroute behavior: Halt the handoff and require the review evidence to classify each finding before publish.
+- Rule surface: `skill-quality-review.md` requires severity, affected surface, disposition, and verification evidence for every finding.
+
+## Minor skill-review findings applied blindly
+
+- Starting condition: A reviewer reports minor skill-quality findings and Executor applies them without evaluating whether they improve execution reliability, evidence quality, or operator clarity.
+- Required halt or reroute behavior: Halt or reroute the change until each minor finding is evaluated and either accepted with rationale or rejected as not useful.
+- Rule surface: The adapted skill-improver loop requires minor findings to be evaluated before implementation.
+
+## External skill-review guidance conflicts with Superteam local contracts
+
+- Starting condition: Trail of Bits-inspired guidance suggests a change that would bypass committed design/plan artifacts, visible-state resume, local Reviewer ownership, latest-head Finisher shutdown, or the prohibition on hidden routing markers.
+- Required halt or reroute behavior: Preserve the Superteam local contract and record the conflict disposition before publish.
+- Rule surface: `skill-quality-review.md` treats Trail of Bits guidance as an adapted review method, not a higher-priority runtime contract.

--- a/docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md
+++ b/docs/superpowers/reviews/2026-04-28-62-trail-of-bits-skill-review.md
@@ -1,0 +1,42 @@
+# Review: Trail of Bits skill loop hardening [#62](https://github.com/patinaproject/superteam/issues/62)
+
+## Purpose
+
+Record the adapted Trail of Bits workflow-skill review and skill-improver evidence for Superteam issue #62.
+
+## RED Baseline
+
+| Check | Command | Expected RED result | Observed |
+| --- | --- | --- | --- |
+| Missing local review guide | `test ! -f skills/superteam/skill-quality-review.md` | Exit code 0 | RED confirmed before implementation: exit code 0, no stdout |
+| Missing Trail of Bits loop references | `rg -n "Trail of Bits\|workflow-skill-reviewer\|skill-improver\|skill-quality-review" skills/superteam docs/superpowers/pressure-tests/superteam-orchestration-contract.md` | Exit code 1, no output | RED confirmed before implementation: exit code 1, no stdout |
+| Missing pressure tests | `rg -n "minor findings\|severity.*disposition\|skill-quality review\|Trail of Bits" docs/superpowers/pressure-tests/superteam-orchestration-contract.md` | Exit code 1, no output | RED confirmed before implementation: exit code 1, no stdout |
+
+## Adapted Review Sources
+
+- Trail of Bits `workflow-skill-reviewer`: structural analysis, workflow pattern analysis, content quality, tool assignment, and anti-pattern scan.
+- Trail of Bits `skill-improver`: critical and major findings must be fixed or explicitly dispositioned; minor findings are evaluated before applying.
+- Superteam local contract: review evidence feeds Brainstormer, Planner, Executor, Reviewer, and Finisher; it does not replace them.
+
+## Findings
+
+| ID | Severity | Surface | Finding | Disposition | Verification |
+| --- | --- | --- | --- | --- | --- |
+| F-62-1 | major | `skills/superteam` | No repo-owned adaptation guide currently tells Superteam reviewers how to run or record the Trail of Bits workflow-skill review loop. | fixed: added `skills/superteam/skill-quality-review.md`. | `rg -n "skill-quality-review\|Trail of Bits" skills/superteam` |
+| F-62-2 | major | `skills/superteam/SKILL.md` and `skills/superteam/agent-spawn-template.md` | Skill/workflow-contract changes do not yet require severity, disposition, and minor-finding evaluation from the adapted loop. | fixed: linked the review guide and updated Executor and Reviewer role guidance. | `rg -n "severity\|disposition\|minor findings" skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md` |
+| F-62-3 | major | `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` | Existing pressure tests do not fail the shortcuts introduced by this issue. | fixed: added pressure tests for skipped loop, vague findings, blind minor fixes, and local-contract conflicts. | `rg -n "Trail of Bits\|minor findings\|local contract" docs/superpowers/pressure-tests/superteam-orchestration-contract.md` |
+
+## Minor Finding Evaluation
+
+No minor findings are accepted by default. During execution, add one row per minor finding discovered by the adapted review loop.
+
+| ID | Surface | Finding | Evaluation | Decision |
+| --- | --- | --- | --- | --- |
+
+## Conflict Disposition
+
+Trail of Bits guidance is advisory when it conflicts with Superteam's local contracts. Superteam preserves committed design and plan artifacts, visible-state resume, Reviewer before Finisher, latest-head Finisher shutdown, and the prohibition on `Loopback:` trailers or hidden workflow-state markers.
+
+## Completion Marker
+
+The adapted skill-improver loop is complete only when no critical or major finding remains open, and all minor findings have been evaluated for usefulness.

--- a/docs/superpowers/specs/2026-04-28-62-use-trail-of-bits-skill-review-loops-to-harden-superteam-design.md
+++ b/docs/superpowers/specs/2026-04-28-62-use-trail-of-bits-skill-review-loops-to-harden-superteam-design.md
@@ -1,0 +1,115 @@
+# Design: Use Trail of Bits skill review loops to harden Superteam [#62](https://github.com/patinaproject/superteam/issues/62)
+
+## Intent
+
+Use Trail of Bits workflow-skill review guidance and skill-improver discipline as a repeatable hardening input for Superteam without making Superteam depend on Claude-only runtime behavior or hidden workflow state.
+
+This change should add a repo-owned quality path for reviewing `skills/superteam/SKILL.md` and adjacent workflow-contract files, capturing findings, applying useful fixes, and documenting the review evidence that proves the workflow-contract surface was actually pressure-tested.
+
+## Requirements
+
+1. The implementation must treat `skills/superteam/SKILL.md` and adjacent workflow files as workflow-skill surfaces, not ordinary docs.
+2. The review path must apply or adapt Trail of Bits `workflow-skill-reviewer` checks for structure, trigger description quality, workflow pattern fit, content quality, tool assignment, and anti-patterns.
+3. The improvement path must apply or adapt Trail of Bits `skill-improver` severity handling: critical and major findings are fixed or explicitly dispositioned; minor findings are evaluated before applying.
+4. Review findings must be recorded with severity, affected surface, finding text, disposition, and verification evidence.
+5. The design must preserve Superteam's current local contracts: issue-first work, committed design and plan artifacts, visible-state resume, teammate ownership, Gate 1 adversarial review, Reviewer before Finisher, and latest-head publish-state follow-through.
+6. The design must not reintroduce `Loopback:` trailers or other hidden persistence markers removed by the current Superteam workflow.
+7. The implementation must document the exact review loop or adapted commands used so future Superteam workflow-contract changes can repeat the gate.
+8. The implementation must include RED/GREEN evidence for any new workflow discipline rule it adds, or explicitly record why a Trail of Bits review step is advisory rather than a new rule.
+9. The PR must include acceptance-criteria verification under the repository PR template and must not claim production readiness without the review loop, pressure tests, and role-specific verification that actually ran.
+
+## Approach
+
+Use a three-layer adaptation rather than vendoring Trail of Bits plugin behavior wholesale.
+
+First, add repository guidance for a Superteam skill-quality review loop. The guidance should name the Trail of Bits sources and translate their expectations into this repo's language: findings, dispositions, evidence, and pressure-test updates. This keeps the quality loop repeatable even when the exact Trail of Bits plugin is not installed in a future runtime.
+
+Second, update Superteam workflow-contract surfaces only where the review loop needs to be enforced. Likely surfaces include `skills/superteam/SKILL.md`, `skills/superteam/agent-spawn-template.md`, and `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`. The implementation should avoid broad refactors and should not turn the operator-facing chat output back into a rigid status template.
+
+Third, run the adapted review loop against Superteam itself. The resulting findings should drive the actual implementation work. Critical and major issues must either be fixed or explicitly rejected as not applicable to Superteam with a repo-specific rationale. Minor findings are accepted only when they improve execution reliability or reviewer evidence.
+
+## Alternatives Considered
+
+### Vendor the Trail of Bits plugins
+
+This would keep the process closest to the upstream tools, but it would make Superteam's runtime story more brittle and could imply Claude-only behavior. This issue should use Trail of Bits as a review methodology, not as a mandatory shipped dependency.
+
+### Only run the existing pressure tests
+
+This preserves today's workflow but does not add the external skill-design lens requested by the issue. The current pressure tests should remain part of verification, but they should be supplemented by Trail of Bits structural review categories.
+
+### Replace Superteam's review contract with skill-improver
+
+This would overfit to one tool. Superteam still needs its teammate-owned local Reviewer and Finisher contracts. The Trail of Bits loop should feed those contracts rather than replace them.
+
+## Acceptance Criteria
+
+### AC-62-1
+
+Given the Superteam skill and adjacent workflow files, when the Trail of Bits workflow-skill review approach is applied or adapted, then the resulting findings are recorded with severity, affected file, and disposition.
+
+### AC-62-2
+
+Given a critical or major finding from that review, when the implementation is complete, then the finding is either fixed in the repository or explicitly documented as not applicable with a repo-specific rationale.
+
+### AC-62-3
+
+Given minor findings from the review, when the implementation is complete, then each minor finding is evaluated for usefulness rather than applied blindly.
+
+### AC-62-4
+
+Given the improvement pass has completed, when a maintainer reviews the PR, then the PR includes the exact verification steps, pressure tests, or review loop evidence that ran.
+
+### AC-62-5
+
+Given Superteam-specific workflow requirements, when Trail of Bits guidance conflicts with local Patina/Superteam contracts, then the local contract remains intact and the decision is documented.
+
+## Workflow-Skill Review Obligations
+
+The implementation must include a RED-phase baseline for any new Superteam discipline rule introduced by this issue. The baseline can be a pressure-test scenario, an adversarial review note, or a documented reviewer failure mode, but it must show what would go wrong without the rule.
+
+The review must explicitly check these writing-skills dimensions before Gate 1 can advance:
+
+- RED/GREEN baseline obligations for new discipline rules.
+- Rationalization resistance for shortcuts such as skipping the Trail of Bits loop, applying minor findings blindly, or treating plugin absence as permission to omit evidence.
+- Red flags for missing severity, missing disposition, non-repeatable review commands, and hidden state.
+- Token-efficiency targets so the Superteam skill does not grow by dumping external reviewer docs inline.
+- Role ownership so Brainstormer, Planner, Executor, Reviewer, and Finisher keep their existing responsibilities.
+- Stage-gate bypass paths, especially paths that would let Executor publish without Reviewer or Finisher because a skill-improver loop already ran.
+
+## Rationalizations to Reject
+
+| Rationalization | Why it fails |
+| --- | --- |
+| "The Trail of Bits reviewer is external, so a summary is enough." | Future reviewers need severity, affected file, disposition, and verification evidence to trust the loop. |
+| "The skill-improver loop fixed issues, so Superteam Reviewer can be skipped." | The loop is an input to local review, not a replacement for Superteam's Reviewer and Finisher stages. |
+| "A minor finding came from a reviewer, so we should apply it automatically." | Minor findings can be false positives or style preferences; each one needs usefulness evaluation. |
+| "The plugin is unavailable, so the AC is impossible." | The repo can adapt the workflow-skill review categories and record the limitation rather than silently skipping the quality gate. |
+| "A new sidecar marker would make the loop easier to resume." | Superteam v1.3.0 resumes from visible artifacts, PR state, and operator prompts; hidden persistence markers are out of scope. |
+
+## Red Flags
+
+- Findings are recorded without severity or disposition.
+- Critical or major findings remain open without an explicit blocker.
+- Minor findings are applied mechanically without value evaluation.
+- Review evidence names Trail of Bits generally but does not identify the checks or adapted process that ran.
+- Implementation changes workflow-contract files without updating or running pressure-test coverage.
+- The review loop bypasses Brainstormer, Planner, Executor, Reviewer, or Finisher ownership.
+- The Superteam skill gains large copied Trail of Bits reference material instead of concise local guidance and links.
+- The implementation reintroduces `Loopback:` trailers or another hidden workflow-state marker.
+
+## Verification Plan
+
+1. Run or adapt the Trail of Bits `workflow-skill-reviewer` process against `skills/superteam`.
+2. Run or adapt the Trail of Bits `skill-improver` severity loop until no critical or major finding remains unaddressed.
+3. Run the Superteam orchestration pressure tests that cover workflow-contract review, natural operator-facing output, visible-state resume, Reviewer handoff, and Finisher shutdown behavior.
+4. Run markdown lint for changed Markdown files.
+5. Verify the PR body maps AC-62-1 through AC-62-5 to the review evidence and pressure-test results that actually ran.
+
+## Out of Scope
+
+- Vendoring Trail of Bits plugins into this repository.
+- Requiring Claude-only agent tools for Superteam to function.
+- Replacing Superteam's local Reviewer and Finisher stages.
+- Reintroducing commit trailers, sidecar files, branch labels, or hidden state for workflow routing.
+- Broad rewrites of Superteam unrelated to skill-review loop hardening.

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -172,6 +172,20 @@ Before any teammate touches governed files, discover the canonical repository ru
 
 If canonical guidance cannot be found, halt and surface the blocker instead of guessing.
 
+## Skill-quality review loop
+
+When a run changes `skills/superteam/SKILL.md`, adjacent `skills/superteam/*.md` workflow-contract files, or repo-owned pressure tests for this workflow, use `skill-quality-review.md` as the local adaptation of Trail of Bits workflow-skill review and skill-improver discipline.
+
+This loop feeds Superteam's normal teammate workflow. It does not replace `Brainstormer`, `Planner`, `Executor`, `Reviewer`, or `Finisher`.
+
+Required outcomes:
+
+- Record each finding with severity, affected surface, disposition, and verification evidence.
+- Fix or explicitly disposition every critical and major finding before publish.
+- Evaluate minor findings for usefulness before applying them.
+- Preserve local contracts when external skill-review guidance conflicts with Superteam.
+- Keep review evidence in durable artifacts, PR acceptance criteria, or other inspectable records rather than volatile chat context.
+
 ## Artifact handoff authority
 
 Handoffs that depend on uncommitted durable artifact changes are incomplete unless the run halts explicitly with a blocker.
@@ -296,6 +310,7 @@ Headline behaviors:
 - Recommend `superpowers:test-driven-development` as the ATDD execution skill.
 - Recommend `superpowers:systematic-debugging` when debugging or failures appear.
 - Recommend `superpowers:writing-skills` when touching `skills/**/*.md`.
+- When implementing a workflow-contract change, produce or update the issue-specific review evidence required by `skill-quality-review.md`.
 - Recommend `superpowers:verification-before-completion` before claiming completion.
 
 ### Reviewer
@@ -307,6 +322,9 @@ Headline behaviors:
 - Recommend `superpowers:requesting-code-review` for first-pass local review.
 - Also recommend `superpowers:receiving-code-review` when analyzing existing or disputed findings before publish.
 - When reviewing changes to `skills/**/*.md` or workflow-contract docs, invoke `superpowers:writing-skills` and run the relevant pressure-test walkthrough before publish.
+- For Superteam workflow-contract changes, apply `skill-quality-review.md` before publish and verify critical/major findings are fixed or dispositioned.
+- Evaluate minor findings for usefulness instead of applying them blindly.
+- Treat the Trail of Bits-inspired review loop as evidence for local review, not as a replacement for local review ownership.
 - If later fixes change those same workflow-contract surfaces again after an earlier review pass, rerun the relevant pressure-test walkthrough before handing the run back to `Finisher`.
 - Report pressure-test pass/fail results and any loopholes found for skill or workflow-contract changes.
 - Report local findings with `feedback_classification` (`implementation-level` | `plan-level` | `spec-level`) and an owner before routing.
@@ -453,6 +471,9 @@ Before resolving or replying to comments tied to a prior branch state:
 | "No findings means no review evidence is needed." | A clean adversarial-review result must include `reviewer_context`, checked dimensions, and `clean_pass_rationale`; silence is not evidence. |
 | "This is a workflow-contract design, but a generic review is enough." | Designs touching `skills/**/*.md` or workflow-contract surfaces require the `superpowers:writing-skills` review dimensions: RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths. |
 | "A finding changed the design, but the earlier review still applies." | Material requirement, ownership, pressure-test, or gate-order changes require rerunning affected review dimensions or recording why rerun is unnecessary. |
+| "The Trail of Bits loop ran, so Reviewer and Finisher can be skipped." | The loop is evidence for Superteam's local stages, not a replacement for Reviewer or latest-head Finisher follow-through. |
+| "A minor skill-review finding came from a reviewer, so we should apply it automatically." | Minor findings can be false positives or style preferences. Evaluate usefulness before applying. |
+| "The upstream plugin is unavailable, so we can omit the evidence." | `skill-quality-review.md` is the repo-owned adaptation. Use it and record any upstream-tool limitation. |
 | "Natural prose means we can omit required Gate 1 evidence." | Natural prose changes rendering, not evidence. Required review status, reviewer context, checked dimensions, and clean-pass rationale must still exist before planning. |
 | "The operator might want audit history, so replay every closed finding." | Audit history stays available in durable artifacts or handoff data. Normal operator-facing output should show actionable findings and current decisions. |
 | "Done-report contracts are status templates, so we can delete them." | Done reports are durable handoff data. The change separates internal data contracts from chat rendering. |
@@ -506,6 +527,10 @@ Before resolving or replying to comments tied to a prior branch state:
 - `pre-flight.md` documenting kebab-casing, default-branch resolution, fetch, checkout, or rebase steps inline instead of referencing `/github-flows:new-branch`.
 - `Team Lead` silently continuing on the default branch after `gh repo view` fails to resolve the default branch.
 - A `superteam` run authoring `docs/superpowers/specs/...` on the default branch.
+- Superteam workflow-contract changes publish without `skill-quality-review.md` evidence.
+- Critical or major skill-review findings remain open without a blocker or explicit disposition.
+- Minor skill-review findings are applied automatically without usefulness evaluation.
+- Trail of Bits guidance overrides a local Superteam contract without a recorded conflict disposition.
 - Operator-facing output repeats closed or dispositioned findings when no operator action is required.
 - Natural prose omits the artifact, decision, active finding, blocker, or next action the operator needs.
 - A change deletes durable done-report or review evidence instead of separating it from chat rendering.
@@ -562,3 +587,4 @@ Do not silently continue past failed checks, missing artifacts, ambiguous reposi
 - [pr-body-template.md](./pr-body-template.md): PR checklist template used by `Finisher`
 - [pre-flight.md](./pre-flight.md): phase-detection sequence, execution-mode capability detection, halt conditions
 - [routing-table.md](./routing-table.md): phase x prompt-class routing, classification heuristic, resume vs restart, Gate 1 durability
+- [skill-quality-review.md](./skill-quality-review.md): local Trail of Bits-inspired skill review and improvement loop

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -128,6 +128,7 @@ Recommend `superpowers:test-driven-development`.
 Recommend `superpowers:systematic-debugging` when debugging or failures appear.
 Recommend `superpowers:verification-before-completion` before claiming completion.
 If any task touches `skills/**/*.md`, also recommend `superpowers:writing-skills`.
+When implementation changes Superteam workflow-contract surfaces, produce or update the issue-specific review evidence required by `skills/superteam/skill-quality-review.md`.
 
 Implement only the assigned task batch.
 Commit the completed implementation and test changes before reporting done or handing off to `Reviewer`.
@@ -150,6 +151,7 @@ Append this block in place of `{role-specific inputs}`:
 Recommend `superpowers:requesting-code-review`.
 Also recommend `superpowers:receiving-code-review` when analyzing existing or disputed findings before publish.
 Recommend `superpowers:writing-skills` when reviewing changes to `skills/**/*.md` or workflow-contract docs.
+For Superteam workflow-contract changes, apply `skills/superteam/skill-quality-review.md` before publish. Verify critical and major findings are fixed or explicitly dispositioned, evaluate minor findings for usefulness, and keep evidence durable in an issue-specific review artifact, PR acceptance criteria, or another inspectable record.
 
 Review locally before publish.
 Own receiving and interpreting local pre-publish review findings.

--- a/skills/superteam/skill-quality-review.md
+++ b/skills/superteam/skill-quality-review.md
@@ -1,0 +1,46 @@
+# Skill Quality Review
+
+Use this guide when a Superteam run changes `skills/superteam/SKILL.md`, `skills/superteam/*.md`, `docs/superpowers/pressure-tests/*.md`, or another repository-owned workflow-contract surface.
+
+The guide adapts Trail of Bits workflow-skill review and skill-improver discipline into Superteam's local workflow. It is a review method, not a runtime dependency.
+
+## Review Sequence
+
+1. Confirm the changed surfaces and read the governing repository rules.
+2. Apply the workflow-skill review categories:
+   - frontmatter and trigger description quality
+   - workflow pattern and phase/gate clarity
+   - progressive disclosure and reference size
+   - file-reference integrity
+   - tool or agent portability
+   - anti-patterns, especially reference dumps, hidden state, and unbounded delegation
+3. Categorize findings:
+   - `critical`: blocks loading, references missing files, or makes the workflow impossible to execute
+   - `major`: materially weakens triggering, gates, role ownership, verification, or handoff safety
+   - `minor`: polish, style, or optional clarity improvement
+4. Fix or explicitly disposition every critical and major finding.
+5. Evaluate every minor finding before applying it. Apply only when it improves execution reliability, evidence quality, or operator clarity.
+6. Record evidence in an issue-specific review artifact or PR acceptance-criteria section.
+
+## Required Evidence
+
+Each finding needs:
+
+- severity: `critical`, `major`, or `minor`
+- affected surface
+- finding summary
+- disposition: `fixed`, `not applicable`, `deferred with rationale`, or `accepted minor`
+- verification command, pressure-test scenario, or review evidence
+
+## Local Contract Priority
+
+When Trail of Bits guidance conflicts with Superteam's local contracts, keep the local contract and record the decision. Local contracts include committed design and plan artifacts, visible-state resume, no hidden routing markers, Reviewer before Finisher, and latest-head Finisher shutdown.
+
+## Completion Criteria
+
+The adapted loop is complete when:
+
+- no critical or major finding remains open
+- every minor finding has been evaluated for usefulness
+- pressure tests cover any new workflow discipline rule
+- the PR body maps acceptance criteria to review evidence that actually ran


### PR DESCRIPTION
## Summary

- Added a Superteam-owned `skill-quality-review.md` guide adapting Trail of Bits workflow-skill review and skill-improver discipline.
- Wired the guide into Superteam Executor and Reviewer contracts, delegated prompt guidance, rationalizations, red flags, and supporting files.
- Added durable review evidence plus pressure tests for skipped review loops, vague findings, blind minor-finding fixes, and local-contract conflicts.

## Linked issue

- Closes #62

## Acceptance criteria

### AC-62-1

Review findings are recorded with severity, affected file, disposition, and verification evidence in the issue-specific review artifact.

- [x] Local evidence — Codex | local | @codex | 2026-04-28T03:45:41Z

### AC-62-2

All recorded major findings are explicitly dispositioned as fixed with verification pointers.

- [x] Local evidence — Codex | local | @codex | 2026-04-28T03:45:41Z

### AC-62-3

Minor findings are required to be evaluated for usefulness before application in the new review guide and workflow contract.

- [x] Local evidence — Codex | local | @codex | 2026-04-28T03:45:41Z

### AC-62-4

The improvement pass includes exact verification evidence: RED baseline commands, targeted review checks, pressure-test walkthrough, markdown lint, plugin version check, and Reviewer approval.

- [x] Local evidence — Codex | local | @codex | 2026-04-28T03:45:41Z

### AC-62-5

Trail of Bits guidance is documented as an adapted review method, with Superteam local contracts taking priority when conflicts arise.

- [x] Local evidence — Codex | local | @codex | 2026-04-28T03:45:41Z

## Validation

- `pnpm lint:md` -> `Summary: 0 error(s)`
- `node scripts/check-plugin-versions.mjs` -> `check-plugin-versions: all manifests at 1.3.0`
- `git diff --check` -> passed
- Diff-scoped forbidden `Loopback:` trailer scan -> no matches
- Local Reviewer re-review -> approved with no findings

## Docs updated

- [x] Updated in this PR