### PR TITLE
feat: #62 harden superteam workflow routing

### DIFF
--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -1,11 +1,35 @@
 ---
 name: superteam
 description: Use when the operator runs `/superteam` or asks to take a GitHub issue from design through implementation, review, and merged-ready PR using the canonical Team Lead, Brainstormer, Planner, Executor, Reviewer, and Finisher teammate roster. Triggers on phrases like "run superteam on #N", "take this issue through the teammate workflow", or "drive #N to PR".
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Task
+  - TodoRead
+  - TodoWrite
 ---
 
 # superteam
 
 `superteam` is an orchestration skill for running a structured issue workflow across a canonical teammate roster. It uses repository-owned artifacts in `skills/` and `docs/` so the workflow stays portable across repositories and runtimes.
+
+## When to Use
+
+- A GitHub issue needs design, planning, implementation, review, PR publication, and publish-state follow-through.
+- An existing `superteam` issue workflow needs to resume from committed artifacts, branch state, or PR state.
+- Operator feedback, review findings, CI state, or PR comments need routing to the correct teammate.
+- Workflow-contract or skill changes need explicit gates, pressure-test evidence, and role-owned handoffs.
+
+## When NOT to Use
+
+- Simple GitHub issue or PR edits: use `using-github:using-github`.
+- Local code changes that do not need the full issue-to-PR workflow: use the relevant `superpowers` implementation or debugging skill directly.
+- One-off code review without teammate orchestration: use `superpowers:requesting-code-review` or `superpowers:receiving-code-review`.
+- General skill architecture review: use `workflow-skill-design:designing-workflow-skills`.
 
 ## Canonical roster
 
@@ -18,90 +42,7 @@ Use teammate names as the primary organizing language across the workflow:
 5. `Reviewer`: owns local pre-publish review findings
 6. `Finisher`: owns publish-state follow-through, CI, and external feedback handling
 
-The workflow may still reference brainstorm, plan, execute, review, and finish phases, but teammate names are the canonical contract language.
-
-## Workflow Diagrams
-
-The workflow diagrams should stay structurally accurate and easy to read:
-
-- use two Mermaid charts instead of trying to show chronology and orchestration in one diagram
-- use only two block types: teammates and artifacts
-- keep artifact nodes visually lighter with black text for readability
-- keep the chronological chart simple and forward-moving
-- keep the orchestration chart top-to-bottom and make `Team Lead` the routing hub for human feedback
-
-Chronological flow:
-
-```mermaid
-flowchart TD
-    issue["Issue"]:::artifact
-    lead["Team Lead"]
-    brainstormer["Brainstormer"]
-    design["Design Doc"]:::artifact
-    planner["Planner"]
-    plan["Plan Doc"]:::artifact
-    executor["Executor"]
-    implementation["Implementation & Tests"]:::artifact
-    reviewer["Reviewer"]
-    finisher["Finisher"]
-    pr["Pull Request"]:::artifact
-    human["Human Test & Review"]
-
-    issue --> lead
-    lead --> brainstormer
-    brainstormer --> design
-    design --> planner
-    planner --> plan
-    plan --> executor
-    executor --> implementation
-    implementation --> reviewer
-    reviewer --> finisher
-    finisher --> pr
-    pr --> human
-
-    classDef artifact fill:#f7f7f7,stroke:#666,stroke-width:1px,color:#000;
-```
-
-Orchestration flow:
-
-```mermaid
-flowchart TD
-    issue["Issue"]:::artifact
-    lead["Team Lead"]
-    brainstormer["Brainstormer"]
-    design["Design Doc"]:::artifact
-    planner["Planner"]
-    plan["Plan Doc"]:::artifact
-    executor["Executor"]
-    implementation["Implementation & Tests"]:::artifact
-    reviewer["Reviewer"]
-    finisher["Finisher"]
-    pr["Pull Request"]:::artifact
-    human["Human Test & Review"]
-
-    issue --> lead
-    lead --> brainstormer
-    brainstormer --> design
-    design --> planner
-    planner --> plan
-    plan --> executor
-    executor --> implementation
-    implementation --> reviewer
-    reviewer --> finisher
-    finisher --> pr
-    pr --> human
-
-    pr -->|"PR feedback / status"| finisher
-    human -->|"human feedback"| lead
-    reviewer -->|"review findings"| lead
-    finisher -->|"needs reroute"| lead
-
-    lead -->|"route planning work"| planner
-    lead -->|"route implementation work"| executor
-    lead -->|"route publish follow-through"| finisher
-
-    classDef artifact fill:#f7f7f7,stroke:#666,stroke-width:1px,color:#000;
-```
+The workflow may still reference brainstorm, plan, execute, review, and finish phases, but teammate names are the canonical contract language. See [workflow-diagrams.md](./workflow-diagrams.md) for the canonical Mermaid diagrams.
 
 ## Pre-flight
 
@@ -130,15 +71,7 @@ When observable state is ambiguous or contradictory per `pre-flight.md` halt con
 
 Execution-mode capability probing is part of this pre-flight. See `pre-flight.md` section `## Execution-mode capability detection` for the deterministic probe order, and `## Execution-mode injection` below for delegation-time injection. Missing execution capability halts only when the selected route requires execute-phase delegation; non-execute routes continue through their owning teammate.
 
-- Prefer the host runtime's normal multi-agent capabilities when available.
-- When the host runtime supports background-agent execution for delegated teammate work, prefer using that capability for bounded, independent work that is unlikely to need live clarification, as an execution aid rather than a correctness dependency.
-- Keep tightly coupled, ambiguity-heavy, or clarification-driven teammate work in the foreground even when background agents are available.
-- When the runtime offers durable follow-up features such as thread heartbeats, monitors, or equivalent wakeups, prefer using them for `Finisher` publish-state follow-through while required checks or external review state remain pending.
-- In Codex app environments, same-thread automations are the native fit when `Finisher` follow-through should stay attached to the current conversation.
-- Treat these runtime capabilities as aids for the existing teammate and `Finisher` loops, not as separate workflows or replacement contracts.
-- Do not block solely because a preferred team feature is unavailable; fall back to direct subagent dispatch.
-- If the host lacks those capabilities, do not stop early; continue using the portable teammate and `Finisher` contracts or report an explicit blocker when follow-through cannot safely continue.
-- Keep runtime-specific checks lightweight. Teammate ownership, gate discipline, and artifact authority are the important parts.
+Runtime capabilities are execution aids for the existing teammate and `Finisher` loops, not separate workflows or replacement contracts. Keep runtime-specific checks lightweight, prefer available team-mode or durable follow-up features only when they fit the current work, and continue through the portable teammate contracts when a preferred capability is unavailable.
 
 ## Execution-mode injection
 
@@ -328,11 +261,7 @@ Headline behaviors:
 - Do not invent a new intent-detection system or infer issue-closing intent from weak heuristics such as commit wording, diff size, or acceptance-criteria count.
 - Every `superteam` run is expected to publish a PR; local-only state is never a valid completion, demo, or handoff state.
 - Push the branch and create or update the PR before treating the run as being in publish-state follow-through.
-- Treat publish-state on the latest pushed head as an explicit `Finisher` state machine:
-  1. `triage`
-  2. `monitoring`
-  3. `ready`
-  4. `blocked`
+- Treat publish-state on the latest pushed head as an explicit `Finisher` state: `triage`, `monitoring`, `ready`, `blocked`, or `merged`.
 - When required checks on the latest pushed head are still pending after immediate branch-side fixes are complete, stay in `monitoring` rather than presenting the run as complete.
 - If later required checks fail while monitoring, re-enter `triage` automatically on the latest pushed head.
 - If later required checks pass while monitoring, allow `ready` only after the rest of the latest-head publish-state sweep is also clear.
@@ -447,9 +376,9 @@ Before resolving or replying to comments tied to a prior branch state:
 | "The issue only says workflow contract; I don't know the file yet, so I can draft first and decide later." | Plausible skill or workflow-contract scope is enough to load `superpowers:writing-skills` before authoring requirements. If the intended surface is uncertain, load writing-skills first or halt for clarification. |
 | "The operator is on the default branch on purpose; they clearly meant to start work here." | When the active issue resolves from the operator prompt and the current branch is the repository default branch, pre-flight MUST auto-switch to the per-issue branch before committed-artifact inspection. Operator intent is captured by the `#<n>` reference, not by the branch they happened to be on. Not even when the operator is the maintainer. Not even under deadline pressure. |
 | "Skipping the auto-switch saves a step; we can branch later." | Skipping authors Gate 1 artifacts on the wrong base and forces `Finisher` to rewrite history or push from the default branch. The rule is not optional. |
-| "Dirty working tree? I can stash and continue." | The canonical `/github-flows:new-branch` algorithm refuses on a dirty working tree. `superteam` halts with `superteam halted at Team Lead: dirty working tree blocks auto-switch to issue branch`. Pre-flight does NOT stash on the operator's behalf. |
-| "Rebase conflict on the existing issue branch is fine; I'll abort and try again." | The canonical algorithm forbids `git rebase --abort` on the operator's behalf. `superteam` halts and surfaces the conflict. |
-| "We can re-implement the kebab + checkout + rebase logic inside `superteam` so we don't depend on `github-flows`." | `/github-flows:new-branch` is the authoritative algorithm. `superteam` references it; it does not fork it. Divergence between the two is a contract bug. |
+| "Dirty working tree? I can stash and continue." | The `superteam` issue-branch procedure refuses on a dirty working tree. `superteam` halts with `superteam halted at Team Lead: dirty working tree blocks auto-switch to issue branch`. Pre-flight does NOT stash on the operator's behalf. |
+| "Rebase conflict on the existing issue branch is fine; I'll abort and try again." | The `superteam` issue-branch procedure forbids `git rebase --abort` on the operator's behalf. `superteam` halts and surfaces the conflict. |
+| "We can skip the self-contained branch procedure because another plugin probably has it." | `superteam` pre-flight is portable and owns its issue-branch procedure. Do not depend on another workflow skill being installed. |
 | "`adversarial_review_findings[]` already has Brainstormer entries, so review happened." | Brainstormer-originated findings are useful but not sufficient. Gate 1 requires an explicit adversarial-review pass against the committed artifact. |
 | "No findings means no review evidence is needed." | A clean adversarial-review result must include `reviewer_context`, checked dimensions, and `clean_pass_rationale`; silence is not evidence. |
 | "This is a workflow-contract design, but a generic review is enough." | Designs touching `skills/**/*.md` or workflow-contract surfaces require the `superpowers:writing-skills` review dimensions: RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths. |
@@ -504,7 +433,7 @@ Before resolving or replying to comments tied to a prior branch state:
 - `Team Lead` proceeding to committed-artifact inspection while the current branch is the repository default branch and the active issue was resolved from an explicit `#<n>` in the prompt.
 - `Team Lead` performing `git stash` or any auto-stash variant as part of the auto-switch path.
 - `Team Lead` running `git rebase --abort` after a rebase conflict on the existing issue branch.
-- `pre-flight.md` documenting kebab-casing, default-branch resolution, fetch, checkout, or rebase steps inline instead of referencing `/github-flows:new-branch`.
+- `pre-flight.md` depending on an external branch workflow instead of the self-contained issue-branch procedure.
 - `Team Lead` silently continuing on the default branch after `gh repo view` fails to resolve the default branch.
 - A `superteam` run authoring `docs/superpowers/specs/...` on the default branch.
 - Operator-facing output repeats closed or dispositioned findings when no operator action is required.
@@ -557,6 +486,10 @@ Any unsatisfied gate or failed teammate contract should halt the run and report:
 
 Do not silently continue past failed checks, missing artifacts, ambiguous repository state, or unresolved publish-state feedback.
 
+## Success criteria
+
+A successful run routes from observable state, preserves committed handoffs, publishes a PR, and either reaches latest-head shutdown readiness or halts with an explicit blocker.
+
 ## Supporting files
 
 - [agent-spawn-template.md](./agent-spawn-template.md): teammate-specific spawn guidance
@@ -564,3 +497,4 @@ Do not silently continue past failed checks, missing artifacts, ambiguous reposi
 - [pre-flight.md](./pre-flight.md): phase-detection sequence, execution-mode capability detection, halt conditions
 - [routing-table.md](./routing-table.md): phase x prompt-class routing, classification heuristic, resume vs restart, Gate 1 durability
 - [loopback-trailers.md](./loopback-trailers.md): deprecation note for legacy `Loopback:` commit trailers
+- [workflow-diagrams.md](./workflow-diagrams.md): canonical chronological and orchestration diagrams

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -190,7 +190,7 @@ Every `superteam` run is expected to publish a PR. Local-only state is never a v
 Push the branch and create or update the PR before treating the run as being in publish-state follow-through.
 Stay in the `Finisher` loop after PR publication until the publish-state follow-through is stable enough to hand off cleanly or an explicit blocker is reported.
 Do not treat PR creation, one status snapshot, restored mergeability, or green CI alone as workflow completion.
-Treat publish-state on the latest pushed head as explicit `Finisher` state: `triage`, `monitoring`, `ready`, or `blocked`.
+Treat publish-state on the latest pushed head as explicit `Finisher` state: `triage`, `monitoring`, `ready`, `blocked`, or `merged`.
 Treat pending required checks on the latest pushed head as active `Finisher` monitoring work, not as completion.
 If later required checks fail while monitoring, re-enter triage automatically on the latest pushed head.
 If later required checks pass while monitoring, only hand off as ready after the rest of the latest-head publish-state sweep is also clear.

--- a/skills/superteam/pre-flight.md
+++ b/skills/superteam/pre-flight.md
@@ -8,21 +8,22 @@ Run this pre-flight at the top of every `/superteam` invocation, before any team
 
 ## Detection sequence
 
-1. **Resolve the active issue.** Order: explicit `#<n>` in the operator prompt, then branch name `<n>-<slug>` per the github-flows convention, then operator. If multiple candidates conflict, halt per the halt conditions below.
+1. **Resolve the active issue.** Order: explicit `#<n>` in the operator prompt, then branch name `<n>-<slug>` per the issue-branch convention, then operator. If multiple candidates conflict, halt per the halt conditions below.
 2. **Auto-switch to issue branch** per `## Auto-switch to issue branch` when its trigger fires.
 3. **Inspect committed artifacts on the active branch.** Look for the design doc at the canonical specs path (`docs/superpowers/specs/YYYY-MM-DD-<issue>-<title>-design.md`) and the plan doc at the canonical plans path (`docs/superpowers/plans/YYYY-MM-DD-<issue>-<title>-plan.md`). Treat only committed state as authoritative.
 4. **Inspect branch state.** Resolve the current branch and its tracking remote; record divergence and uncommitted state for completeness, but do NOT use uncommitted state as the phase signal.
-5. **Inspect PR state.** Determine whether a PR exists for this branch on origin and, if so, whether it is open or merged, and the latest `Finisher` substate signals (CI, review state, mergeability).
-6. **Derive the detected phase** per the phase derivation rules below.
-7. **Classify the operator prompt** per `routing-table.md` `## Prompt-classification heuristic`.
-8. **Probe execution-mode capability** per the `## Execution-mode capability detection` section below.
-9. **Route** per `routing-table.md` using the `(detected_phase, prompt_classification)` pair as the key.
+5. **Inspect implementation and local review state.** Determine whether committed implementation work is present beyond the committed plan and whether local pre-publish review resolution is visible from committed artifacts, review notes, implementation commits, or PR state.
+6. **Inspect PR state.** Determine whether a PR exists for this branch on origin and, if so, whether it is open or merged, and the latest `Finisher` substate signals (CI, review state, mergeability).
+7. **Derive the detected phase** per the phase derivation rules below.
+8. **Classify the operator prompt** per `routing-table.md` `## Prompt-classification heuristic`.
+9. **Probe execution-mode capability** per the `## Execution-mode capability detection` section below.
+10. **Route** per `routing-table.md` using the `(detected_phase, prompt_classification)` pair as the key.
 
 ## Phase derivation rules
 
 - no design doc, no plan, no PR -> `brainstorm`
 - design doc present, no plan doc on branch, no PR -> `brainstorm` (Gate 1 still open per R15)
-- plan doc present on branch, no PR -> `execute`
+- plan doc present on branch, no PR -> `execute`, with route refined by `implementation_state` and `local_review_state`
 - PR open or merged -> `finish`, with `Finisher` substate derived from PR / CI / review state
 - artifacts and PR state cannot be reconciled -> halt per the halt conditions below
 
@@ -30,11 +31,26 @@ Run this pre-flight at the top of every `/superteam` invocation, before any team
 
 Trigger (both MUST hold): issue came from source 1; current branch equals the default branch from `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`.
 
-Algorithm: invoke `/github-flows:new-branch` (`patinaproject/github-flows`, `skills/new-branch/workflow.md`) as authoritative. Do NOT inline kebab, default-branch, dirty-tree, fetch, checkout, or rebase logic. Skip its Step 6 (lockfile install). Re-run step 3 on the new branch.
+Algorithm:
+
+1. Refuse a dirty working tree. If `git status --porcelain` is non-empty, halt with condition 5.
+2. Resolve the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If it fails or returns empty, halt with condition 6.
+3. Resolve the issue title with `gh issue view <n> --json number,title,state`. If it fails, halt with condition 8. If the issue is not open, ask the operator before continuing.
+4. Compute the issue branch as `<issue-number>-<kebab-title>`:
+   - lowercase the title
+   - replace each run of non-`[a-z0-9]` characters with one hyphen
+   - trim leading and trailing hyphens
+   - prepend `<issue-number>-`
+   - truncate the full string to 60 characters, preferring the previous hyphen boundary, then trim trailing hyphens
+5. Fetch `origin/<defaultBranch>`.
+6. If the branch does not exist locally, check out `-b <branch> origin/<defaultBranch>`.
+7. If the branch exists locally, check it out and rebase onto `origin/<defaultBranch>`.
+8. If rebase conflicts occur, halt with condition 7 and do not run `git rebase --abort`.
+9. Skip dependency installation; pre-flight needs branch state only. Re-run committed-artifact inspection on the new branch.
 
 No-op on `<n>-<slug>` matching the issue, or sources 2/3. Mismatched `<n>` fires halt 3.
 
-Forbidden: auto-stash; `git rebase --abort`; silent fallback on `gh repo view` failure; inline reimplementation.
+Forbidden: auto-stash; `git rebase --abort`; silent fallback on `gh repo view` failure; external branch-workflow dependency.
 
 ## Halt conditions
 
@@ -56,7 +72,7 @@ When any halt fires, surface the blocker explicitly and stop. Do not "pick the m
 Order:
 
 1. Explicit `#<n>` in the operator prompt.
-2. Branch name `<n>-<slug>` per the github-flows convention.
+2. Branch name `<n>-<slug>` per the issue-branch convention.
 3. Operator (ask).
 
 If multiple candidates conflict, halt per halt condition 3 above.
@@ -87,8 +103,23 @@ The pre-flight produces this record, which is the input to `routing-table.md`:
 {
   active_issue,
   detected_phase,
+  prompt_classification,
   open_gate?,
+  current_branch,
+  tracking_remote?,
+  branch_divergence,
+  implementation_state,
+  local_review_state,
+  pr_state,
+  finisher_substate_signals?,
   execution_mode,
   operator_override?
 }
 ```
+
+Field value contracts:
+
+- `implementation_state`: `none` | `in_progress` | `complete_unreviewed` | `reviewed`
+- `local_review_state`: `not_applicable` | `not_visible` | `open_findings` | `resolved`
+- `pr_state`: `absent` | `open` | `merged`
+- `finisher_substate_signals`: `triage` | `monitoring` | `ready` | `blocked` | `merged`

--- a/skills/superteam/routing-table.md
+++ b/skills/superteam/routing-table.md
@@ -6,28 +6,38 @@ Heavy reference for the explicit `(detected_phase, prompt_classification)` routi
 
 | detected_phase | prompt_classification | route_to | action | notes |
 |---|---|---|---|---|
+| brainstorm | no design doc + no open gate | Brainstormer | create design artifact | default first invocation route; run Gate 1 after design is committed and reviewed |
 | brainstorm | Gate 1 open + prompt looks like feedback | Brainstormer | deliver-as-feedback (delta-only revision) | per R6; do not restart |
-| brainstorm | Gate 1 open + prompt is approval-only or rejection-only (explicit token, no requirement / feedback delta) | Planner | fire Gate 1 approval and route forward | Gate 1 is durably observable iff a plan doc has been committed on the branch (R15); ephemeral in-session "approve" without a committed plan doc is NOT durable |
+| brainstorm | Gate 1 open + prompt is approval-only (explicit approve token, no requirement / feedback delta) | Planner | fire Gate 1 approval and route forward | Gate 1 is durably observable iff a plan doc has been committed on the branch (R15); ephemeral in-session "approve" without a committed plan doc is NOT durable |
+| brainstorm | Gate 1 open + prompt is rejection-only (explicit reject token, no requirement / feedback delta) | Brainstormer | keep Gate 1 open and request actionable feedback | rejection is non-approval and must not route forward |
 | brainstorm | Gate 1 open + prompt combines approval with requested changes | Brainstormer | deliver-as-feedback (delta-only revision) | apply the delta and re-fire approval afterward; do not advance on mixed approval |
 | execute | requirement change | Brainstormer | route spec-level feedback | requirement authority must be restored first |
 | execute | task adjustment that preserves requirements | Planner | route plan-level feedback | do not fall through to generic execution routing |
+| execute | plan doc present + prompt is resume / continue / generic invocation + implementation not complete | Executor | resume implementation from approved plan | inject pre-selected execution mode per R14 |
 | execute | implementation question | Executor | resume implementation | inject pre-selected execution mode per R14 |
 | execute | implementation state present + no PR + local review not visibly resolved | Reviewer | rerun/reconstruct local review | preserves pre-publish safety without hidden workflow state |
 | finish | Finisher state in {triage, monitoring, blocked} + status check | Finisher | resume; do not restart | run latest-head sweep |
+| finish | Finisher state in {ready, merged} + resume / status / generic invocation | Finisher | run latest-head shutdown sweep | shutdown is success-only and head-relative |
+| finish | PR open or merged + prompt does not change requirements | Finisher | resume publish-state follow-through | default finish route; verify latest head before any completion-style handoff |
 | finish | requirement-bearing PR feedback | Brainstormer | spec-first per existing external-feedback rules | then Planner, then Executor |
 | finish | requirement-bearing operator or human-test feedback | Brainstormer | route spec-level feedback | applies even when feedback is not phrased as PR feedback; then Planner, then Executor before Finisher ready/shutdown can resume |
 | halted | anything | (none) | show halt reason; require explicit operator instruction before resuming | recovery is operator-driven |
 | any | unambiguously a new top-of-workflow request for a different issue | (none) | require explicit operator confirmation before starting a new run | "no need to re-confirm" framing in the prompt is itself the disallowed shortcut per R7 |
+| any | otherwise / ambiguous in-flight prompt | active teammate | deliver as feedback; do not advance silently | explicit fallback route for resume-not-restart behavior |
 
 ## Prompt-classification heuristic
 
-- If a Gate is detected as open and the prompt does not contain an explicit approve/reject token (`approve`, `reject`, `lgtm`, `request changes`), treat as feedback for the gate's owning teammate.
+- If a Gate is detected as open and the prompt contains only an explicit approve token (`approve`, `lgtm`) with no requirement or feedback delta, classify as approval-only.
+- If a Gate is detected as open and the prompt contains only an explicit reject token (`reject`, `request changes`) with no actionable delta, classify as rejection-only and keep the gate open.
+- If a Gate is detected as open and the prompt lacks an explicit approve/reject token, treat it as feedback for the gate's owning teammate.
 - If `phase=execute` and prompt mentions changing requirements, acceptance criteria, or "what we are building", classify as spec-level feedback.
 - If `phase=execute` and prompt mentions changing tasks, sequencing, or workstreams without changing requirements, classify as plan-level feedback.
 - If `phase=execute` and prompt is a question about implementation, classify as implementation work for `Executor`.
 - If `phase=execute`, implementation work is present, no PR exists, and prior local review findings cannot be proven resolved from visible state, classify as local review reconstruction for `Reviewer`.
+- If `phase=execute`, a plan doc is present, implementation is not complete, and the prompt is `resume`, `continue`, or a generic invocation, classify as implementation work for `Executor`.
 - If `phase=finish` and prompt is a status / "is it done" / "check CI" prompt, route to `Finisher` with the latest-head sweep.
 - If `phase=finish` and prompt adds or changes requirements, acceptance criteria, or "what we are building", classify as spec-level feedback even when it is not PR feedback.
+- If `phase=finish` and the PR is ready, merged, or the prompt is otherwise generic, route to `Finisher` for latest-head publish-state or shutdown handling.
 - If the prompt names a different issue number explicitly, require operator confirmation before starting a new run.
 - Otherwise, treat the prompt as feedback for the active teammate.
 - **Bias:** when a phase is in flight and the prompt is ambiguous, classify as feedback. Ambiguous prompts MUST NOT silently start a new phase.

--- a/skills/superteam/workflow-diagrams.md
+++ b/skills/superteam/workflow-diagrams.md
@@ -1,0 +1,82 @@
+# Workflow diagrams
+
+The workflow diagrams should stay structurally accurate and easy to read:
+
+- use two Mermaid charts instead of trying to show chronology and orchestration in one diagram
+- use only two block types: teammates and artifacts
+- keep artifact nodes visually lighter with black text for readability
+- keep the chronological chart simple and forward-moving
+- keep the orchestration chart top-to-bottom and make `Team Lead` the routing hub for human feedback
+
+## Chronological flow
+
+```mermaid
+flowchart TD
+    issue["Issue"]:::artifact
+    lead["Team Lead"]
+    brainstormer["Brainstormer"]
+    design["Design Doc"]:::artifact
+    planner["Planner"]
+    plan["Plan Doc"]:::artifact
+    executor["Executor"]
+    implementation["Implementation & Tests"]:::artifact
+    reviewer["Reviewer"]
+    finisher["Finisher"]
+    pr["Pull Request"]:::artifact
+    human["Human Test & Review"]
+
+    issue --> lead
+    lead --> brainstormer
+    brainstormer --> design
+    design --> planner
+    planner --> plan
+    plan --> executor
+    executor --> implementation
+    implementation --> reviewer
+    reviewer --> finisher
+    finisher --> pr
+    pr --> human
+
+    classDef artifact fill:#f7f7f7,stroke:#666,stroke-width:1px,color:#000;
+```
+
+## Orchestration flow
+
+```mermaid
+flowchart TD
+    issue["Issue"]:::artifact
+    lead["Team Lead"]
+    brainstormer["Brainstormer"]
+    design["Design Doc"]:::artifact
+    planner["Planner"]
+    plan["Plan Doc"]:::artifact
+    executor["Executor"]
+    implementation["Implementation & Tests"]:::artifact
+    reviewer["Reviewer"]
+    finisher["Finisher"]
+    pr["Pull Request"]:::artifact
+    human["Human Test & Review"]
+
+    issue --> lead
+    lead --> brainstormer
+    brainstormer --> design
+    design --> planner
+    planner --> plan
+    plan --> executor
+    executor --> implementation
+    implementation --> reviewer
+    reviewer --> finisher
+    finisher --> pr
+    pr --> human
+
+    pr -->|"PR feedback / status"| finisher
+    human -->|"human feedback"| lead
+    reviewer -->|"review findings"| lead
+    finisher -->|"needs reroute"| lead
+
+    lead -->|"route planning work"| planner
+    lead -->|"route implementation work"| executor
+    lead -->|"route publish follow-through"| finisher
+
+    classDef artifact fill:#f7f7f7,stroke:#666,stroke-width:1px,color:#000;
+```


### PR DESCRIPTION
## Summary

- Applied workflow-skill-design and skill-improver review loops to harden the Superteam workflow skill.
- Added explicit any-point routing coverage for brainstorm, execute, finish, halted, and ambiguous in-flight prompts.
- Made pre-flight routing signals explicit and kept workflow diagrams in a one-hop supporting file.

## Linked issue

- Closes #62

## Acceptance criteria

### AC-62-1

Workflow-skill review findings were recorded by severity, affected file, and disposition through the review findings addressed in this PR.

- [x] Codex evidence — Codex local review loop | macOS worktree | @tlmader | 2026-04-28T04:52:54Z
- [ ] Manual test: 1. Review the PR diff for `skills/superteam/SKILL.md`, `skills/superteam/pre-flight.md`, and `skills/superteam/routing-table.md`; 2. Confirm each review finding is either fixed in the diff or described in this PR; 3. Mark this box after confirming.

### AC-62-2

Critical and major findings from the workflow-skill-design pass and adapted skill-improver loop were fixed in repository skill files.

- [x] Codex evidence — `pnpm lint:md` and review/fix cycles | macOS worktree | @tlmader | 2026-04-28T04:52:54Z
- [ ] Manual test: 1. Check that `SKILL.md` has trigger scope, When to Use, When NOT to Use, success criteria, and `allowed-tools`; 2. Check that `pre-flight.md` includes explicit routing inputs and no external github-flows dependency; 3. Mark this box after confirming.

### AC-62-3

Minor findings were evaluated rather than applied blindly; the final pass kept only functional improvements that support skill execution.

- [x] Codex evidence — 10 review/refactor cycles plus skill-improver fallback evaluation | macOS worktree | @tlmader | 2026-04-28T04:52:54Z
- [ ] Manual test: 1. Inspect the diff for unnecessary style-only churn; 2. Confirm retained changes map to routing, triggering, progressive disclosure, or verification value; 3. Mark this box after confirming.

### AC-62-4

The PR includes the exact verification steps and review loop evidence that ran.

- [x] Codex evidence — `pnpm lint:md`, `git diff --check`, frontmatter parse check, supporting-file existence check, and adapted skill-improver loop | macOS worktree | @tlmader | 2026-04-28T04:52:54Z
- [ ] Manual test: 1. Read this PR's Validation section; 2. Confirm the listed commands and review loops are sufficient for the workflow-skill hardening pass; 3. Mark this box after confirming.

### AC-62-5

Superteam-specific workflow requirements remain intact while Trail of Bits guidance is adapted where it fits this repository.

- [x] Codex evidence — local contract review of teammate gates, issue branch behavior, Finisher shutdown, and publish-state follow-through | macOS worktree | @tlmader | 2026-04-28T04:52:54Z
- [ ] Manual test: 1. Confirm the diff preserves Team Lead, Brainstormer, Planner, Executor, Reviewer, and Finisher ownership; 2. Confirm local Patina/Superteam contracts are not replaced by Claude-only runtime assumptions; 3. Mark this box after confirming.

## Validation

- `pnpm lint:md`
- `git diff --check`
- YAML/frontmatter parse check for `skills/superteam/SKILL.md`
- Supporting-file existence check for Superteam skill references
- `rg 'github-flows|/github-flows:new-branch' skills/superteam` returned no matches
- Ran 10 workflow-skill-design review/refactor cycles
- Ran skill-improver in a subagent; plugin-dev `skill-reviewer` was unavailable, so the subagent used the closest workflow-skill-design fallback loop and emitted `<skill-improvement-complete>`

## Docs updated

- [ ] Not needed
- [x] Updated in this PR

