### PR TITLE
feat: #65 document skill-improver quality gate for superteam

### DIFF
--- a/docs/skill-improver-quality-gate.md
+++ b/docs/skill-improver-quality-gate.md
@@ -1,0 +1,147 @@
+# Superteam skill-improver quality gate
+
+Repeatable quality gate for changes to `skills/superteam/SKILL.md` and adjacent
+workflow-contract files (`agent-spawn-template.md`, `pre-flight.md`,
+`routing-table.md`, `pr-body-template.md`, `loopback-trailers.md`).
+
+The gate runs the Trail of Bits `skill-improver` loop against the live skill
+directory. It produces explicit completion evidence that maintainers can attach
+to a PR, and it has a documented fallback when the required dependencies are
+not installed.
+
+## When to run
+
+Run the gate before publishing a PR that touches:
+
+- `skills/superteam/**` — any file in the skill package
+- `docs/superpowers/specs/**-design.md` or `docs/superpowers/plans/**-plan.md`
+  whose subject is a Superteam workflow-contract surface
+
+Other repository changes do not require this gate.
+
+## Dependency probe
+
+The gate has two modes. Detect which one applies before running:
+
+1. Confirm the `skill-improver` plugin is available:
+
+   ```bash
+   ls "$HOME/.claude/plugins/cache/trailofbits/skill-improver"/*/skills/skill-improver/SKILL.md \
+     2>/dev/null
+   ```
+
+2. Confirm the `plugin-dev` plugin (which provides the `skill-reviewer`
+   subagent) is available:
+
+   ```bash
+   ls "$HOME/.claude/plugins/cache"/**/skills/plugin-dev/skill-reviewer 2>/dev/null
+   ```
+
+   In Claude Code, `/plugins` should also list `plugin-dev` as enabled.
+
+If both probes succeed, run the **primary mode**. If either fails, run the
+**fallback mode**.
+
+## Primary mode: real skill-improver loop
+
+Invoke the loop from a Claude Code session that has both plugins enabled:
+
+```text
+/skill-improver:skill-improver on superteam
+```
+
+The slash command resolves the skill path, calls the setup script to start a
+session, and drives review-fix iterations until either:
+
+- the assistant emits the explicit completion marker
+  `<skill-improvement-complete>` on its own line, or
+- max iterations are reached, or
+- the operator cancels with `/skill-improver:cancel-skill-improver <session-id>`.
+
+Each iteration calls the `plugin-dev:skill-reviewer` agent on the skill
+directory and applies fixes to critical and major findings. Minor findings are
+evaluated for usefulness rather than applied blindly.
+
+### Required completion evidence
+
+Capture the following from the run and include it in the PR:
+
+- The exact dispatch command (`/skill-improver:skill-improver on superteam`).
+- The session ID printed by the setup script
+  (`Session ID: <YYYYMMDDhhmmss>-<short>`).
+- The total iteration count reported on completion.
+- A list of each Critical and Major finding from the final review pass with its
+  disposition: `fixed` (with the file change summary) or `not applicable`
+  (with a repo-specific rationale that cites repository conventions or
+  authoring discipline such as `superpowers:writing-skills`).
+- A brief evaluation note for any Minor finding the maintainer chose to skip.
+
+A run is acceptable for the gate when the final reviewer pass reports zero
+unresolved Critical and zero unresolved Major findings.
+
+### Cancelling the loop
+
+If the loop continues past a verified clean reviewer pass because the stop hook
+does not detect the marker, cancel the session explicitly so the state file is
+removed:
+
+```text
+/skill-improver:cancel-skill-improver <session-id>
+```
+
+Cancellation preserves all changes the loop made to the skill files. Note the
+cancellation in the PR alongside the final reviewer disposition so the gate
+result remains auditable.
+
+## Fallback mode: writing-skills review
+
+Use the fallback when `plugin-dev` or `skill-improver` is unavailable in the
+maintainer's environment.
+
+1. Load `superpowers:writing-skills` and review the diff against its
+   discipline: RED/GREEN baseline obligation, rationalization-table coverage,
+   red-flag bullets, token-efficiency targets, role ownership, and
+   stage-gate bypass paths.
+2. Pressure-test the changed sections by walking the relevant Superteam
+   teammate contracts (Team Lead, Brainstormer, Planner, Executor, Reviewer,
+   Finisher) and confirming the change does not weaken any gate.
+3. Record the reviewer (self-review or another maintainer) and the dimensions
+   checked.
+
+The fallback is a known limitation: it does not produce a `skill-reviewer`
+machine pass. PRs that use the fallback MUST state that the
+`plugin-dev:skill-reviewer` agent was unavailable in the run environment and
+that the review was performed against `superpowers:writing-skills` only.
+
+## PR evidence
+
+Every PR that touches a workflow-contract surface listed under [When to run]
+(#when-to-run) must include the gate evidence in its body. Suggested layout:
+
+```markdown
+## Skill-improver quality gate
+
+- Mode: primary | fallback
+- Dispatch: `/skill-improver:skill-improver on superteam`
+- Session: `<session-id>` (cancelled after verification | completed at
+  iteration `<n>`)
+- Final reviewer pass: 0 Critical, 0 Major; Minor evaluated below
+- Findings:
+  - `<finding>` — fixed: `<file:line>` `<short summary>`
+  - `<finding>` — not applicable: `<rationale citing repo conventions>`
+  - `<finding>` (minor) — skipped: `<evaluation note>`
+- Fallback caveats (fallback mode only): `plugin-dev:skill-reviewer`
+  unavailable in run environment; review performed against
+  `superpowers:writing-skills` discipline.
+```
+
+Place this block under a `## Skill-improver quality gate` heading in the PR
+body, in addition to the standard PR template sections.
+
+## Reusing later
+
+Future Superteam workflow-contract changes should reuse this document by
+linking to it from the PR body and copying the evidence block. Do not
+re-derive the procedure or invent new dispatch patterns. If the procedure needs
+to change, update this document in the same PR that changes the procedure and
+note the change in the rationale.

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: superteam
-description: Use when taking a GitHub issue from design through execution and merged-ready review using a disciplined teammate-based multi-agent workflow.
+description: Use when the operator runs `/superteam` or asks to take a GitHub issue from design through implementation, review, and merged-ready PR using the canonical Team Lead, Brainstormer, Planner, Executor, Reviewer, and Finisher teammate roster. Triggers on phrases like "run superteam on #N", "take this issue through the teammate workflow", or "drive #N to PR".
 ---
 
 # superteam
@@ -307,6 +307,7 @@ Headline behaviors:
 - Recommend `superpowers:requesting-code-review` for first-pass local review.
 - Also recommend `superpowers:receiving-code-review` when analyzing existing or disputed findings before publish.
 - When reviewing changes to `skills/**/*.md` or workflow-contract docs, invoke `superpowers:writing-skills` and run the relevant pressure-test walkthrough before publish.
+- When the change touches `skills/superteam/**` or any Superteam workflow-contract surface, run the skill-improver quality gate documented in `docs/skill-improver-quality-gate.md` (primary mode when the `skill-improver` and `plugin-dev` plugins are available, fallback mode otherwise) and capture the required completion evidence in the PR body.
 - If later fixes change those same workflow-contract surfaces again after an earlier review pass, rerun the relevant pressure-test walkthrough before handing the run back to `Finisher`.
 - Report pressure-test pass/fail results and any loopholes found for skill or workflow-contract changes.
 - Report local findings with `feedback_classification` (`implementation-level` | `plan-level` | `spec-level`) and an owner before routing.
@@ -562,3 +563,4 @@ Do not silently continue past failed checks, missing artifacts, ambiguous reposi
 - [pr-body-template.md](./pr-body-template.md): PR checklist template used by `Finisher`
 - [pre-flight.md](./pre-flight.md): phase-detection sequence, execution-mode capability detection, halt conditions
 - [routing-table.md](./routing-table.md): phase x prompt-class routing, classification heuristic, resume vs restart, Gate 1 durability
+- [loopback-trailers.md](./loopback-trailers.md): deprecation note for legacy `Loopback:` commit trailers


### PR DESCRIPTION
## Summary

- Add `docs/skill-improver-quality-gate.md` defining the repeatable Superteam skill-improver quality gate, with a primary mode (real `skill-improver` loop + `plugin-dev:skill-reviewer` agent) and a `superpowers:writing-skills` fallback when those plugins are unavailable.
- Wire the new gate into the Reviewer contract in `skills/superteam/SKILL.md` so future workflow-contract changes are required to run it and attach completion evidence.
- Tighten the `superteam` skill description and the `## Supporting files` index found via this gate's first dogfood run.

## Linked issue

- Closes #65

## Acceptance criteria

### AC-65-1

Maintainers can run a documented skill-improver loop against `skills/superteam` and capture completion evidence when the Trail of Bits dependencies are available.

- [x] Verified locally: `docs/skill-improver-quality-gate.md` `## Primary mode` documents the dispatch (`/skill-improver:skill-improver on superteam`), the session-ID and iteration-count outputs, and the required `<skill-improvement-complete>` marker. The Reviewer contract in `skills/superteam/SKILL.md` requires running the gate for any change touching `skills/superteam/**`.
- [ ] Manual test: 1) Confirm `plugin-dev` and Trail of Bits `skill-improver` are enabled in `/plugins`. 2) Run `/skill-improver:skill-improver on superteam`. 3) Verify the loop produces a session ID, iteration counts, and a final reviewer pass with zero Critical and zero Major findings. 4) Cancel via `/skill-improver:cancel-skill-improver <session-id>` if needed and confirm changes are preserved.

### AC-65-2

Documented fallback path when `plugin-dev:skill-reviewer` is unavailable.

- [x] Verified locally: `docs/skill-improver-quality-gate.md` `## Fallback mode: writing-skills review` defines the substitute review steps and requires the PR to state that `plugin-dev:skill-reviewer` was unavailable in the run environment.
- [ ] Manual test: 1) Disable `plugin-dev` (or run on an environment without it). 2) Follow the fallback procedure. 3) Confirm the PR body explicitly states the limitation per the doc's caveat language.

### AC-65-3

Critical or major skill-improver findings are fixed or explicitly documented as not applicable with rationale.

- [x] Verified locally: dogfood run produced two actionable Major findings; both were fixed in this PR — description rewritten in `skills/superteam/SKILL.md:3` and `loopback-trailers.md` added to the `## Supporting files` index in `skills/superteam/SKILL.md:566`. Other initial-pass findings (SKILL.md size, rationalization-table extraction, red-flags extraction, done-report duplication, R-ID inlining, two Mermaid diagrams, deprecated `loopback-trailers.md` retention) were evaluated as out of scope or false positive against `superpowers:writing-skills` discipline and the maintainer's R23 summary-with-pointer pattern, and the next reviewer pass returned 0 Critical and 0 Major.
- [ ] Manual test: 1) `git diff main..HEAD -- skills/superteam/SKILL.md` and confirm both fixes are present. 2) Re-run the gate and confirm the final reviewer pass reports 0 Critical and 0 Major.

### AC-65-4

Minor findings are evaluated for usefulness rather than applied blindly.

- [x] Verified locally: the dogfood run's residual Minor findings (cross-reference precision on line 156, default-branch auto-switch absent from pre-flight summary, ~360-char description length) were each evaluated against the SKILL.md summary-with-pointer design and skipped with rationale. `docs/skill-improver-quality-gate.md` codifies that minor findings must be evaluated and noted in the PR body.
- [ ] Manual test: 1) Read `docs/skill-improver-quality-gate.md` `### Required completion evidence`. 2) Confirm it requires "a brief evaluation note for any Minor finding the maintainer chose to skip."

### AC-65-5

PR includes the exact skill-improver command or dispatch pattern, output marker or completion evidence, and any fallback caveats.

- [x] Verified locally: see [Skill-improver quality gate](#skill-improver-quality-gate) below; the doc's PR-evidence template is reproduced inline.
- [ ] Manual test: 1) Open this PR. 2) Confirm the Skill-improver quality gate section names the dispatch, session ID, iteration count, mode, and finding dispositions per the template in `docs/skill-improver-quality-gate.md`.

## Validation

- `pnpm exec markdownlint-cli2 docs/skill-improver-quality-gate.md skills/superteam/SKILL.md` — 0 errors
- Dogfood gate run: see Skill-improver quality gate below

## Skill-improver quality gate

- Mode: primary
- Dispatch: `/skill-improver:skill-improver on superteam`
- Session: `20260428121032-1214C9DB` (cancelled after verification — stop hook did not detect the on-its-own-line marker)
- Final reviewer pass: 0 Critical, 0 Major; Minor evaluated below
- Findings:
  - Description lacked `/superteam` slash-command trigger and example phrasings — fixed: `skills/superteam/SKILL.md:3` (rewrote to add `/superteam` trigger and three concrete operator phrases).
  - `## Supporting files` index omitted `loopback-trailers.md` — fixed: `skills/superteam/SKILL.md:566` (added the deprecation-breadcrumb entry).
  - SKILL.md word count above general guidance — not applicable: the rationalization-table and red-flags scaffolding is required inline by `superpowers:writing-skills` discipline; further extraction would weaken the anti-rationalization contract.
  - `## Pre-flight` summary "duplicates" `pre-flight.md` — not applicable: deliberate summary-with-pointer per R23; the heavy reference owns the algorithm.
  - Done-report contracts appear in `SKILL.md` and `agent-spawn-template.md` — not applicable: SKILL.md owns the canonical contract; the spawn template owns operational handoff guidance for delegated teammates.
  - R-numbered rule IDs not centrally indexed — not applicable: each rule's normative behavior is stated inline at its citation site, with full rule bodies in `docs/superpowers/specs/` design docs.
  - Two Mermaid diagrams are similar — not applicable: `## Workflow Diagrams` deliberately separates chronology and orchestration views.
  - `loopback-trailers.md` retained as a deprecation note — not applicable: kept intentionally per #57 to anchor the deprecation history.
  - (Minor) line 156 cross-reference precision — skipped: `## Pre-flight` has a single subsection; reference is unambiguous in context.
  - (Minor) default-branch auto-switch missing from pre-flight summary — skipped: discipline asserted in rationalization table and red flags; mirroring detail in the summary defeats summary-with-pointer.
  - (Minor) description length ~360 chars — skipped: reviewer noted "no change required."
- Fallback caveats: not used (primary mode succeeded).

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
