### PR TITLE
fix: #70 restrict writing-skills review trigger

### DIFF
--- a/docs/superpowers/plans/2026-05-03-70-restrict-writing-skills-review-to-skill-file-changes-plan.md
+++ b/docs/superpowers/plans/2026-05-03-70-restrict-writing-skills-review-to-skill-file-changes-plan.md
@@ -1,0 +1,245 @@
+# Plan: Restrict writing-skills review to skill file changes [#70](https://github.com/patinaproject/superteam/issues/70)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Narrow Superteam's `superpowers:writing-skills` review trigger so it is mandatory for installable skill changes and not triggered solely by non-skill workflow or playbook changes.
+
+**Architecture:** This is a Markdown workflow-contract change. Keep Brainstormer Gate 1 design-review language intact where it intentionally requires writing-skills dimensions for workflow-contract designs, but narrow Reviewer and spawn-template review-trigger language to installable skill-package changes. Add a small rationalization/red-flag closure so future reviewers cannot re-expand "workflow-contract" into a writing-skills trigger for non-skill docs.
+
+**Tech Stack:** Markdown skill files; `rg`; `pnpm lint:md`; Superteam fallback skill-improver review evidence through `superpowers:writing-skills`.
+
+---
+
+## File Structure
+
+- Modify `skills/superteam/SKILL.md`: Reviewer default-model rationale, Reviewer role trigger, rationalization table, and red flags.
+- Modify `skills/superteam/agent-spawn-template.md`: Reviewer prompt trigger and pressure-test result wording.
+- Preserve `skills/superteam/SKILL.md` Brainstormer/Gate 1 design-time writing-skills dimensions unless implementation review finds direct Reviewer-trigger wording there.
+- Preserve `docs/skill-improver-quality-gate.md`: it already governs `skills/superteam/**` changes and is not the bug.
+
+## Inventory Baseline
+
+Run:
+
+```bash
+rg -n "workflow-contract.*writing-skills|writing-skills.*workflow-contract|skills/\\*\\*/\\*\\.md\\` or workflow-contract|skills/\\*\\*/\\*\\.md\\` or workflow" skills/superteam
+```
+
+Expected baseline includes:
+
+- Preserve as Gate 1 design-review language:
+  - `skills/superteam/SKILL.md`: Gate 1 adversarial review dimensions
+  - `skills/superteam/SKILL.md`: Brainstormer design-time rule
+  - `skills/superteam/agent-spawn-template.md`: Gate 1 adversarial review dimensions
+  - `skills/superteam/agent-spawn-template.md`: Brainstormer design-time rule
+- Update as Reviewer/review-trigger language:
+  - `skills/superteam/SKILL.md`: Reviewer model rationale
+  - `skills/superteam/SKILL.md`: Reviewer role bullet
+  - `skills/superteam/SKILL.md`: rationalization/red-flag lines that say skill or workflow-contract changes are reviewed with writing-skills
+  - `skills/superteam/agent-spawn-template.md`: Reviewer recommendation and pressure-test result wording
+
+## Task 1: Narrow SKILL.md Reviewer Trigger
+
+**Files:**
+
+- Modify: `skills/superteam/SKILL.md`
+
+- [ ] **Step 1: Confirm RED baseline**
+
+Run the inventory command above. Confirm the current Reviewer language says
+`skills/**/*.md` or workflow-contract docs trigger `superpowers:writing-skills`.
+
+- [ ] **Step 2: Edit Reviewer model rationale**
+
+Change the Reviewer default rationale from "skills/**/*.md and workflow-contract changes" to installable skill-package changes:
+
+```markdown
+| `Reviewer` | `opus` | Owns adversarial pressure-tests for installable skill-package changes (per `### Reviewer`, which requires invoking `superpowers:writing-skills` and running the relevant pressure-test walkthrough before publish when `skills/**` or packaged skill behavior changes). That is deep adversarial reasoning, not bounded pattern matching — the same justification that puts `Brainstormer` on Opus. Operators can downshift via `model: sonnet for reviewer` for trivial repo-rule reviews. |
+```
+
+- [ ] **Step 3: Edit Reviewer role bullet**
+
+Replace the broad trigger:
+
+```markdown
+- When reviewing changes to `skills/**/*.md` or workflow-contract docs, invoke `superpowers:writing-skills` and run the relevant pressure-test walkthrough before publish.
+```
+
+with:
+
+```markdown
+- When reviewing changes to installable skill-package files (`skills/**`, including adjacent prompt or workflow-contract files packaged with a skill), invoke `superpowers:writing-skills` and run the relevant pressure-test walkthrough before publish. Do not invoke writing-skills solely because non-skill docs, operational playbooks, PR templates, or process documents outside `skills/**` describe a workflow.
+```
+
+- [ ] **Step 4: Keep skill-improver gate bullet intact**
+
+Do not remove or weaken:
+
+```markdown
+- When the change touches `skills/superteam/**` or any Superteam workflow-contract surface, run the skill-improver quality gate documented in `docs/skill-improver-quality-gate.md` (primary mode when the `skill-improver` and `plugin-dev` plugins are available, fallback mode otherwise) and capture the required completion evidence in the PR body.
+```
+
+- [ ] **Step 5: Add rationalization closure**
+
+Add this row to the rationalization table near the existing writing-skills rows:
+
+```markdown
+| "It is a workflow contract, so Reviewer should invoke writing-skills." | `superpowers:writing-skills` is mandatory for installable skill-package changes, not for every non-skill workflow, playbook, PR template, or process document. Reviewer still performs local pre-publish review and any explicit repo-specific gate for non-skill workflow docs, but the workflow label alone is not a writing-skills trigger. |
+```
+
+- [ ] **Step 6: Replace broad red flag**
+
+Replace:
+
+```markdown
+- Skill or workflow-contract changes reviewed without `superpowers:writing-skills` or a pressure-test walkthrough.
+```
+
+with:
+
+```markdown
+- Installable skill-package changes under `skills/**` reviewed without `superpowers:writing-skills` or a pressure-test walkthrough.
+- Reviewer invokes `superpowers:writing-skills` for changes that touch only non-skill workflow docs, operational playbooks, PR templates, or process documents outside `skills/**`.
+```
+
+## Task 2: Narrow Agent Spawn Template Reviewer Prompt
+
+**Files:**
+
+- Modify: `skills/superteam/agent-spawn-template.md`
+
+- [ ] **Step 1: Edit Reviewer recommendation**
+
+Replace:
+
+```markdown
+Recommend `superpowers:writing-skills` when reviewing changes to `skills/**/*.md` or workflow-contract docs.
+```
+
+with:
+
+```markdown
+Recommend `superpowers:writing-skills` when reviewing changes to installable skill-package files (`skills/**`, including adjacent prompt or workflow-contract files packaged with a skill). Do not recommend writing-skills solely for non-skill workflow docs, operational playbooks, PR templates, or process documents outside `skills/**`.
+```
+
+- [ ] **Step 2: Edit pressure-test result wording**
+
+Replace:
+
+```markdown
+When the changed scope includes `skills/**/*.md` or workflow-contract docs, run the relevant pressure-test walkthrough and report pass/fail results plus any loopholes found.
+```
+
+with:
+
+```markdown
+When the changed scope includes installable skill-package files (`skills/**`, including adjacent prompt or workflow-contract files packaged with a skill), run the relevant pressure-test walkthrough and report pass/fail results plus any loopholes found.
+```
+
+Replace:
+
+```markdown
+- `pressure_test_results[]`: for skill or workflow-contract changes, the scenarios checked and their pass/fail outcomes, or an explicit empty result when not applicable
+```
+
+with:
+
+```markdown
+- `pressure_test_results[]`: for installable skill-package changes, the scenarios checked and their pass/fail outcomes, or an explicit empty result when not applicable
+```
+
+## Task 3: Verify Inventory And Pressure Scenarios
+
+**Files:**
+
+- Review: `skills/superteam/SKILL.md`
+- Review: `skills/superteam/agent-spawn-template.md`
+
+- [ ] **Step 1: Re-run inventory**
+
+Run:
+
+```bash
+rg -n "workflow-contract.*writing-skills|writing-skills.*workflow-contract|skills/\\*\\*/\\*\\.md\\` or workflow-contract|skills/\\*\\*/\\*\\.md\\` or workflow" skills/superteam
+```
+
+Expected result:
+
+- Remaining matches are Brainstormer/Gate 1 design-time writing-skills dimensions or historical rationalization examples that are not Reviewer triggers.
+- Reviewer/spawn-template review-trigger matches use "installable skill-package" language instead of "`skills/**/*.md` or workflow-contract docs".
+
+- [ ] **Step 2: Run AC pressure checks by inspection**
+
+Confirm:
+
+- `AC-70-1`: There is no Reviewer trigger saying non-skill workflow docs invoke writing-skills.
+- `AC-70-2`: Skill-package changes still mandate writing-skills.
+- `AC-70-3`: Workflow-contract wording near Reviewer review trigger is scoped to packaged skill files or removed.
+- `AC-70-4`: Inventory result has explicit preserved-vs-updated disposition.
+
+- [ ] **Step 3: Run markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: `Summary: 0 error(s)`.
+
+- [ ] **Step 4: Commit implementation**
+
+Use `fix:` because this corrects shipped Superteam runtime behavior:
+
+```bash
+git add skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md
+git commit -m "fix: #70 restrict writing-skills review trigger"
+```
+
+## Task 4: Reviewer And Publish Evidence
+
+**Files:**
+
+- Review: changed files
+- PR body later: `.github/pull_request_template.md`
+
+- [ ] **Step 1: Run fallback skill-improver gate if primary tooling is unavailable**
+
+Probe:
+
+```bash
+ls "$HOME/.claude/plugins/cache/trailofbits/skill-improver"/*/skills/skill-improver/SKILL.md 2>/dev/null
+ls "$HOME/.claude/plugins/cache"/**/skills/plugin-dev/skill-reviewer 2>/dev/null
+```
+
+If either command has no result, record fallback mode:
+
+```text
+Mode: fallback
+Reviewer: local Superteam Reviewer in this run
+Dimensions: RED/GREEN baseline obligation, rationalization resistance, red flags, token-efficiency target, role ownership, stage-gate bypass paths
+Pressure tests: PT-70-1, PT-70-2, PT-70-3
+```
+
+- [ ] **Step 2: Local review expectations**
+
+Reviewer must verify:
+
+- Operational-playbook-only scenario no longer triggers writing-skills.
+- Superteam skill-package change still triggers writing-skills and skill-improver gate.
+- Mixed skill and non-skill workflow change can identify `skills/**` as the trigger.
+
+- [ ] **Step 3: Finisher PR evidence**
+
+The PR body must include:
+
+- `Closes #70`
+- Acceptance Criteria entries for `AC-70-1` through `AC-70-4`
+- Validation command `pnpm lint:md`
+- Skill-improver quality gate evidence, primary or fallback
+
+## Self-Review
+
+- Spec coverage: Tasks map to AC-70-1 through AC-70-4 and preserve the skill-improver gate.
+- Placeholder scan: No TODO/TBD placeholders remain.
+- Type/path consistency: All paths match the repository's `skills/superteam/**` and `docs/superpowers/**` layout.

--- a/docs/superpowers/specs/2026-05-03-70-restrict-writing-skills-review-to-skill-file-changes-design.md
+++ b/docs/superpowers/specs/2026-05-03-70-restrict-writing-skills-review-to-skill-file-changes-design.md
@@ -1,0 +1,239 @@
+# Design: Restrict writing-skills review to skill file changes [#70](https://github.com/patinaproject/superteam/issues/70)
+
+## Intent summary
+
+Restrict Superteam's `superpowers:writing-skills` trigger so it applies to
+actual installable skill changes, not every workflow, playbook, or operational
+document change that can be described as a workflow-contract surface.
+
+The current contract is too broad in the `Reviewer` role and nearby spawn
+guidance. It says skill or workflow-contract changes should invoke
+`superpowers:writing-skills`, which lets a reviewer rationalize that ordinary
+workflow or operational playbook edits need skill pressure tests even when no
+`skills/**/*.md` file changed. The fix should preserve the strong
+writing-skills gate for real skill edits while routing non-skill workflow docs
+through ordinary local review and any repository-specific gates that apply.
+
+This is a workflow-contract change because it modifies the installed
+`superteam` skill and its adjacent teammate prompt guidance.
+
+## Requirements
+
+- **AC-70-1**: When a change touches workflow, operational playbook, or other
+  process-document files but no installable skill files, Superteam review does
+  not invoke `superpowers:writing-skills` solely because those files are
+  workflow-contract surfaces.
+- **AC-70-2**: When a change touches installable skill files, Superteam review
+  invokes `superpowers:writing-skills` according to the skill-change review
+  contract.
+- **AC-70-3**: When Superteam guidance mentions workflow-contract changes, the
+  writing-skills trigger is scoped clearly to skill changes only.
+- **AC-70-4**: Superteam guidance that couples "workflow-contract" with
+  `superpowers:writing-skills` is inventoried and either updated to the
+  narrowed Reviewer trigger or explicitly preserved as a design-time Gate 1
+  review dimension, so stale wording cannot preserve the reported
+  rationalization.
+
+## Scope
+
+The intended implementation surface is narrow:
+
+- `skills/superteam/SKILL.md`
+- `skills/superteam/agent-spawn-template.md`
+
+The change should update the `Reviewer` contract, red flags, and spawn-template
+instructions that currently say `skills/**/*.md` or workflow-contract docs both
+trigger `superpowers:writing-skills`.
+
+The implementation must inventory current `workflow-contract` plus
+`writing-skills` wording across `skills/superteam/**` before editing. Reviewer
+and spawn-template review-trigger language should be narrowed. Gate 1
+Brainstormer design-time language may still require writing-skills dimensions
+for workflow-contract designs, but any preserved wording must be explicitly
+identified as design-review evidence rather than the Reviewer trigger for
+non-skill workflow docs.
+
+This issue does not remove the separate `docs/skill-improver-quality-gate.md`
+requirement for `skills/superteam/**` changes. That gate remains required for
+this PR because the implementation will touch the Superteam skill package. The
+fix only narrows what counts as a `superpowers:writing-skills` trigger.
+
+## Behavior design
+
+### Skill-file changes
+
+Use `superpowers:writing-skills` when the changed surface is an installable
+skill file:
+
+- `skills/**/SKILL.md`
+- adjacent files inside a skill package when those files define installed skill
+  behavior or teammate prompt contracts
+
+For this repository, `skills/superteam/**` is an installable skill package, so
+changes there still require writing-skills review and the Superteam
+skill-improver quality gate.
+
+### Non-skill workflow or playbook changes
+
+Do not invoke `superpowers:writing-skills` only because a file is a workflow,
+playbook, runbook, design artifact, plan artifact, PR template, or operational
+process document outside an installable skill package.
+
+Those files may still need careful review. The correct review is the ordinary
+local pre-publish review for the surface, plus any explicit repository gate
+documented for that file. The reviewer should not relabel them as
+writing-skills work unless they actually change installed skill behavior.
+
+### Ambiguous surfaces
+
+If a changed file is adjacent to a skill package or could be consumed as part
+of installed skill behavior, classify by the file's role:
+
+- inside `skills/<skill-name>/`: skill-surface; writing-skills applies
+- outside `skills/`: non-skill unless repository guidance explicitly says the
+  file is packaged as skill behavior
+
+This prevents "workflow-contract" from becoming a catch-all phrase that routes
+everything through writing-skills.
+
+## RED-phase baseline obligation
+
+The observable failure is captured by the issue example:
+
+```text
+Reviewer's role for skill/workflow-contract changes invokes
+superpowers:writing-skills pressure tests; #994 doesn't touch skills/**/*.md
+directly, but the operational playbooks are workflow-contract surfaces and
+warrant a careful read.
+```
+
+RED behavior:
+
+1. A change updates operational playbooks or workflow docs outside
+   `skills/**`.
+2. Reviewer sees "workflow-contract" in the current contract.
+3. Reviewer invokes or justifies invoking `superpowers:writing-skills` even
+   though no installable skill file changed.
+
+GREEN behavior:
+
+1. The same change updates operational playbooks or workflow docs outside
+   `skills/**`.
+2. Reviewer performs local review for that surface and checks any explicit
+   repo-specific gates.
+3. Reviewer does not invoke `superpowers:writing-skills` unless the diff also
+   changes `skills/**` or another file explicitly packaged as installed skill
+   behavior.
+
+## Loophole closure
+
+| Excuse | Reality |
+|--------|---------|
+| "It is a workflow contract, so writing-skills applies." | Writing-skills applies to installable skill changes. Workflow-contract wording outside `skills/**` is not enough by itself. |
+| "Operational playbooks teach agents what to do, so they are basically skills." | A playbook can need careful review without being an installable skill. Use the surface's own review gate unless it is packaged as skill behavior. |
+| "The contract says skill/workflow-contract changes, so I should keep using both triggers." | The slash is the bug. The trigger must distinguish skill changes from non-skill workflow docs. |
+| "If writing-skills no longer applies, review can be light." | No. Reviewer still owns local pre-publish review, artifact ownership, verification, and role-rule compliance for every changed surface. |
+| "Superteam skill package files are workflow docs too, so they can skip writing-skills." | Files under `skills/superteam/**` are part of an installable skill package. Writing-skills and the skill-improver quality gate still apply. |
+
+## Red flags
+
+- Reviewer justifies `superpowers:writing-skills` for a diff that touches only
+  `docs/**`, `.github/**`, or operational playbooks outside `skills/**`.
+- Guidance still says "`skills/**/*.md` or workflow-contract docs" as a single
+  trigger for writing-skills.
+- The fix weakens review for actual skill-package files under
+  `skills/superteam/**`.
+- The fix removes the skill-improver quality gate for Superteam skill-package
+  changes.
+- The fix relies on fuzzy phrases like "agent-facing docs" instead of a clear
+  packaged-skill boundary.
+
+## Token-efficiency target
+
+Keep the runtime skill changes small. Prefer replacing the broad trigger text
+with scoped wording instead of adding a new general taxonomy of every possible
+workflow document. The expected `SKILL.md` change should be a handful of
+targeted lines plus one rationalization-table row or red-flag bullet if needed.
+
+## Pressure tests
+
+### PT-70-1: Operational playbook only
+
+Scenario: A PR changes `docs/dev-onboarding-for-admins.md` and no files under
+`skills/**`.
+
+Expected behavior: Reviewer performs local pre-publish review and any explicit
+repo-specific checks for that document. Reviewer does not invoke
+`superpowers:writing-skills` solely because the document is a workflow or
+operational playbook.
+
+Failure signal: Reviewer says the document is a workflow-contract surface and
+therefore needs writing-skills pressure tests.
+
+### PT-70-2: Superteam skill package change
+
+Scenario: A PR changes `skills/superteam/SKILL.md` or
+`skills/superteam/agent-spawn-template.md`.
+
+Expected behavior: Reviewer invokes `superpowers:writing-skills`, runs the
+relevant pressure-test walkthrough, and runs the Superteam skill-improver
+quality gate or documented fallback.
+
+Failure signal: Reviewer treats the narrowed trigger as permission to skip
+writing-skills for actual Superteam skill-package changes.
+
+### PT-70-3: Mixed skill and non-skill workflow change
+
+Scenario: A PR changes both `skills/superteam/SKILL.md` and a non-skill
+workflow document under `docs/**`.
+
+Expected behavior: Writing-skills applies because the PR touches an installable
+skill package. The non-skill document receives appropriate local review, but it
+is not independently used as the reason writing-skills applies.
+
+Failure signal: Reviewer cannot explain which changed files caused the
+writing-skills trigger.
+
+## Out of scope
+
+- Changing Brainstormer Gate 1 requirements for workflow-contract designs.
+  This issue is about the Reviewer and spawn-guidance trigger that caused the
+  reported mistake.
+- Removing local pre-publish review for workflow or operational documents.
+- Changing the Superteam skill-improver quality gate for `skills/superteam/**`.
+- Defining a universal taxonomy for all process documentation across
+  repositories.
+
+## Adversarial review
+
+Reviewer context: same-thread fallback for the initial design draft. A fresh
+review pass is still required before Gate 1 approval is presented.
+
+### Checked dimensions
+
+- **RED/GREEN baseline obligation**: Present. The issue example is converted
+  into before/after observable behavior.
+- **Rationalization resistance**: Present. The design closes the broad
+  "workflow contract equals skill" rationalization and the opposite "skip real
+  skill review" rationalization.
+- **Red flags**: Present. The list names both over-triggering and
+  under-triggering failure modes.
+- **Token-efficiency targets**: Present. The implementation is constrained to
+  targeted wording replacements.
+- **Role ownership**: Present. Reviewer owns the narrowed trigger; ordinary
+  local review remains intact for non-skill docs.
+- **Stage-gate bypass paths**: Present. Actual skill-package changes still
+  require writing-skills and skill-improver evidence.
+
+### Findings
+
+| Source | Severity | Location | Finding | Disposition |
+|---|---|---|---|---|
+| brainstormer | material | `## Scope` | The first pass could be misread as removing the skill-improver quality gate from Superteam package changes. | Resolved by stating that the gate remains required for `skills/superteam/**` and this issue only narrows the writing-skills trigger. |
+| adversarial-review | material | `AC-70-2` | `may invoke` weakened the preserved skill-change gate. A later teammate could satisfy the AC while making writing-skills optional for installable skill changes. | Resolved by changing AC-70-2 to mandatory `invokes` language. |
+| adversarial-review | material | `## Scope`, `AC-70-3` | The design did not require an inventory or disposition of other `workflow-contract` plus `writing-skills` wording, so stale guidance could preserve the reported rationalization. | Resolved by adding AC-70-4 and an implementation note requiring inventory, trigger narrowing, and explicit preservation only for Gate 1 design-review dimensions. |
+
+After these revisions, the adversarial-review result is `findings dispositioned`.
+The design retains the checked writing-skills dimensions: RED/GREEN baseline
+obligation, rationalization resistance, red flags, token-efficiency target, role
+ownership, and stage-gate bypass protection for real skill-package changes.

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -107,7 +107,7 @@ An explicit `inline` (or equivalent: `run inline`, `execute in this session`) in
 | `Brainstormer` | `opus` | Design reasoning, requirement framing, adversarial review, loophole-closure synthesis. |
 | `Planner` | `opus` | Plan structuring, workstream decomposition, dependency reasoning. |
 | `Executor` | `sonnet` | Bounded ATDD / implementation grunt work; cost and speed win without sacrificing correctness on tasks that already have explicit AC IDs and a committed plan. |
-| `Reviewer` | `opus` | Owns adversarial pressure-tests for `skills/**/*.md` and workflow-contract changes (per `### Reviewer`, which requires invoking `superpowers:writing-skills` and running the relevant pressure-test walkthrough before publish). That is deep adversarial reasoning, not bounded pattern matching — the same justification that puts `Brainstormer` on Opus. Operators can downshift via `model: sonnet for reviewer` for trivial repo-rule reviews. |
+| `Reviewer` | `opus` | Owns adversarial pressure-tests for installable skill-package changes (per `### Reviewer`, which requires invoking `superpowers:writing-skills` and running the relevant pressure-test walkthrough before publish when `skills/**` or packaged skill behavior changes). That is deep adversarial reasoning, not bounded pattern matching — the same justification that puts `Brainstormer` on Opus. Operators can downshift via `model: sonnet for reviewer` for trivial repo-rule reviews. |
 | `Finisher` | `sonnet` | CI triage, PR ops, status sweeps, mechanical follow-through. |
 
 Notes:
@@ -320,10 +320,10 @@ Headline behaviors:
 - Own receiving and interpreting local pre-publish review findings.
 - Recommend `superpowers:requesting-code-review` for first-pass local review.
 - Also recommend `superpowers:receiving-code-review` when analyzing existing or disputed findings before publish.
-- When reviewing changes to `skills/**/*.md` or workflow-contract docs, invoke `superpowers:writing-skills` and run the relevant pressure-test walkthrough before publish.
+- When reviewing changes to installable skill-package files (`skills/**`, including adjacent prompt or workflow-contract files packaged with a skill), invoke `superpowers:writing-skills` and run the relevant pressure-test walkthrough before publish. Do not invoke writing-skills solely because non-skill docs, operational playbooks, PR templates, or process documents outside `skills/**` describe a workflow.
 - When the change touches `skills/superteam/**` or any Superteam workflow-contract surface, run the skill-improver quality gate documented in `docs/skill-improver-quality-gate.md` (primary mode when the `skill-improver` and `plugin-dev` plugins are available, fallback mode otherwise) and capture the required completion evidence in the PR body.
-- If later fixes change those same workflow-contract surfaces again after an earlier review pass, rerun the relevant pressure-test walkthrough before handing the run back to `Finisher`.
-- Report pressure-test pass/fail results and any loopholes found for skill or workflow-contract changes.
+- If later fixes change installable skill-package files again after an earlier review pass, rerun the relevant pressure-test walkthrough before handing the run back to `Finisher`.
+- Report pressure-test pass/fail results and any loopholes found for installable skill-package changes.
 - Report local findings with `feedback_classification` (`implementation-level` | `plan-level` | `spec-level`) and an owner before routing.
 - Separate durable done-report or review data from operator-facing prose; the data must remain inspectable, but the chat handoff should be as natural and decision-focused as the situation allows.
 - Keep findings local; do not take ownership of external review feedback.
@@ -455,6 +455,7 @@ Before resolving or replying to comments tied to a prior branch state:
 | "It's simpler to just route through `superpowers:executing-plans` and let it ask the developer." | Execute-phase delegations bind directly to the chosen execution-mode skill per R14. Routing through `superpowers:executing-plans` on default paths surfaces a redundant prompt to the developer and is forbidden when the resolved mode is `team mode` or `subagent-driven`. |
 | "The maintainer already signed off on the direction; I can skip writing-skills and just draft the spec." | Per R25, when the design under brainstorming touches `skills/**/*.md` or any workflow-contract surface, invoking `superpowers:writing-skills` is unconditional on the trigger. Cited authority does not waive the rule. The discipline is required because the design itself must carry loophole-closure language, rationalization-table rows, red-flags bullets, token-efficiency targets, and a RED-phase baseline obligation for any new discipline rule. |
 | "The issue only says workflow contract; I don't know the file yet, so I can draft first and decide later." | Plausible skill or workflow-contract scope is enough to load `superpowers:writing-skills` before authoring requirements. If the intended surface is uncertain, load writing-skills first or halt for clarification. |
+| "It is a workflow contract, so Reviewer should invoke writing-skills." | `superpowers:writing-skills` is mandatory for installable skill-package changes, not for every non-skill workflow, playbook, PR template, or process document. Reviewer still performs local pre-publish review and any explicit repo-specific gate for non-skill workflow docs, but the workflow label alone is not a writing-skills trigger. |
 | "The parent model is fine, just inherit." | Per-role defaults are binding (R26). Silent inheritance is forbidden for every role except `Team Lead`. The operator's silence on which model to use is NOT permission to inherit — it means "use the per-role default". The only path to inheritance is the host runtime lacking a model-override mechanism, in which case `Team Lead` inherits-and-warns once per run. |
 | "The operator said 'go faster' — that's basically asking for Sonnet." | Ambiguous framing is NOT an operator override (R26, parallel to R14). Only canonical tokens (`model: opus`, `model: sonnet`, `model: haiku`, or `use <model>` / `with <model>`) override the per-role default. "Go faster" routes to the per-role default; for `Executor` that is already Sonnet. |
 | "Brainstormer's default is Opus, but the operator typed `model: sonnet`, so I'll keep Opus because the design needs reasoning." | Operator override always wins for the delegation it targets. `Team Lead` does not second-guess the operator's explicit token. Override scope is the next delegation only. |
@@ -491,7 +492,8 @@ Before resolving or replying to comments tied to a prior branch state:
 - `Executor` claiming completion without explicit task IDs, SHAs, or verification evidence.
 - `Reviewer` failing to classify findings as `implementation-level`, `plan-level`, or `spec-level`.
 - Local pre-publish review findings routed through `Finisher` instead of `Team Lead`.
-- Skill or workflow-contract changes reviewed without `superpowers:writing-skills` or a pressure-test walkthrough.
+- Installable skill-package changes under `skills/**` reviewed without `superpowers:writing-skills` or a pressure-test walkthrough.
+- Reviewer invokes `superpowers:writing-skills` for changes that touch only non-skill workflow docs, operational playbooks, PR templates, or process documents outside `skills/**`.
 - Local review findings taking ownership of external PR feedback away from `Finisher`.
 - `Finisher` resolving prior-state comments without checking current branch state first.
 - `Finisher` treating missing runtime wakeups as permission to stop early or present a completion-style handoff.

--- a/skills/superteam/agent-spawn-template.md
+++ b/skills/superteam/agent-spawn-template.md
@@ -149,19 +149,19 @@ Append this block in place of `{role-specific inputs}`:
 ```text
 Recommend `superpowers:requesting-code-review`.
 Also recommend `superpowers:receiving-code-review` when analyzing existing or disputed findings before publish.
-Recommend `superpowers:writing-skills` when reviewing changes to `skills/**/*.md` or workflow-contract docs.
+Recommend `superpowers:writing-skills` when reviewing changes to installable skill-package files (`skills/**`, including adjacent prompt or workflow-contract files packaged with a skill). Do not recommend writing-skills solely for non-skill workflow docs, operational playbooks, PR templates, or process documents outside `skills/**`.
 
 Review locally before publish.
 Own receiving and interpreting local pre-publish review findings.
 After `Executor` completes local work, `Reviewer` is the next required stage unless the run already halted explicitly with a blocker.
-When the changed scope includes `skills/**/*.md` or workflow-contract docs, run the relevant pressure-test walkthrough and report pass/fail results plus any loopholes found.
-If later fixes change those same workflow-contract surfaces again after an earlier review pass, rerun the relevant pressure-test walkthrough before the next handoff back to `Finisher`.
+When the changed scope includes installable skill-package files (`skills/**`, including adjacent prompt or workflow-contract files packaged with a skill), run the relevant pressure-test walkthrough and report pass/fail results plus any loopholes found.
+If later fixes change installable skill-package files again after an earlier review pass, rerun the relevant pressure-test walkthrough before the next handoff back to `Finisher`.
 If that walkthrough finds a loophole, route the finding before publish instead of treating the review as complete.
 Done-report contract:
 - `findings[]`: local findings, if any, with one entry per issue
   - each finding entry includes `summary`, `feedback_classification` (`implementation-level` | `plan-level` | `spec-level`), and `owner`
 - `verification_gaps[]`: any missing or invalid verification
-- `pressure_test_results[]`: for skill or workflow-contract changes, the scenarios checked and their pass/fail outcomes, or an explicit empty result when not applicable
+- `pressure_test_results[]`: for installable skill-package changes, the scenarios checked and their pass/fail outcomes, or an explicit empty result when not applicable
 Do not turn completion evidence or review data into a robotic chat report by default. Preserve the data for downstream teammates, and surface only the active findings, verification gaps, or next actions the operator needs.
 Do not take ownership of external PR comments or bot feedback.
 ```


### PR DESCRIPTION
# Pull Request

PR title rule for squash merges: use the exact commitlint/commitizen format for the PR title so the squash commit can be reused unchanged.

`type: #123 short description`

Examples:

- `docs: #12 add superteam skill guide`
- `chore: #34 bootstrap commit hooks`

This title rule applies to pull requests only. GitHub issue titles should stay plain-language and should not use conventional-commit prefixes.

## Summary

- Narrows Superteam Reviewer guidance so `superpowers:writing-skills` is mandatory for installable skill-package changes, not for non-skill workflow/playbook docs solely because they describe a workflow.
- Updates the Reviewer spawn template, rationalization table, and red flags to close the reported workflow-contract over-triggering path.
- Preserves Brainstormer/Gate 1 design-time writing-skills dimensions and the Superteam skill-improver quality gate for `skills/superteam/**`.

## Linked issue

- Closes #70

## Acceptance criteria

### AC-70-1

Non-skill workflow, playbook, PR-template, and process-document changes no longer independently trigger `superpowers:writing-skills` in Reviewer guidance.

- [x] Local evidence — markdownlint + inventory + fallback pressure review | local | @tlmader | 2026-05-03T10:06:40Z
- [ ] Manual test: 1. Review a docs-only workflow/playbook diff outside `skills/**`. 2. Confirm Reviewer guidance does not invoke `superpowers:writing-skills` solely for that non-skill workflow surface.

### AC-70-2

Installable skill-package changes still invoke `superpowers:writing-skills` according to the skill-change review contract.

- [x] Local evidence — markdownlint + inventory + fallback pressure review | local | @tlmader | 2026-05-03T10:06:40Z
- [ ] Manual test: 1. Review a `skills/superteam/**` diff. 2. Confirm Reviewer guidance still requires `superpowers:writing-skills`, pressure-test walkthrough evidence, and the Superteam quality gate.

### AC-70-3

Reviewer and spawn-template guidance now scopes workflow-contract wording to installable skill-package files instead of using workflow-contract docs as a standalone writing-skills trigger.

- [x] Local evidence — markdownlint + inventory + fallback pressure review | local | @tlmader | 2026-05-03T10:06:40Z
- [ ] Manual test: 1. Inspect `skills/superteam/SKILL.md` and `skills/superteam/agent-spawn-template.md`. 2. Confirm Reviewer trigger language names installable skill-package files and explicitly excludes non-skill workflow docs as a sole trigger.

### AC-70-4

The `workflow-contract` plus `writing-skills` inventory was dispositioned: Reviewer-trigger wording was narrowed, while Brainstormer/Gate 1 design-review dimensions were intentionally preserved.

- [x] Local evidence — markdownlint + inventory + fallback pressure review | local | @tlmader | 2026-05-03T10:06:40Z
- [ ] Manual test: 1. Run the inventory `rg` command from the plan. 2. Confirm remaining matches are either narrowed Reviewer trigger language, preserved Brainstormer/Gate 1 design-review language, or explicit rationalization/red-flag closure.

## Validation

- `pnpm lint:md` — passed, `Summary: 0 error(s)`.
- `git diff --check -- skills/superteam/SKILL.md skills/superteam/agent-spawn-template.md` — passed.
- `rg -n "workflow-contract.*writing-skills|writing-skills.*workflow-contract|skills/\\*\\*/\\*\\.md\\` or workflow-contract|skills/\\*\\*/\\*\\.md\\` or workflow|installable skill-package|non-skill workflow" skills/superteam` — reviewed preserved-vs-updated inventory.
- Local Reviewer fallback pressure walkthrough — PT-70-1, PT-70-2, and PT-70-3 passed with no findings or verification gaps.

## Docs updated

- [x] Updated in this PR

## Skill-improver quality gate

- Mode: fallback
- Dispatch: primary `/skill-improver:skill-improver on superteam` was not run because `plugin-dev:skill-reviewer` was unavailable in this run environment.
- Session: not applicable in fallback mode
- Final reviewer pass: fallback local Reviewer found 0 Critical, 0 Major, and no actionable findings.
- Findings:
  - No Critical or Major findings.
  - PT-70-1 passed: non-skill workflow/playbook-only changes no longer independently trigger `superpowers:writing-skills`.
  - PT-70-2 passed: `skills/superteam/**` changes still trigger `superpowers:writing-skills`, pressure-test walkthroughs, and the Superteam quality gate.
  - PT-70-3 passed: mixed changes identify `skills/**` or packaged skill behavior as the writing-skills trigger; non-skill workflow docs are not an independent trigger.
- Fallback caveats: `plugin-dev:skill-reviewer` unavailable in run environment; review performed against `superpowers:writing-skills` discipline.

