### PR TITLE
feat: #77 use Codex model defaults

### DIFF
--- a/docs/project-overrides.md
+++ b/docs/project-overrides.md
@@ -113,7 +113,22 @@ Every applied delta is logged on the operator-facing chat surface:
 
 ---
 
-## Minimal example — model override only
+## Minimal example (Claude host) — model override only
+
+```markdown
+---
+agent: executor
+---
+
+## Model
+sonnet
+```
+
+Applied delta: `superteam delta applied: executor (model); non-negotiable-rules-sha=a1b2c3d4`
+
+---
+
+## Minimal example (Codex host) — model override only
 
 ```markdown
 ---
@@ -128,7 +143,7 @@ Applied delta: `superteam delta applied: executor (model); non-negotiable-rules-
 
 ---
 
-## Full example — all four sections
+## Full example (Codex host) — all four sections
 
 ```markdown
 ---

--- a/docs/project-overrides.md
+++ b/docs/project-overrides.md
@@ -52,7 +52,7 @@ agent: <role>
 ---
 
 ## Model
-<one of: opus | sonnet | haiku | inherit>
+<host-aware token; see closed model enum below>
 
 ## Tools
 allow:
@@ -69,11 +69,13 @@ field is required whenever a body section is present.
 
 ### Closed model enum
 
-Legal `## Model` values: `{ opus, sonnet, haiku, inherit }`.
+Legal `## Model` values are host-aware: `{ inherit, opus, sonnet, haiku }` on `claude-code`; `{ inherit, gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.4-mini }` on `codex`.
 
 `inherit` resolves to "use the shipped default for this role." For non-`team-lead` roles
 a delta of `inherit` is allowed but logs `superteam delta inherit-redundant: <role>`.
 Any other value halts dispatch.
+
+`gpt-5.3-codex-spark` is not a valid `## Model` delta value. It is override-only for exact targeted `Executor` or `Finisher` one-delegation operator overrides.
 
 ### Append-only system prompt
 
@@ -88,9 +90,7 @@ halt with a verbatim blocker. The literal token list lives in
 
 ### Operator-prompt model override (N2)
 
-The operator's R26 model override (canonical tokens: `model: opus`, `model: sonnet`,
-`model: haiku`, or `use <model>` / `with <model>`) applies to the model layer only, after
-the delta is merged. Tool allow/deny and system-prompt-append layers are not
+The operator's R26 model override uses canonical host tokens (Claude: `model: opus|sonnet|haiku`; Codex: `model: gpt-5.5|gpt-5.4|gpt-5.3-codex|gpt-5.4-mini`, plus `use <model>` / `with <model>` aliases) and applies to the model layer only, after the delta is merged. Tool allow/deny and system-prompt-append layers are not
 operator-prompt-overridable.
 
 ---
@@ -121,7 +121,7 @@ agent: executor
 ---
 
 ## Model
-sonnet
+gpt-5.3-codex
 ```
 
 Applied delta: `superteam delta applied: executor (model); non-negotiable-rules-sha=a1b2c3d4`
@@ -136,7 +136,7 @@ agent: brainstormer
 ---
 
 ## Model
-opus
+gpt-5.5
 
 ## Tools
 allow:

--- a/docs/superpowers/plans/2026-05-05-77-update-codex-model-recommendations-for-teammate-roles-plan.md
+++ b/docs/superpowers/plans/2026-05-05-77-update-codex-model-recommendations-for-teammate-roles-plan.md
@@ -1,0 +1,186 @@
+# Plan: Update Codex model recommendations for teammate roles [#77](https://github.com/patinaproject/superteam/issues/77)
+
+## Planning basis
+
+- Issue: [#77](https://github.com/patinaproject/superteam/issues/77)
+- Approved design: [2026-05-05-77-update-codex-model-recommendations-for-teammate-roles-design.md](/Users/tlmader/.codex/worktrees/b1e8/superteam/docs/superpowers/specs/2026-05-05-77-update-codex-model-recommendations-for-teammate-roles-design.md)
+- Approved design commit: `830b42d724fc00f8e99d5869d2ae524270f6ae62`
+- Planner scope: this plan covers only the implementation surfaces named in the approved design. No code or docs outside that surface should change unless execution finds a direct contradiction that blocks an AC.
+
+## Scope and constraints
+
+- Primary goal: update Codex-hosted Superteam model defaults and host-aware model-selection guidance without weakening Claude-host guidance.
+- Keep `Team Lead` at `inherit`.
+- Update only Codex per-role defaults under `skills/superteam/agents/*.openai.yaml`.
+- Treat `gpt-5.3-codex-spark` as override-only for `Executor` and `Finisher`.
+- Reject Spark from shipped defaults, project deltas, and host-wide default enums.
+- Preserve Claude guidance in `skills/superteam/.claude/agents/*.md` unless execution finds a concrete inconsistency that blocks AC-77-5.
+- Because this issue changes `skills/**/*.md` and workflow-contract surfaces, readiness claims require `superpowers:writing-skills` review dimensions, the named pressure tests, and the `skill-improver` quality gate evidence before handoff to Finisher.
+
+## Acceptance criteria mapping
+
+| AC | Implementation target |
+|---|---|
+| `AC-77-1` | Replace Claude-era Codex defaults in `skills/superteam/agents/*.openai.yaml` and update shared contract text so Codex non-`Team Lead` delegations resolve to Codex-native defaults. |
+| `AC-77-2` | Set Codex per-role YAML defaults to the issue-approved table and verify by direct file inspection plus targeted `rg`. |
+| `AC-77-3` | Update host-aware override grammar and loophole language so exact Codex model tokens override one targeted delegation only, then revert to defaults. |
+| `AC-77-4` | Document `gpt-5.3-codex-spark` only as an explicit transient override for trivial `Executor` or `Finisher` delegations, and explicitly reject it from defaults and project deltas. |
+| `AC-77-5` | Keep Claude-facing files and guidance valid by splitting host vocabularies instead of replacing Claude tokens globally. |
+
+## Files in scope
+
+- Modify `skills/superteam/SKILL.md`
+- Modify `skills/superteam/project-deltas.md`
+- Modify `skills/superteam/agents/brainstormer.openai.yaml`
+- Modify `skills/superteam/agents/planner.openai.yaml`
+- Modify `skills/superteam/agents/executor.openai.yaml`
+- Modify `skills/superteam/agents/reviewer.openai.yaml`
+- Modify `skills/superteam/agents/finisher.openai.yaml`
+- Inspect only `skills/superteam/agents/team-lead.openai.yaml`
+- Inspect only `skills/superteam/.claude/agents/*.md`
+
+## Workstreams
+
+### WS-77-1: Codex per-role defaults
+
+**AC linkage:** `AC-77-1`, `AC-77-2`, `AC-77-5`
+
+#### Files to modify
+
+- `skills/superteam/agents/brainstormer.openai.yaml`
+- `skills/superteam/agents/planner.openai.yaml`
+- `skills/superteam/agents/executor.openai.yaml`
+- `skills/superteam/agents/reviewer.openai.yaml`
+- `skills/superteam/agents/finisher.openai.yaml`
+
+#### Task IDs
+
+- `T77-1` Change `brainstormer.openai.yaml` from `model: opus` to `model: gpt-5.5`.
+- `T77-2` Change `planner.openai.yaml` from `model: opus` to `model: gpt-5.4`.
+- `T77-3` Change `executor.openai.yaml` from `model: sonnet` to `model: gpt-5.3-codex`.
+- `T77-4` Change `reviewer.openai.yaml` from `model: opus` to `model: gpt-5.5`.
+- `T77-5` Change `finisher.openai.yaml` from `model: sonnet` to `model: gpt-5.4-mini`.
+- `T77-6` Confirm `team-lead.openai.yaml` remains `model: inherit` and does not gain stale prose that contradicts the new Codex contract.
+- `T77-7` Inspect `skills/superteam/.claude/agents/*.md` to confirm Claude role metadata remains unchanged and still valid for `AC-77-5`.
+
+#### RED verification
+
+- `rg -n '^model: (opus|sonnet|haiku)$' skills/superteam/agents/*.openai.yaml`
+- Expected before changes: matches for non-`Team Lead` Codex role files.
+
+#### GREEN verification
+
+- `rg -n '^model: (gpt-5\\.5|gpt-5\\.4|gpt-5\\.3-codex|gpt-5\\.4-mini|inherit)$' skills/superteam/agents/*.openai.yaml`
+- `rg -n '^model: (opus|sonnet|haiku)$' skills/superteam/agents/*.openai.yaml`
+- Expected after changes: first command shows the approved Codex mapping plus `inherit`; second command returns no matches.
+
+### WS-77-2: Shared model-selection contract and override grammar
+
+**AC linkage:** `AC-77-1`, `AC-77-3`, `AC-77-4`, `AC-77-5`
+
+#### Files to modify
+
+- `skills/superteam/SKILL.md`
+- `skills/superteam/project-deltas.md`
+
+#### Task IDs
+
+- `T77-8` Update `skills/superteam/SKILL.md` `## Model selection` so per-role defaults are explicitly host-specific rather than globally limited to `opus`, `sonnet`, or `haiku`.
+- `T77-9` Update `skills/superteam/SKILL.md` `### Operator override grammar` to include supported Codex model tokens and preserve the exact-token-only rule.
+- `T77-10` Update `skills/superteam/SKILL.md` `## Project deltas (Team Lead lookup)` schema and closed-enum prose to describe host-aware legal values.
+- `T77-11` Update rationalization, loophole, and red-flag language in `skills/superteam/SKILL.md` so it rejects silent inheritance and ambiguous downshifts for Codex the same way it currently rejects them for Claude.
+- `T77-12` Update `skills/superteam/project-deltas.md` `resolve_role_config` pseudocode so `allowed_model_values` is host-aware and Spark is excluded from delta-legal values.
+- `T77-13` Update `skills/superteam/project-deltas.md` grammar examples to include supported Codex exact tokens and targeted examples such as `model: gpt-5.3-codex-spark for finisher`.
+- `T77-14` Update `skills/superteam/project-deltas.md` loophole-closure text so Spark remains override-only, one-delegation, and limited to `Executor` or `Finisher`.
+- `T77-15` Ensure every shared reference to non-`Team Lead` explicit model binding is host-aware and no longer says all non-`Team Lead` roles must resolve only to `opus`, `sonnet`, or `haiku`.
+
+#### Explicit Spark rule
+
+- Spark is valid only as an exact operator override token for the next `Executor` or `Finisher` delegation.
+- Spark is invalid as:
+  - a shipped role default
+  - a project-delta `## Model` value
+  - a host-wide `allowed_model_values` member
+  - a `Reviewer`, `Planner`, `Brainstormer`, or `Team Lead` override target
+  - an inferred response to phrases like "go cheap", "go faster", or "tiny task"
+
+#### RED verification
+
+- `rg -n "every other delegation MUST resolve to .*|<one of: opus \\| sonnet \\| haiku \\| inherit>|\\{ opus, sonnet, haiku, inherit \\}|parsed\\.model not in \\{\"opus\", \"sonnet\", \"haiku\", \"inherit\"\\}" skills/superteam/SKILL.md skills/superteam/project-deltas.md`
+- `rg -n "gpt-5\\.3-codex-spark" skills/superteam/SKILL.md skills/superteam/project-deltas.md`
+- Expected before changes: Claude-only enum text is present; Spark is absent or insufficiently constrained.
+
+#### GREEN verification
+
+- `rg -n "allowed_model_values|gpt-5\\.5|gpt-5\\.4|gpt-5\\.3-codex|gpt-5\\.4-mini|gpt-5\\.3-codex-spark" skills/superteam/SKILL.md skills/superteam/project-deltas.md`
+- `rg -n "override-only|Executor|Finisher|invalid model value" skills/superteam/SKILL.md skills/superteam/project-deltas.md`
+- `rg -n "every other delegation MUST resolve to .*|\\{ opus, sonnet, haiku, inherit \\}" skills/superteam/SKILL.md`
+- Expected after changes: host-aware token language and Spark restrictions are present; the old shared Claude-only wording is removed from Codex-applicable sections.
+
+### WS-77-3: Review evidence and readiness gates
+
+**AC linkage:** `AC-77-3`, `AC-77-4`, `AC-77-5`
+
+#### Files to modify
+
+- None required for this workstream unless execution needs to add clarifying verification notes inside the touched files.
+
+#### Task IDs
+
+- `T77-16` Run the design pressure tests as implementation-review walkthroughs against the final edited files, not as confidence-only claims.
+- `T77-17` Invoke `superpowers:writing-skills` during review because the change touches `skills/**/*.md` and workflow-contract surfaces.
+- `T77-18` Capture evidence for the required writing-skills dimensions: RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths.
+- `T77-19` Run the `skill-improver` quality gate because the change touches `skills/superteam/**`, and record completion evidence before Finisher handoff.
+- `T77-20` Do not claim readiness if any pressure test, writing-skills dimension, or skill-improver evidence is missing.
+
+## Pressure tests to execute during review
+
+- `PT-77-1` Codex default resolution
+  - Prove Codex role defaults come from `agents/*.openai.yaml` and use `gpt-*` values for every non-`Team Lead` role.
+- `PT-77-2` Claude preservation
+  - Prove `.claude/agents/*.md` remain the Claude-owned default surface and are not silently rewritten to Codex model IDs.
+- `PT-77-3` Codex override scope
+  - Prove `model: gpt-5.3-codex-spark for finisher` applies only to the next targeted `Finisher` delegation and does not persist.
+- `PT-77-4` Ambiguous downshift pressure
+  - Prove phrases such as `go cheap` or `tiny Executor task` remain non-overrides.
+- `PT-77-5` Project delta validation
+  - Prove host-aware validation accepts supported Codex delta values, still accepts supported Claude delta values on Claude, and rejects Spark in deltas.
+- `PT-77-5A` Spark wrong-role override rejection
+  - Prove `model: gpt-5.3-codex-spark for reviewer` is rejected and does not silently map to another cheap model.
+- `PT-77-6` Writing-skills review dimensions
+  - Prove the review explicitly checked RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency, role ownership, and stage-gate bypass paths.
+
+## Validation commands
+
+Run these exact commands during implementation and review:
+
+```bash
+sed -n '1,220p' skills/superteam/agents/brainstormer.openai.yaml
+sed -n '1,220p' skills/superteam/agents/planner.openai.yaml
+sed -n '1,220p' skills/superteam/agents/executor.openai.yaml
+sed -n '1,220p' skills/superteam/agents/reviewer.openai.yaml
+sed -n '1,220p' skills/superteam/agents/finisher.openai.yaml
+sed -n '80,220p' skills/superteam/SKILL.md
+sed -n '1,260p' skills/superteam/project-deltas.md
+rg -n '^model: (gpt-5\.5|gpt-5\.4|gpt-5\.3-codex|gpt-5\.4-mini|inherit)$' skills/superteam/agents/*.openai.yaml
+rg -n '^model: (opus|sonnet|haiku)$' skills/superteam/agents/*.openai.yaml
+rg -n 'gpt-5\.3-codex-spark|allowed_model_values|override-only|invalid model value' skills/superteam/SKILL.md skills/superteam/project-deltas.md
+rg -n 'skill-improver|writing-skills|RED|GREEN|rationalization|stage-gate bypass' skills/superteam/SKILL.md skills/superteam/project-deltas.md skills/superteam/agents/reviewer.openai.yaml
+pnpm lint:md
+git diff -- skills/superteam/SKILL.md skills/superteam/project-deltas.md skills/superteam/agents/*.openai.yaml
+```
+
+## Sequencing and handoff
+
+1. Complete `WS-77-1` first so the Codex role metadata matches the issue-approved table.
+2. Complete `WS-77-2` next so the shared contract explains and validates the new defaults correctly.
+3. Finish with `WS-77-3` review evidence before any readiness claim or Finisher handoff.
+4. Keep commits scoped to the implementation surface above; do not fold unrelated cleanup into this issue.
+
+## Expected implementation output
+
+- Codex role YAML defaults match the issue table exactly.
+- Shared docs describe host-specific model vocabularies without weakening Claude guidance.
+- Spark is documented as an explicit transient override for trivial `Executor` or `Finisher` delegations only.
+- Project-delta validation is host-aware and rejects Spark from `allowed_model_values`.
+- Reviewer evidence includes writing-skills pressure-test coverage and `skill-improver` completion evidence before readiness claims.

--- a/docs/superpowers/specs/2026-05-05-77-update-codex-model-recommendations-for-teammate-roles-design.md
+++ b/docs/superpowers/specs/2026-05-05-77-update-codex-model-recommendations-for-teammate-roles-design.md
@@ -24,11 +24,12 @@ The design separates host vocabularies instead of replacing `opus` / `sonnet` / 
   - `Executor`: `gpt-5.3-codex`
   - `Reviewer`: `gpt-5.5`
   - `Finisher`: `gpt-5.4-mini`
-- Document `gpt-5.3-codex-spark` only as an optional explicit downshift for trivial `Executor` or `Finisher` delegations. It must not become a shipped teammate role, a default, or an automatic inference path.
+- Document `gpt-5.3-codex-spark` only as an optional explicit, transient operator downshift for trivial `Executor` or `Finisher` delegations. It must not become a shipped teammate role, a default, a host-wide allowed value, a project-delta value, or an automatic inference path.
 - Split model vocabularies by active host:
   - Claude Code allowed model tokens: `opus`, `sonnet`, `haiku`, plus `inherit` where the current contract allows it.
-  - Codex allowed model tokens: `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, plus `inherit` where the current contract allows it.
-- Update project-delta model validation so the legal `## Model` values are host-aware rather than Claude-only. A Codex project delta may name a supported Codex token; a Claude project delta may still name `opus`, `sonnet`, or `haiku`.
+  - Codex role and project-delta model tokens: `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.4-mini`, plus `inherit` where the current contract allows it.
+- Treat `gpt-5.3-codex-spark` as a Codex override-only token, accepted only when an exact operator override targets the next `Executor` or `Finisher` delegation. It is not part of the host-wide role/default token set and must be rejected in project deltas.
+- Update project-delta model validation so the legal `## Model` values are host-aware rather than Claude-only. A Codex project delta may name a supported Codex role token; a Claude project delta may still name `opus`, `sonnet`, or `haiku`; neither host may use the transient Spark downshift in a project delta.
 - Update operator-override grammar examples so Codex examples name exact supported Codex model tokens. Ambiguous phrases such as "use the cheap model", "go faster", or "use the smart model" remain non-overrides on both hosts.
 - Keep `.claude/agents/*.md` model metadata unchanged unless implementation finds an actual Claude-specific inconsistency. The Codex work belongs in `agents/*.openai.yaml` and cross-host orchestration docs.
 - Update rationalization and red-flag language that currently hard-codes `opus`, `sonnet`, and `haiku` as the only non-inherit possibilities so it covers host-specific model tokens without weakening the binding requirement.
@@ -43,7 +44,7 @@ Keep the current "per-role defaults live in the shipped agent file" rule, but cl
 | Host | Authoritative role files | Default vocabulary |
 |---|---|---|
 | Claude Code | `skills/superteam/.claude/agents/<role>.md` | `inherit`, `opus`, `sonnet`, `haiku` |
-| Codex | `skills/superteam/agents/<role>.openai.yaml` | `inherit`, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.4-mini`, `gpt-5.3-codex-spark` |
+| Codex | `skills/superteam/agents/<role>.openai.yaml` | `inherit`, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.4-mini` |
 
 `skills/superteam/agents/openai.yaml` remains plugin-level metadata, not a per-role config surface.
 
@@ -60,11 +61,12 @@ Keep the current "per-role defaults live in the shipped agent file" rule, but cl
 
 ### Override grammar
 
-Keep the #67 grammar shape and make the canonical token set host-aware:
+Keep the #67 grammar shape and make the canonical token set host-aware. Spark is the one Codex exception: it is an override-only token, not a role/default/project-delta token.
 
 - Claude examples remain `model: opus`, `model: sonnet`, `model: haiku`, plus `use <model>` and `with <model>`.
 - Codex examples add exact tokens such as `model: gpt-5.3-codex`, `use gpt-5.4-mini`, and `with gpt-5.5`.
 - Targeted form remains `model: <model> for <role>`, for example `model: gpt-5.3-codex-spark for finisher`.
+- `gpt-5.3-codex-spark` is valid only when the exact override token targets `Executor` or `Finisher` for the next delegation. `model: gpt-5.3-codex-spark for reviewer`, untargeted Spark overrides, role defaults, and project deltas using Spark are invalid.
 - Matching remains case-insensitive on canonical token forms. No fuzzy intent inference is added.
 - Override scope remains one targeted delegation only. Later delegations re-resolve from host-specific role defaults.
 
@@ -75,8 +77,10 @@ Revise `resolve_role_config` and the surrounding prose so the closed enum is a h
 ```text
 allowed_model_values(host):
   claude-code -> {inherit, opus, sonnet, haiku}
-  codex -> {inherit, gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.4-mini, gpt-5.3-codex-spark}
+  codex -> {inherit, gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.4-mini}
 ```
+
+`gpt-5.3-codex-spark` deliberately stays outside `allowed_model_values(host)`. It is handled only by the operator-override parser after the target role is known, and only for `Executor` or `Finisher` one-delegation overrides.
 
 The existing invalid-model halt string can stay stable:
 
@@ -118,7 +122,7 @@ If implementation needs better diagnostics, it may add explanatory prose near th
 |---|---|
 | Codex IDs accidentally replace Claude aliases globally. | Treat `.claude/agents/*.md` as Claude-owned and keep a host-specific token table in shared docs. Verify with targeted `rg` checks. |
 | Host-aware enum becomes an open enum and accepts typos. | Keep the enum closed per host and preserve invalid-value halt behavior. |
-| `gpt-5.3-codex-spark` becomes an inferred default for "small" work. | Document it only as an explicit operator downshift token for trivial `Executor` or `Finisher` delegations. |
+| `gpt-5.3-codex-spark` becomes an inferred default, project-delta value, or wrong-role override for "small" work. | Keep Spark outside the Codex role/default/project-delta enum and accept it only as an exact, targeted, one-delegation operator override for `Executor` or `Finisher`. |
 | Ambiguous budget language becomes a model override. | Preserve the #67 non-override phrase list and add Codex examples without adding fuzzy matching. |
 | Planner over-edits unrelated orchestration contracts. | Scope implementation to model-selection prose, Codex role metadata, and project-delta model validation. |
 | Reviewer cannot prove skill readiness from prose alone. | Require pressure tests and writing-skills review dimensions before any production-readiness claim for `skills/**/*.md` changes. |
@@ -143,7 +147,11 @@ Given operator text "this is just a tiny Executor task, go cheap", `Team Lead` d
 
 ### PT-77-5: Project delta validation
 
-Given active host `codex` and a project delta with `## Model` set to `gpt-5.4-mini`, `resolve_role_config` accepts it for supported roles. Given active host `codex` and `## Model` set to `sonnet`, it halts as an invalid model value for Codex. Given active host `claude-code` and `## Model` set to `sonnet`, it remains valid.
+Given active host `codex` and a project delta with `## Model` set to `gpt-5.4-mini`, `resolve_role_config` accepts it for supported roles. Given active host `codex` and `## Model` set to `sonnet` or `gpt-5.3-codex-spark`, it halts as an invalid model value for Codex. Given active host `claude-code` and `## Model` set to `sonnet`, it remains valid.
+
+### PT-77-5A: Spark wrong-role override rejection
+
+Given operator text `model: gpt-5.3-codex-spark for reviewer`, `Team Lead` rejects the override as invalid for the targeted role and does not silently apply Spark, infer another cheap model, or persist the requested value. A Reviewer delegation must use `gpt-5.5` unless an exact supported Reviewer override is present.
 
 ### PT-77-6: Writing-skills review dimensions
 
@@ -155,7 +163,7 @@ This Brainstormer pass did not run an independent adversarial review. The later 
 
 - RED/GREEN baseline: before state is Claude-only Codex metadata and a closed Claude-only enum; after state is host-aware default resolution and host-aware override validation.
 - Rationalization resistance: no "parent model is fine", "go cheap means spark", or "Codex can reuse Claude aliases" shortcuts.
-- Red flags: Codex YAMLs with `model: opus|sonnet|haiku`, shared docs saying all non-`Team Lead` roles must resolve only to Claude aliases, or project deltas accepting Codex model strings on Claude hosts without a host check.
+- Red flags: Codex YAMLs with `model: opus|sonnet|haiku`, shared docs saying all non-`Team Lead` roles must resolve only to Claude aliases, project deltas accepting Codex model strings on Claude hosts without a host check, or Spark appearing in role defaults, host-wide enums, project-delta values, or non-`Executor` / non-`Finisher` overrides.
 - Token efficiency: `SKILL.md` should stay concise and push literal token catalogs into `project-deltas.md`.
 - Role ownership: `Team Lead` owns model resolution; role files own shipped defaults; operator owns explicit overrides; Reviewer owns pressure-test verification.
 - Stage-gate bypass paths: no model change should bypass Gate 1, execution-mode routing, Reviewer, Finisher, or committed handoff requirements.
@@ -167,6 +175,7 @@ This Brainstormer pass did not run an independent adversarial review. The later 
 | brainstormer | material | `skills/superteam/SKILL.md` and `skills/superteam/project-deltas.md` | Current shared contract states every non-`Team Lead` role must resolve only to `opus`, `sonnet`, or `haiku`, which conflicts with Codex-native defaults. | Addressed by requirement to make the enum host-aware rather than globally replacing Claude guidance. |
 | brainstormer | material | `skills/superteam/agents/*.openai.yaml` | Current Codex role metadata uses Claude aliases for all non-`Team Lead` roles. | Addressed by AC-77-2 requirements and affected-file mapping. |
 | brainstormer | minor | Spark downshift path | Without explicit wording, `gpt-5.3-codex-spark` could become an inferred default for any "small" task. | Addressed by non-goal, override grammar, and pressure tests requiring exact operator token use. |
+| adversarial-review | material | `docs/superpowers/specs/2026-05-05-77-update-codex-model-recommendations-for-teammate-roles-design.md:27` | Design scoped `gpt-5.3-codex-spark` to optional explicit downshift for trivial `Executor` or `Finisher` delegations, but later included Spark in the host-wide Codex token set and project-delta enum. That admitted persistent project-delta use and wrong-role use, weakening AC-77-4. | Resolved by removing Spark from Codex role/default/project-delta `allowed_model_values(host)`, defining Spark as override-only after target role resolution, limiting it to one-delegation `Executor` or `Finisher` overrides, and adding pressure tests for project-delta and wrong-role rejection. |
 
 ## Handoff guidance
 

--- a/docs/superpowers/specs/2026-05-05-77-update-codex-model-recommendations-for-teammate-roles-design.md
+++ b/docs/superpowers/specs/2026-05-05-77-update-codex-model-recommendations-for-teammate-roles-design.md
@@ -1,0 +1,173 @@
+# Design: Update Codex model recommendations for teammate roles [#77](https://github.com/patinaproject/superteam/issues/77)
+
+## Intent summary
+
+Update the `superteam` model-selection contract so Codex-hosted teammate delegations use Codex-native model IDs while Claude-hosted delegations keep the existing Claude guidance. The change should preserve the static per-role policy introduced by [#67](https://github.com/patinaproject/superteam/issues/67): `Team Lead` resolves a model at delegation time, explicit operator overrides are unambiguous and non-persistent, and silent inheritance is forbidden except for `Team Lead` itself or the existing inherit-and-warn capability fallback.
+
+The design separates host vocabularies instead of replacing `opus` / `sonnet` / `haiku` globally. Claude Code continues to use Claude model aliases in `.claude/agents/*.md` and Claude override examples. Codex uses `gpt-*` model IDs in `agents/*.openai.yaml`, Codex override examples, Codex project-delta validation, and any Codex-facing recommendation text.
+
+## Acceptance criteria
+
+- **AC-77-1**: Given a Codex host, when `Team Lead` resolves teammate model defaults, every non-`Team Lead` role uses a Codex-native default instead of `opus`, `sonnet`, or `haiku`.
+- **AC-77-2**: Given the `Brainstormer`, `Planner`, `Executor`, `Reviewer`, and `Finisher` Codex role files, when their Codex model metadata is inspected, the defaults match the agreed table in issue #77.
+- **AC-77-3**: Given an operator override in a Codex run, when the override names a supported Codex model token, `Team Lead` applies it only to the targeted delegation and subsequent delegations revert to role defaults.
+- **AC-77-4**: Given a trivial `Executor` or `Finisher` task, when `gpt-5.3-codex-spark` is available, the docs describe it as an optional downshift path rather than a canonical role.
+- **AC-77-5**: Given existing Claude-facing guidance, when this change is complete, Claude model guidance remains valid or is clearly separated from Codex guidance instead of being silently replaced.
+
+## Requirements
+
+- Preserve the #67 invariants: static per-role defaults, binding model resolution at delegation time, explicit override tokens only, one-delegation override scope, no persistent override memory, and inherit-and-warn when the host lacks a model-override surface.
+- Keep `Team Lead` as `inherit` on both hosts.
+- Set Codex role defaults exactly:
+  - `Brainstormer`: `gpt-5.5`
+  - `Planner`: `gpt-5.4`
+  - `Executor`: `gpt-5.3-codex`
+  - `Reviewer`: `gpt-5.5`
+  - `Finisher`: `gpt-5.4-mini`
+- Document `gpt-5.3-codex-spark` only as an optional explicit downshift for trivial `Executor` or `Finisher` delegations. It must not become a shipped teammate role, a default, or an automatic inference path.
+- Split model vocabularies by active host:
+  - Claude Code allowed model tokens: `opus`, `sonnet`, `haiku`, plus `inherit` where the current contract allows it.
+  - Codex allowed model tokens: `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, plus `inherit` where the current contract allows it.
+- Update project-delta model validation so the legal `## Model` values are host-aware rather than Claude-only. A Codex project delta may name a supported Codex token; a Claude project delta may still name `opus`, `sonnet`, or `haiku`.
+- Update operator-override grammar examples so Codex examples name exact supported Codex model tokens. Ambiguous phrases such as "use the cheap model", "go faster", or "use the smart model" remain non-overrides on both hosts.
+- Keep `.claude/agents/*.md` model metadata unchanged unless implementation finds an actual Claude-specific inconsistency. The Codex work belongs in `agents/*.openai.yaml` and cross-host orchestration docs.
+- Update rationalization and red-flag language that currently hard-codes `opus`, `sonnet`, and `haiku` as the only non-inherit possibilities so it covers host-specific model tokens without weakening the binding requirement.
+- Verification must include markdown inspection and targeted `rg` checks proving no Codex role YAML still uses Claude-only model aliases and no shared text still says every non-`Team Lead` role must resolve only to `opus`, `sonnet`, or `haiku`.
+
+## Proposed architecture
+
+### Host-aware model defaults
+
+Keep the current "per-role defaults live in the shipped agent file" rule, but clarify that the authoritative file is host-specific:
+
+| Host | Authoritative role files | Default vocabulary |
+|---|---|---|
+| Claude Code | `skills/superteam/.claude/agents/<role>.md` | `inherit`, `opus`, `sonnet`, `haiku` |
+| Codex | `skills/superteam/agents/<role>.openai.yaml` | `inherit`, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.4-mini`, `gpt-5.3-codex-spark` |
+
+`skills/superteam/agents/openai.yaml` remains plugin-level metadata, not a per-role config surface.
+
+### Codex default policy
+
+| Teammate | Codex default | Rationale |
+|---|---|---|
+| `Team Lead` | `inherit` | Main session owns routing, gate enforcement, and pre-flight; it should not downshift itself. |
+| `Brainstormer` | `gpt-5.5` | Strongest reasoning for ambiguity, requirements, loopholes, and design pressure tests. |
+| `Planner` | `gpt-5.4` | Strong structured planning without spending flagship reasoning on every decomposition step. |
+| `Executor` | `gpt-5.3-codex` | Codex-specialized implementation and test work after ACs and plan constraints are explicit. |
+| `Reviewer` | `gpt-5.5` | Deep adversarial review, especially for `skills/**/*.md` and workflow-contract changes. Operators may explicitly downshift for trivial code-only review. |
+| `Finisher` | `gpt-5.4-mini` | Cheaper mechanical follow-through for PR ops, status sweeps, labels, and CI polling. |
+
+### Override grammar
+
+Keep the #67 grammar shape and make the canonical token set host-aware:
+
+- Claude examples remain `model: opus`, `model: sonnet`, `model: haiku`, plus `use <model>` and `with <model>`.
+- Codex examples add exact tokens such as `model: gpt-5.3-codex`, `use gpt-5.4-mini`, and `with gpt-5.5`.
+- Targeted form remains `model: <model> for <role>`, for example `model: gpt-5.3-codex-spark for finisher`.
+- Matching remains case-insensitive on canonical token forms. No fuzzy intent inference is added.
+- Override scope remains one targeted delegation only. Later delegations re-resolve from host-specific role defaults.
+
+### Project deltas
+
+Revise `resolve_role_config` and the surrounding prose so the closed enum is a host-specific closed enum, not an open free-form model field:
+
+```text
+allowed_model_values(host):
+  claude-code -> {inherit, opus, sonnet, haiku}
+  codex -> {inherit, gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.4-mini, gpt-5.3-codex-spark}
+```
+
+The existing invalid-model halt string can stay stable:
+
+```text
+superteam halted at Team Lead: project delta for <role> has invalid model value <value>
+```
+
+If implementation needs better diagnostics, it may add explanatory prose near the enum, but it should not change the halt string unless the plan explicitly accounts for downstream tests and documentation that expect it.
+
+### Documentation split
+
+`SKILL.md` should describe the cross-host contract and link to `project-deltas.md` for literal grammar examples. `project-deltas.md` should carry literal host-specific token lists, override examples, non-override phrases, and the host-aware enum in pseudocode. This keeps `SKILL.md` from becoming a long model catalog while preserving an inspectable contract.
+
+## Affected files
+
+- `skills/superteam/SKILL.md`: update `## Model selection`, project-delta schema prose, rationalization rows, red flags, and supporting-file descriptions so they are host-aware.
+- `skills/superteam/project-deltas.md`: update `resolve_role_config` pseudocode, enum prose, override grammar examples, loophole closure, and any Claude-only examples that are meant to apply to Codex too.
+- `skills/superteam/agents/brainstormer.openai.yaml`: set `model: gpt-5.5`.
+- `skills/superteam/agents/planner.openai.yaml`: set `model: gpt-5.4`.
+- `skills/superteam/agents/executor.openai.yaml`: set `model: gpt-5.3-codex`.
+- `skills/superteam/agents/reviewer.openai.yaml`: set `model: gpt-5.5`.
+- `skills/superteam/agents/finisher.openai.yaml`: set `model: gpt-5.4-mini`.
+- `skills/superteam/agents/team-lead.openai.yaml`: keep `model: inherit`; inspect only to confirm no stale prose contradicts the new Codex contract.
+- `skills/superteam/.claude/agents/*.md`: preserve current Claude model metadata unless a direct inconsistency is found.
+- Optional docs such as `docs/project-overrides.md`, if present and still describing a Claude-only `## Model` enum, should be updated to show host-aware examples.
+
+## Non-goals
+
+- No dynamic model scoring, automatic complexity inference, automatic downshift, budget tracking, or benchmark harness.
+- No runtime model-availability probing beyond the existing model-override capability path.
+- No new teammate role for `gpt-5.3-codex-spark`.
+- No replacement of Claude guidance with Codex guidance.
+- No changes to execution-mode routing, Gate 1 approval, branch management, PR ownership, or done-report contracts except where text references model selection.
+- No broad skill refactor while making this change.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Codex IDs accidentally replace Claude aliases globally. | Treat `.claude/agents/*.md` as Claude-owned and keep a host-specific token table in shared docs. Verify with targeted `rg` checks. |
+| Host-aware enum becomes an open enum and accepts typos. | Keep the enum closed per host and preserve invalid-value halt behavior. |
+| `gpt-5.3-codex-spark` becomes an inferred default for "small" work. | Document it only as an explicit operator downshift token for trivial `Executor` or `Finisher` delegations. |
+| Ambiguous budget language becomes a model override. | Preserve the #67 non-override phrase list and add Codex examples without adding fuzzy matching. |
+| Planner over-edits unrelated orchestration contracts. | Scope implementation to model-selection prose, Codex role metadata, and project-delta model validation. |
+| Reviewer cannot prove skill readiness from prose alone. | Require pressure tests and writing-skills review dimensions before any production-readiness claim for `skills/**/*.md` changes. |
+
+## Pressure tests
+
+### PT-77-1: Codex default resolution
+
+Given active host `codex` and no operator model override, `Team Lead` resolves defaults from `agents/<role>.openai.yaml`. `Brainstormer`, `Planner`, `Executor`, `Reviewer`, and `Finisher` bind the Codex defaults from the issue table. Any non-`Team Lead` Codex delegation resolving to `opus`, `sonnet`, `haiku`, or inherited parent model is a failure, except for the documented inherit-and-warn capability fallback.
+
+### PT-77-2: Claude preservation
+
+Given active host `claude-code`, `Team Lead` still reads `.claude/agents/<role>.md`, accepts Claude override tokens, and binds Claude aliases. Any implementation that forces `gpt-*` tokens into Claude role metadata or claims Claude operators must use Codex model IDs fails AC-77-5.
+
+### PT-77-3: Codex override scope
+
+Given operator text `model: gpt-5.3-codex-spark for finisher`, the next matching `Finisher` delegation binds `gpt-5.3-codex-spark`. The following `Finisher` delegation without an override reverts to `gpt-5.4-mini`. Reusing spark because the previous task was trivial is a failure.
+
+### PT-77-4: Ambiguous downshift pressure
+
+Given operator text "this is just a tiny Executor task, go cheap", `Team Lead` does not infer `gpt-5.3-codex-spark`. It binds `Executor` to `gpt-5.3-codex` unless an exact supported Codex token is present. Treating "go cheap" as an override fails.
+
+### PT-77-5: Project delta validation
+
+Given active host `codex` and a project delta with `## Model` set to `gpt-5.4-mini`, `resolve_role_config` accepts it for supported roles. Given active host `codex` and `## Model` set to `sonnet`, it halts as an invalid model value for Codex. Given active host `claude-code` and `## Model` set to `sonnet`, it remains valid.
+
+### PT-77-6: Writing-skills review dimensions
+
+Before handoff to Finisher, Reviewer pressure-tests the implementation against the required `superpowers:writing-skills` dimensions: RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths. Missing this evidence blocks readiness claims for skill/workflow-contract changes.
+
+## Adversarial review preparation
+
+This Brainstormer pass did not run an independent adversarial review. The later review should use fresh context when available and check:
+
+- RED/GREEN baseline: before state is Claude-only Codex metadata and a closed Claude-only enum; after state is host-aware default resolution and host-aware override validation.
+- Rationalization resistance: no "parent model is fine", "go cheap means spark", or "Codex can reuse Claude aliases" shortcuts.
+- Red flags: Codex YAMLs with `model: opus|sonnet|haiku`, shared docs saying all non-`Team Lead` roles must resolve only to Claude aliases, or project deltas accepting Codex model strings on Claude hosts without a host check.
+- Token efficiency: `SKILL.md` should stay concise and push literal token catalogs into `project-deltas.md`.
+- Role ownership: `Team Lead` owns model resolution; role files own shipped defaults; operator owns explicit overrides; Reviewer owns pressure-test verification.
+- Stage-gate bypass paths: no model change should bypass Gate 1, execution-mode routing, Reviewer, Finisher, or committed handoff requirements.
+
+## Brainstormer review notes
+
+| Source | Severity | Location | Finding | Disposition |
+|---|---|---|---|---|
+| brainstormer | material | `skills/superteam/SKILL.md` and `skills/superteam/project-deltas.md` | Current shared contract states every non-`Team Lead` role must resolve only to `opus`, `sonnet`, or `haiku`, which conflicts with Codex-native defaults. | Addressed by requirement to make the enum host-aware rather than globally replacing Claude guidance. |
+| brainstormer | material | `skills/superteam/agents/*.openai.yaml` | Current Codex role metadata uses Claude aliases for all non-`Team Lead` roles. | Addressed by AC-77-2 requirements and affected-file mapping. |
+| brainstormer | minor | Spark downshift path | Without explicit wording, `gpt-5.3-codex-spark` could become an inferred default for any "small" task. | Addressed by non-goal, override grammar, and pressure tests requiring exact operator token use. |
+
+## Handoff guidance
+
+Planner should turn this design into a tightly scoped implementation plan. Executor should update only the Codex model metadata and model-selection contract surfaces necessary to satisfy the ACs. Reviewer should not accept "docs look right" as readiness evidence; because this touches `skills/**/*.md` and workflow-contract files, Reviewer must require the pressure-test walkthrough evidence named above before Finisher publication.

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -89,13 +89,24 @@ Operator override: explicit `inline` (or equivalent) switches mode for that dele
 
 ### Per-teammate model defaults
 
-Per-role defaults live in the shipped agent file (the `model:` field is authoritative across both host formats — Claude frontmatter and Codex top-level YAML). `inherit` for `Team Lead` is a literal value; every other delegation MUST resolve to `opus`, `sonnet`, or `haiku`. Defaults are deliberately static.
+Per-role defaults live in the shipped agent file for the active host (Claude frontmatter under `.claude/agents/*.md`; Codex top-level YAML under `agents/*.openai.yaml`). `inherit` for `Team Lead` is a literal value; every other delegation MUST resolve to an explicit host-supported token. Defaults are deliberately static.
+
+Host token sets:
+
+- `claude-code`: `inherit`, `opus`, `sonnet`, `haiku`
+- `codex`: `inherit`, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.4-mini`
+
+`gpt-5.3-codex-spark` is not a default token and is not part of either host's role-default set.
 
 ### Operator override grammar
 
 The override grammar mirrors R14's discipline: only unambiguous tokens count. The matching rule is the same as R14 inline override — substring match on the canonical token forms only, no fuzzy interpretation.
 
-Canonical override tokens (`model: opus`, `model: sonnet`, `model: haiku`, or `use <model>` / `with <model>`) override the per-role default for the next delegation only. Targeted form: `model: <model> for <role>`. Matching is case-insensitive; token applies to the next teammate delegation only; does NOT persist. The full grammar examples and the non-override phrase list live in [`project-deltas.md` `## Model-override grammar examples`](./project-deltas.md#model-override-grammar-examples).
+Canonical override tokens are host-aware and exact (`model: opus`, `model: sonnet`, `model: haiku` on Claude; `model: gpt-5.5`, `model: gpt-5.4`, `model: gpt-5.3-codex`, `model: gpt-5.4-mini` on Codex, plus `use <model>` / `with <model>` aliases). Targeted form: `model: <model> for <role>`. Matching is case-insensitive; token applies to the next teammate delegation only; does NOT persist.
+
+`gpt-5.3-codex-spark` is override-only for exact targeted `Executor` or `Finisher` delegations and never a default, host-wide enum member, or project-delta value.
+
+The full grammar examples and the non-override phrase list live in [`project-deltas.md` `## Model-override grammar examples`](./project-deltas.md#model-override-grammar-examples).
 
 Override scope: operator override always wins for its targeted delegation; subsequent delegations revert to the per-role default. There is no implicit "remember the last override" behavior.
 
@@ -125,7 +136,7 @@ agent: <role>
 ---
 
 ## Model
-<one of: opus | sonnet | haiku | inherit>
+<host-aware token; see closed model enum below>
 
 ## Tools
 allow:
@@ -139,7 +150,7 @@ deny:
 
 ### Closed model enum
 
-The only legal `## Model` values in a delta are `{ opus, sonnet, haiku, inherit }`. `inherit` resolves to "use the shipped default model for this role." For non-`team-lead` roles, a delta of `inherit` is allowed but logs `superteam delta inherit-redundant: <role>`. Invalid values halt (see halt strings below).
+`## Model` is a host-aware closed enum: `{inherit, opus, sonnet, haiku}` on `claude-code`; `{inherit, gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.4-mini}` on `codex`. `inherit` resolves to "use the shipped default model for this role." For non-`team-lead` roles, a delta of `inherit` is allowed but logs `superteam delta inherit-redundant: <role>`. Invalid values halt (see halt strings below). `gpt-5.3-codex-spark` is invalid in project deltas.
 
 ### Precedence
 
@@ -321,8 +332,8 @@ Before resolving comments tied to a prior branch state: verify current state mat
 | "The operator said 'faster' / 'this is taking forever' — that's basically asking for inline." | Inline is auto-selected NEVER. Only unambiguous tokens (`inline`, `run inline`, `execute in this session`) are operator overrides per R14. Ambiguous framing is not. Not even when the CTO is cited. Not even under deadline pressure. |
 | "It's simpler to just route through `superpowers:executing-plans` and let it ask the developer." | Execute-phase delegations bind directly to the chosen execution-mode skill per R14. Routing through `superpowers:executing-plans` on default paths surfaces a redundant prompt to the developer and is forbidden when the resolved mode is `team mode` or `subagent-driven`. |
 | "The parent model is fine, just inherit." | Per-role defaults are binding (R26). Silent inheritance is forbidden for every role except `Team Lead`. The operator's silence on which model to use is NOT permission to inherit — it means "use the per-role default". The only path to inheritance is the host runtime lacking a model-override mechanism, in which case `Team Lead` inherits-and-warns once per run. |
-| "The operator said 'go faster' — that's basically asking for Sonnet." | Ambiguous framing is NOT an operator override (R26, parallel to R14). Only canonical tokens (`model: opus`, `model: sonnet`, `model: haiku`, or `use <model>` / `with <model>`) override the per-role default. "Go faster" routes to the per-role default; for `Executor` that is already Sonnet. |
-| "Brainstormer's default is Opus, but the operator typed `model: sonnet`, so I'll keep Opus because the design needs reasoning." | Operator override always wins for the delegation it targets. `Team Lead` does not second-guess the operator's explicit token. Override scope is the next delegation only. |
+| "The operator said 'go faster' — that's basically asking for Sonnet." | Ambiguous framing is NOT an operator override (R26, parallel to R14). Only canonical host tokens override the per-role default. "Go faster" routes to the per-role default; for Codex `Executor` that is `gpt-5.3-codex`. |
+| "Brainstormer's default is `gpt-5.5`, but the operator typed `model: gpt-5.4`, so I'll keep `gpt-5.5` because the design needs reasoning." | Operator override always wins for the delegation it targets. `Team Lead` does not second-guess the operator's explicit token. Override scope is the next delegation only. |
 | "The operator is on the default branch on purpose; they clearly meant to start work here." | When the active issue resolves from the operator prompt and the current branch is the repository default branch, pre-flight MUST auto-switch to the per-issue branch before committed-artifact inspection. Operator intent is captured by the `#<n>` reference, not by the branch they happened to be on. Not even when the operator is the maintainer. Not even under deadline pressure. |
 | "Skipping the auto-switch saves a step; we can branch later." | Skipping authors Gate 1 artifacts on the wrong base and forces `Finisher` to rewrite history or push from the default branch. The rule is not optional. |
 | "Dirty working tree? I can stash and continue." | The `superteam` issue-branch procedure refuses on a dirty working tree. `superteam` halts with `superteam halted at Team Lead: dirty working tree blocks auto-switch to issue branch`. Pre-flight does NOT stash on the operator's behalf. |
@@ -378,13 +389,13 @@ Before resolving comments tied to a prior branch state: verify current state mat
 - `pre-flight.md` depending on an external branch workflow instead of the self-contained issue-branch procedure.
 - `Team Lead` silently continuing on the default branch after `gh repo view` fails to resolve the default branch.
 - A `superteam` run authoring `docs/superpowers/specs/...` on the default branch.
-- A teammate delegation that omits a resolved `model` value (or omits the host's model-override parameter on the dispatch surface) when the per-role default is `opus`, `sonnet`, or `haiku`. Inheritance is reserved for `Team Lead` and for the inherit-and-warn capability fallback; every other delegation MUST carry an explicit model on the dispatch surface.
+- A teammate delegation that omits a resolved `model` value (or omits the host's model-override parameter on the dispatch surface) when the per-role default is not `inherit`. Inheritance is reserved for `Team Lead` and for the inherit-and-warn capability fallback; every other delegation MUST carry an explicit model on the dispatch surface.
 - Treating "go faster" / "use the cheap model" / "use the better model" / similar fuzzy framing as an operator model override.
-- An execute-phase delegation that resolves `{model}` to the parent session model by default rather than to the per-role `Executor` default (`sonnet`).
+- An execute-phase delegation that resolves `{model}` to the parent session model by default rather than to the per-role `Executor` default (`gpt-5.3-codex` on Codex; `sonnet` on Claude).
 - A per-role procedural rule appears in `SKILL.md` after the refactor (it should be in the role's agent file under [`## Teammate contracts`](#teammate-contracts)).
 - A delta applied silently (no `superteam delta applied: <role> (...); non-negotiable-rules-sha=<prefix>` audit line on the operator-facing chat surface, with stderr fallback only when chat is unavailable).
 - A project delta uses a section heading outside the closed documented set `{ ## Model, ## Tools, ## System prompt append }`. Any other top-level heading is "undocumented" and is ignored with a warn — the determination is mechanical, not judgmental.
-- A malformed delta is interpreted ("looks like sonnet") instead of halting.
+- A malformed delta is interpreted ("looks like sonnet" or "looks like gpt-5.4") instead of halting.
 - Team Lead delegates without first probing and logging the active host. "Active host" is determined deterministically by D3's probe order (`CLAUDECODE` env vars → `CODEX_*` env vars → runtime self-id) and the result is logged at pre-flight as `superteam active host: <name> (probe=<source>)`. A delegation with no preceding probe-log line is a red flag.
 - The active host is outside the supported set `{ claude-code, codex }` and Team Lead delegates anyway instead of halting at pre-flight.
 - The plugin-level `agents/openai.yaml` is treated as a per-role config surface (it is plugin-level metadata; per-role files are `agents/<role>.openai.yaml`).

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: superteam
-description: Use when the operator runs `/superteam` or asks to take a GitHub issue from design through implementation, review, and merged-ready PR using the canonical Team Lead, Brainstormer, Planner, Executor, Reviewer, and Finisher teammate roster. Triggers on phrases like "run superteam on #N", "take this issue through the teammate workflow", or "drive #N to PR".
+description: This skill should be used when the operator runs `/superteam` or asks to take a GitHub issue from design through implementation, review, and merged-ready PR using the canonical Team Lead, Brainstormer, Planner, Executor, Reviewer, and Finisher teammate roster. Triggers on phrases like "run superteam on #N", "take this issue through the teammate workflow", or "drive #N to PR".
 allowed-tools:
   - Read
   - Write
@@ -314,94 +314,29 @@ External PR comments, review threads, bot findings, and other repository feedbac
 
 Before resolving comments tied to a prior branch state: verify current state matches the state the comment referred to; do not respond as if nothing changed; re-route requirement-bearing feedback through the spec-first path.
 
-## Rationalization table
+## Quality guards
 
-| Excuse | Reality |
-|--------|---------|
-| "The design file probably exists if Brainstormer says it does." | Gate 1 requires verifying the artifact exists at the reported path before approval. |
-| "I can summarize the approval request in one short fallback blurb." | Approval packets must include artifact path, concise intent summary, and full requirement set; split oversized packets instead of collapsing them. |
-| "I can replay the whole approval request after a small revision." | Re-fired approval after revisions must be delta-only. |
-| "Just pick the most likely interpretation and proceed." | Ambiguous or contradictory observable state halts the run with an explicit blocker per `## Failure handling`. Resume requires explicit operator clarification of the intended issue, branch, or phase. Not even when there is a deadline. Not even when an authority claim is cited. |
-| "The prompt is short/ambiguous, but the operator clearly meant approval — just advance the gate." | Ambiguous prompts during an open gate are feedback to the active teammate per `routing-table.md`. Approval requires an explicit token (`approve`, `lgtm`, etc.). Not even when an authority claim is cited. Not even when the prior in-session approval feels binding. |
-| "We've already done a lot of work on this — restarting would waste it, so let me just keep going from a fresh top-of-workflow." | The default for repeated `/superteam` invocations is **resume**. Restart requires an explicit operator token (`restart`, `start over`, `new run`) per R7. "Pivot, no need to re-confirm" in the prompt is itself the disallowed shortcut. |
-| "Gate 1 was approved last session; the operator just told me so — no need to re-open it." | Gate 1 is durably observable iff a plan doc has been committed on the branch (R15). Ephemeral in-session approval is NOT durable. Operator memory is not the durable signal; the committed plan doc is. |
-| "Removing `Loopback:` trailers means we can skip local review on a later run." | When implementation exists without a PR and prior local findings cannot be proven resolved from visible state, route through `Reviewer` before `Finisher` can publish. |
-| "A direct operator requirement change during finish is not PR feedback, so Finisher can handle it." | Requirement-bearing deltas route spec-first regardless of source. PR feedback, human-test feedback, and direct operator prompts all return to `Brainstormer`, then `Planner`, then `Executor` before `Finisher` ready/shutdown can resume. |
-| "No execution-mode tool is available, so every `/superteam` invocation must halt." | Missing execution capability blocks only routes that require execute-phase delegation. Approval, review, and `Finisher` status work can continue through their owning teammate. |
-| "We can replace `Loopback:` trailers with another hidden marker." | Feedback routing must resume from visible artifacts, PR state, and operator prompts; do not add sidecar state, branch labels, or new commit footers. |
-| "The operator said 'faster' / 'this is taking forever' — that's basically asking for inline." | Inline is auto-selected NEVER. Only unambiguous tokens (`inline`, `run inline`, `execute in this session`) are operator overrides per R14. Ambiguous framing is not. Not even when the CTO is cited. Not even under deadline pressure. |
-| "It's simpler to just route through `superpowers:executing-plans` and let it ask the developer." | Execute-phase delegations bind directly to the chosen execution-mode skill per R14. Routing through `superpowers:executing-plans` on default paths surfaces a redundant prompt to the developer and is forbidden when the resolved mode is `team mode` or `subagent-driven`. |
-| "The parent model is fine, just inherit." | Per-role defaults are binding (R26). Silent inheritance is forbidden for every role except `Team Lead`. The operator's silence on which model to use is NOT permission to inherit — it means "use the per-role default". The only path to inheritance is the host runtime lacking a model-override mechanism, in which case `Team Lead` inherits-and-warns once per run. |
-| "The operator said 'go faster' — that's basically asking for Sonnet." | Ambiguous framing is NOT an operator override (R26, parallel to R14). Only canonical host tokens override the per-role default. "Go faster" routes to the per-role default; for Codex `Executor` that is `gpt-5.3-codex`. |
-| "Brainstormer's default is `gpt-5.5`, but the operator typed `model: gpt-5.4`, so I'll keep `gpt-5.5` because the design needs reasoning." | Operator override always wins for the delegation it targets. `Team Lead` does not second-guess the operator's explicit token. Override scope is the next delegation only. |
-| "The operator is on the default branch on purpose; they clearly meant to start work here." | When the active issue resolves from the operator prompt and the current branch is the repository default branch, pre-flight MUST auto-switch to the per-issue branch before committed-artifact inspection. Operator intent is captured by the `#<n>` reference, not by the branch they happened to be on. Not even when the operator is the maintainer. Not even under deadline pressure. |
-| "Skipping the auto-switch saves a step; we can branch later." | Skipping authors Gate 1 artifacts on the wrong base and forces `Finisher` to rewrite history or push from the default branch. The rule is not optional. |
-| "Dirty working tree? I can stash and continue." | The `superteam` issue-branch procedure refuses on a dirty working tree. `superteam` halts with `superteam halted at Team Lead: dirty working tree blocks auto-switch to issue branch`. Pre-flight does NOT stash on the operator's behalf. |
-| "Rebase conflict on the existing issue branch is fine; I'll abort and try again." | The `superteam` issue-branch procedure forbids `git rebase --abort` on the operator's behalf. `superteam` halts and surfaces the conflict. |
-| "We can skip the self-contained branch procedure because another plugin probably has it." | `superteam` pre-flight is portable and owns its issue-branch procedure. Do not depend on another workflow skill being installed. |
-| "`adversarial_review_findings[]` already has Brainstormer entries, so review happened." | Brainstormer-originated findings are useful but not sufficient. Gate 1 requires an explicit adversarial-review pass against the committed artifact. |
-| "No findings means no review evidence is needed." | A clean adversarial-review result must include `reviewer_context`, checked dimensions, and `clean_pass_rationale`; silence is not evidence. |
-| "This is a workflow-contract design, but a generic review is enough." | Designs touching `skills/**/*.md` or workflow-contract surfaces require the `superpowers:writing-skills` review dimensions: RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths. |
-| "A finding changed the design, but the earlier review still applies." | Material requirement, ownership, pressure-test, or gate-order changes require rerunning affected review dimensions or recording why rerun is unnecessary. |
-| "Natural prose means we can omit required Gate 1 evidence." | Natural prose changes rendering, not evidence. Required review status, reviewer context, checked dimensions, and clean-pass rationale must still exist before planning. |
-| "The shipped agent file already says it; I can prune it from SKILL.md too." | Orchestration invariants (gates, done-report contracts, routing, halt conditions) STAY in SKILL.md and are referenced from agent files. Per-role procedure moves; cross-role invariants do not. |
-| "The project delta replaces the shipped system prompt because the project knows better." | Deltas are append-only. There is no `replace` mode. Stripping shipped guardrails is forbidden by design. |
-| "I applied a delta but it's the same as the default, so I don't need to log it." | Delta application is always logged: `superteam delta applied`, `superteam delta empty`, or (during pre-flight) `superteam delta orphan`. Silent layering is forbidden. |
-| "The host doesn't have a per-role agent file shipped yet, so I'll just guess from the Claude file." | Missing host-file is a logged fallback to portable defaults plus plugin-level prompt only. Do not silently apply a different host's agent file. |
-| "The malformed delta probably means model: sonnet — I'll just use that." | Malformed delta values halt with `superteam halted at Team Lead: project delta for <role> has invalid model value <value>`. No interpretation, no guess, no default-substitution. |
-| "Empty delta file means the project is unfinished — I'll fall back to no override and not log." | Empty deltas are an intentional anchor; they are a no-op AND they log `superteam delta empty: <role>` so future operators see the file was inspected. |
-| "A project delta append treats acceptance-criteria IDs as advisory — it's a project preference, I should respect it." | Forbidden by LC5 + the D1 non-negotiable-rules block. The denylist lint halts dispatch on any forbidden-intent token (see [`project-deltas.md`](./project-deltas.md#forbidden-append-denylist-lc5)); paraphrase-bypass is countered by the agent file's first-body-section structural defense. |
-| "The active host probe is ambiguous, I'll guess Claude Code." | Forbidden. D3 specifies a deterministic probe order (`CLAUDECODE` env vars → `CODEX_*` env vars → runtime self-id). First match wins; result logged. No guessing. |
-| "The append redefines a done-report field, but it's clearer than SKILL.md's version." | Forbidden by LC5. Done-report contracts are SKILL.md-owned invariants. Lint halts. |
-| "An append-only delta tells Executor it may push for our repo's special workflow." | Forbidden by LC4. Push authority is in Executor's non-negotiable rules block; denylist lint matches `may push` / `may open PR` / `may merge`. |
-| "The host has no shipped per-role file, I'll fall back to the plugin-level prompt for every role." | Out-of-supported-set hosts halt at pre-flight; there is no silent per-delegation degradation. |
+The expanded rationalization table and red-flag catalog live in
+[quality-guards.md](./quality-guards.md). Keep `SKILL.md` focused on the
+orchestration contract; use the reference during review, pressure tests, and
+skill-improver loops.
 
-## Red flags
+High-risk summary:
 
-- Using older stage-only language where the canonical teammate roster should be used.
-- Asking for design approval before verifying the cited artifact exists.
-- Approval requests that omit the artifact path, concise intent summary, or full requirement set.
-- Gate 1 approval packet has `adversarial_review_findings[]` entries but no evidence that an adversarial-review pass occurred.
-- Adversarial review reports `clean` without `reviewer_context`, checked dimensions, or `clean_pass_rationale`.
-- `Planner` starts while a blocker or material `adversarial_review_findings[]` item remains open.
-- Brainstormer-originated findings are treated as a replacement for adversarial review.
-- Workflow-contract design approval proceeds without the `superpowers:writing-skills` adversarial-review dimensions.
-- Oversized approval requests collapsed into a vague summary instead of split into clean sections.
-- Approval requests that hide real approval-relevant findings.
-- Replaying already-approved content instead of sending delta-only approval after revisions.
-- Touching governed files without canonical-rule discovery from repository guidance.
-- Delegated teammate prompts that omit expected `superpowers` recommendations or fail to warn when an expected skill is unavailable.
-- `Team Lead` continuing past contradictory branch / artifact / PR state without halting.
-- Resolving execution-mode capability without running the deterministic probe order in `pre-flight.md`.
-- Classifying an ambiguous prompt during an open gate as approval rather than feedback.
-- Restarting a run on a repeated `/superteam` invocation without an explicit operator restart token or an unambiguous new-issue signal.
-- Treating a prior in-session "approve" as Gate 1 approval when no plan doc has been committed on the branch.
-- Silently switching issues mid-run when the prompt names a different issue without explicit operator confirmation.
-- Reintroducing required `Loopback:` commit trailers or another hidden workflow-state marker.
-- Fresh-session resume from implementation work with no PR skipping `Reviewer` before `Finisher` publication when local review resolution is not visible.
-- An execute-phase delegation prompt that names `superpowers:executing-plans` as the entry skill when the resolved mode is `team mode` or `subagent-driven`.
-- An execute-phase delegation that omits the resolved execution mode and asks the developer to choose.
-- Treating ambiguous "faster" / "inline-ish" / "forever" framing as an inline override.
-- Halting a non-execute route solely because execution-mode capability is unavailable.
-- `Team Lead` proceeding to committed-artifact inspection while the current branch is the repository default branch and the active issue was resolved from an explicit `#<n>` in the prompt.
-- `Team Lead` performing `git stash` or any auto-stash variant as part of the auto-switch path.
-- `Team Lead` running `git rebase --abort` after a rebase conflict on the existing issue branch.
-- `pre-flight.md` depending on an external branch workflow instead of the self-contained issue-branch procedure.
-- `Team Lead` silently continuing on the default branch after `gh repo view` fails to resolve the default branch.
-- A `superteam` run authoring `docs/superpowers/specs/...` on the default branch.
-- A teammate delegation that omits a resolved `model` value (or omits the host's model-override parameter on the dispatch surface) when the per-role default is not `inherit`. Inheritance is reserved for `Team Lead` and for the inherit-and-warn capability fallback; every other delegation MUST carry an explicit model on the dispatch surface.
-- Treating "go faster" / "use the cheap model" / "use the better model" / similar fuzzy framing as an operator model override.
-- An execute-phase delegation that resolves `{model}` to the parent session model by default rather than to the per-role `Executor` default (`gpt-5.3-codex` on Codex; `sonnet` on Claude).
-- A per-role procedural rule appears in `SKILL.md` after the refactor (it should be in the role's agent file under [`## Teammate contracts`](#teammate-contracts)).
-- A delta applied silently (no `superteam delta applied: <role> (...); non-negotiable-rules-sha=<prefix>` audit line on the operator-facing chat surface, with stderr fallback only when chat is unavailable).
-- A project delta uses a section heading outside the closed documented set `{ ## Model, ## Tools, ## System prompt append }`. Any other top-level heading is "undocumented" and is ignored with a warn — the determination is mechanical, not judgmental.
-- A malformed delta is interpreted ("looks like sonnet" or "looks like gpt-5.4") instead of halting.
-- Team Lead delegates without first probing and logging the active host. "Active host" is determined deterministically by D3's probe order (`CLAUDECODE` env vars → `CODEX_*` env vars → runtime self-id) and the result is logged at pre-flight as `superteam active host: <name> (probe=<source>)`. A delegation with no preceding probe-log line is a red flag.
-- The active host is outside the supported set `{ claude-code, codex }` and Team Lead delegates anyway instead of halting at pre-flight.
-- The plugin-level `agents/openai.yaml` is treated as a per-role config surface (it is plugin-level metadata; per-role files are `agents/<role>.openai.yaml`).
-- An orphan `docs/superpowers/<unknown>.md` file is silently used to override an unintended role.
-- A dispatch audit line is missing the `non-negotiable-rules-sha=<prefix>` field.
-- A delta append textually contains a denylist token and dispatch did NOT halt.
+- Do not advance Gate 1 without verified artifact, full requirements, and
+  adversarial-review evidence.
+- Do not treat ambiguous prompts as approval, inline execution, model override,
+  restart, or issue switch.
+- Do not route requirement-bearing feedback straight to implementation.
+- Do not silently inherit teammate models, skip execution-mode binding, or
+  ignore active-host/model-override probes.
+- Do not continue past contradictory branch, artifact, PR, dirty-worktree, or
+  unsupported-host state.
+- Do not replace visible workflow state with hidden trailers, sidecar files,
+  branch labels, or other invisible markers.
+- Do not let project deltas replace shipped guardrails, redefine done reports,
+  bypass AC IDs, or grant push/PR authority.
+- Do not publish without Reviewer and Finisher success on the latest head.
 
 ## Shutdown
 
@@ -426,6 +361,7 @@ A successful run routes from observable state, preserves committed handoffs, pub
 - `docs/superpowers/<role>.md` in the consuming repo: project override surface (see `## Project deltas (Team Lead lookup)`).
 - `docs/project-overrides.md` in this repo: operator-facing authoring guide for project delta files (schema, examples, edge-case table).
 - [project-deltas.md](./project-deltas.md): Team Lead supporting reference — literal denylist tokens, halt/audit-log format strings, active-host probe order, and the `resolve_role_config` algorithm body. SKILL.md names every rule; this file carries the literal bodies.
+- [quality-guards.md](./quality-guards.md): expanded rationalization table and red-flag catalog used for review and pressure tests.
 - [pre-flight.md](./pre-flight.md): phase-detection sequence, execution-mode capability detection, halt conditions
 - [routing-table.md](./routing-table.md): phase x prompt-class routing, classification heuristic, resume vs restart, Gate 1 durability
 - [workflow-diagrams.md](./workflow-diagrams.md): canonical chronological and orchestration diagrams

--- a/skills/superteam/agents/brainstormer.openai.yaml
+++ b/skills/superteam/agents/brainstormer.openai.yaml
@@ -2,7 +2,7 @@
 # tools: Read, Write, Edit, Bash, Glob, Grep (not natively enforced by Codex host; document as parity target)
 # validator: no codex-validate binary in this repo; validated by manual schema match against openai.yaml precedent
 agent: brainstormer
-model: opus
+model: gpt-5.5
 system_prompt: |
   # brainstormer
 

--- a/skills/superteam/agents/executor.openai.yaml
+++ b/skills/superteam/agents/executor.openai.yaml
@@ -2,7 +2,7 @@
 # tools: Read, Write, Edit, Bash, Glob, Grep, Task (not natively enforced by Codex host; document as parity target)
 # validator: no codex-validate binary in this repo; validated by manual schema match against openai.yaml precedent
 agent: executor
-model: sonnet
+model: gpt-5.3-codex
 system_prompt: |
   # executor
 

--- a/skills/superteam/agents/finisher.openai.yaml
+++ b/skills/superteam/agents/finisher.openai.yaml
@@ -2,7 +2,7 @@
 # tools: Read, Write, Edit, Bash, Glob, Grep (not natively enforced by Codex host; document as parity target)
 # validator: no codex-validate binary in this repo; validated by manual schema match against openai.yaml precedent
 agent: finisher
-model: sonnet
+model: gpt-5.4-mini
 system_prompt: |
   # finisher
 

--- a/skills/superteam/agents/planner.openai.yaml
+++ b/skills/superteam/agents/planner.openai.yaml
@@ -2,7 +2,7 @@
 # tools: Read, Write, Edit, Bash, Glob, Grep (not natively enforced by Codex host; document as parity target)
 # validator: no codex-validate binary in this repo; validated by manual schema match against openai.yaml precedent
 agent: planner
-model: opus
+model: gpt-5.4
 system_prompt: |
   # planner
 

--- a/skills/superteam/agents/reviewer.openai.yaml
+++ b/skills/superteam/agents/reviewer.openai.yaml
@@ -2,7 +2,7 @@
 # tools: Read, Bash, Glob, Grep (not natively enforced by Codex host; document as parity target)
 # validator: no codex-validate binary in this repo; validated by manual schema match against openai.yaml precedent
 agent: reviewer
-model: opus
+model: gpt-5.5
 system_prompt: |
   # reviewer
 

--- a/skills/superteam/project-deltas.md
+++ b/skills/superteam/project-deltas.md
@@ -45,7 +45,7 @@ def resolve_role_config(role, host, host_tool_capabilities):
              f"{role} attempts to weaken non-negotiable rules (matched: {matched})")
     config = shipped.copy()
     if parsed.model is not None:
-        if parsed.model not in {"opus", "sonnet", "haiku", "inherit"}:
+        if parsed.model not in allowed_model_values(host):
             halt("superteam halted at Team Lead: project delta for "
                  f"{role} has invalid model value {parsed.model}")
         if parsed.model == "inherit" and shipped.model != "inherit":
@@ -70,6 +70,18 @@ def resolve_role_config(role, host, host_tool_capabilities):
     # before binding the dispatch parameter.
     return config
 ```
+
+Host-aware enum used by `resolve_role_config`:
+
+```text
+allowed_model_values(host):
+  claude-code -> {inherit, opus, sonnet, haiku}
+  codex -> {inherit, gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.4-mini}
+```
+
+`gpt-5.3-codex-spark` is deliberately excluded from `allowed_model_values(host)`.
+It is accepted only by the operator-override parser for exact targeted `Executor`
+or `Finisher` one-delegation overrides.
 
 ---
 
@@ -157,11 +169,12 @@ pre-flight (see halt strings above).
 
 Canonical override tokens (case-insensitive; whitespace around the colon is permitted):
 
-- `model: opus` and aliases `use opus`, `with opus`
-- `model: sonnet` and aliases `use sonnet`, `with sonnet`
-- `model: haiku` and aliases `use haiku`, `with haiku`
+- Claude tokens: `model: opus`, `model: sonnet`, `model: haiku` and aliases `use <model>`, `with <model>`
+- Codex tokens: `model: gpt-5.5`, `model: gpt-5.4`, `model: gpt-5.3-codex`, `model: gpt-5.4-mini` and aliases `use <model>`, `with <model>`
 
-Targeted form: `model: <model> for <role>`, e.g. `model: opus for executor`.
+Targeted form: `model: <model> for <role>`, e.g. `model: gpt-5.4 for planner`.
+
+Spark exception: `model: gpt-5.3-codex-spark for executor` or `model: gpt-5.3-codex-spark for finisher` is valid for one delegation only. Spark targeting other roles or untargeted Spark is invalid.
 
 Phrases that do NOT count as an override — `Team Lead` MUST resolve to the per-role
 default and MUST NOT route these through the override path:
@@ -173,7 +186,7 @@ default and MUST NOT route these through the override path:
 - "save tokens" / "be efficient"
 - "this is taking too long"
 - Any phrasing that names a model family informally without the canonical token
-  (e.g. "use Claude opus please" without `model:` or `use opus`)
+  (e.g. "use Claude opus please" without `model:` or `use opus`, or "use Codex 5.4" without `model:` / `use gpt-5.4`)
 
 ---
 
@@ -194,5 +207,5 @@ default and MUST NOT route these through the override path:
    override the operator with a per-role default reasoning ("but Brainstormer needs
    Opus"). The override scope is one delegation; defaults reassert on the next.
 5. **No persistent override memory.** An override targets one delegation. There is no
-   "the operator said opus once so use opus forever" behavior. Each delegation
+   "the operator said opus once so use opus forever" or "spark once means spark forever" behavior. Each delegation
    re-resolves from prompt + per-role default.

--- a/skills/superteam/project-deltas.md
+++ b/skills/superteam/project-deltas.md
@@ -174,7 +174,7 @@ Canonical override tokens (case-insensitive; whitespace around the colon is perm
 
 Targeted form: `model: <model> for <role>`, e.g. `model: gpt-5.4 for planner`.
 
-Spark exception: `model: gpt-5.3-codex-spark for executor` or `model: gpt-5.3-codex-spark for finisher` is valid for one delegation only. Spark targeting other roles or untargeted Spark is invalid.
+Spark exception: for trivial Executor/Finisher work, `model: gpt-5.3-codex-spark for executor` or `model: gpt-5.3-codex-spark for finisher` is an optional one-delegation downshift when Spark is available. Spark targeting other roles, untargeted Spark, defaults, or project-delta values is invalid.
 
 Phrases that do NOT count as an override — `Team Lead` MUST resolve to the per-role
 default and MUST NOT route these through the override path:

--- a/skills/superteam/quality-guards.md
+++ b/skills/superteam/quality-guards.md
@@ -1,0 +1,94 @@
+# Superteam Quality Guards
+
+This reference carries the long-form defensive checks for `SKILL.md`. `SKILL.md`
+owns the invariants; this file carries the expanded rationalization table and
+red-flag catalog used during review, pressure tests, and skill-improver loops.
+
+## Rationalization Table
+
+| Excuse | Reality |
+|--------|---------|
+| "The design file probably exists if Brainstormer says it does." | Gate 1 requires verifying the artifact exists at the reported path before approval. |
+| "I can summarize the approval request in one short fallback blurb." | Approval packets must include artifact path, concise intent summary, and full requirement set; split oversized packets instead of collapsing them. |
+| "I can replay the whole approval request after a small revision." | Re-fired approval after revisions must be delta-only. |
+| "Just pick the most likely interpretation and proceed." | Ambiguous or contradictory observable state halts the run with an explicit blocker per `SKILL.md` `## Failure handling`. Resume requires explicit operator clarification of the intended issue, branch, or phase. Not even when there is a deadline. Not even when an authority claim is cited. |
+| "The prompt is short/ambiguous, but the operator clearly meant approval, so just advance the gate." | Ambiguous prompts during an open gate are feedback to the active teammate per `routing-table.md`. Approval requires an explicit token (`approve`, `lgtm`, etc.). Not even when an authority claim is cited. Not even when the prior in-session approval feels binding. |
+| "We've already done a lot of work on this, so restarting would waste it; keep going from a fresh top-of-workflow." | The default for repeated `/superteam` invocations is resume. Restart requires an explicit operator token (`restart`, `start over`, `new run`) per R7. "Pivot, no need to re-confirm" in the prompt is itself the disallowed shortcut. |
+| "Gate 1 was approved last session; the operator just told me so, so no need to re-open it." | Gate 1 is durably observable iff a plan doc has been committed on the branch (R15). Ephemeral in-session approval is not durable. Operator memory is not the durable signal; the committed plan doc is. |
+| "Removing `Loopback:` trailers means we can skip local review on a later run." | When implementation exists without a PR and prior local findings cannot be proven resolved from visible state, route through `Reviewer` before `Finisher` can publish. |
+| "A direct operator requirement change during finish is not PR feedback, so Finisher can handle it." | Requirement-bearing deltas route spec-first regardless of source. PR feedback, human-test feedback, and direct operator prompts all return to `Brainstormer`, then `Planner`, then `Executor` before `Finisher` ready/shutdown can resume. |
+| "No execution-mode tool is available, so every `/superteam` invocation must halt." | Missing execution capability blocks only routes that require execute-phase delegation. Approval, review, and `Finisher` status work can continue through their owning teammate. |
+| "We can replace `Loopback:` trailers with another hidden marker." | Feedback routing must resume from visible artifacts, PR state, and operator prompts; do not add sidecar state, branch labels, or new commit footers. |
+| "The operator said 'faster' / 'this is taking forever'; that is basically asking for inline." | Inline is auto-selected never. Only unambiguous tokens (`inline`, `run inline`, `execute in this session`) are operator overrides per R14. Ambiguous framing is not. Not even when the CTO is cited. Not even under deadline pressure. |
+| "It's simpler to route through `superpowers:executing-plans` and let it ask the developer." | Execute-phase delegations bind directly to the chosen execution-mode skill per R14. Routing through `superpowers:executing-plans` on default paths surfaces a redundant prompt to the developer and is forbidden when the resolved mode is `team mode` or `subagent-driven`. |
+| "The parent model is fine, just inherit." | Per-role defaults are binding (R26). Silent inheritance is forbidden for every role except `Team Lead`. The operator's silence on which model to use is not permission to inherit. It means "use the per-role default". The only path to inheritance is the host runtime lacking a model-override mechanism, in which case `Team Lead` inherits-and-warns once per run. |
+| "The operator said 'go faster'; that is basically asking for Sonnet." | Ambiguous framing is not an operator override (R26, parallel to R14). Only canonical host tokens override the per-role default. "Go faster" routes to the per-role default; for Codex `Executor` that is `gpt-5.3-codex`. |
+| "Brainstormer's default is `gpt-5.5`, but the operator typed `model: gpt-5.4`, so keep `gpt-5.5` because the design needs reasoning." | Operator override always wins for the delegation it targets. `Team Lead` does not second-guess the operator's explicit token. Override scope is the next delegation only. |
+| "The operator is on the default branch on purpose; they clearly meant to start work here." | When the active issue resolves from the operator prompt and the current branch is the repository default branch, pre-flight must auto-switch to the per-issue branch before committed-artifact inspection. Operator intent is captured by the `#<n>` reference, not by the branch they happened to be on. Not even when the operator is the maintainer. Not even under deadline pressure. |
+| "Skipping the auto-switch saves a step; we can branch later." | Skipping authors Gate 1 artifacts on the wrong base and forces `Finisher` to rewrite history or push from the default branch. The rule is not optional. |
+| "Dirty working tree? I can stash and continue." | The `superteam` issue-branch procedure refuses on a dirty working tree. `superteam` halts with `superteam halted at Team Lead: dirty working tree blocks auto-switch to issue branch`. Pre-flight does not stash on the operator's behalf. |
+| "Rebase conflict on the existing issue branch is fine; I'll abort and try again." | The `superteam` issue-branch procedure forbids `git rebase --abort` on the operator's behalf. `superteam` halts and surfaces the conflict. |
+| "We can skip the self-contained branch procedure because another plugin probably has it." | `superteam` pre-flight is portable and owns its issue-branch procedure. Do not depend on another workflow skill being installed. |
+| "`adversarial_review_findings[]` already has Brainstormer entries, so review happened." | Brainstormer-originated findings are useful but not sufficient. Gate 1 requires an explicit adversarial-review pass against the committed artifact. |
+| "No findings means no review evidence is needed." | A clean adversarial-review result must include `reviewer_context`, checked dimensions, and `clean_pass_rationale`; silence is not evidence. |
+| "This is a workflow-contract design, but a generic review is enough." | Designs touching `skills/**/*.md` or workflow-contract surfaces require the `superpowers:writing-skills` review dimensions: RED/GREEN baseline obligations, rationalization resistance, red flags, token-efficiency targets, role ownership, and stage-gate bypass paths. |
+| "A finding changed the design, but the earlier review still applies." | Material requirement, ownership, pressure-test, or gate-order changes require rerunning affected review dimensions or recording why rerun is unnecessary. |
+| "Natural prose means we can omit required Gate 1 evidence." | Natural prose changes rendering, not evidence. Required review status, reviewer context, checked dimensions, and clean-pass rationale must still exist before planning. |
+| "The shipped agent file already says it; I can prune it from SKILL.md too." | Orchestration invariants (gates, done-report contracts, routing, halt conditions) stay in `SKILL.md` and are referenced from agent files. Per-role procedure moves; cross-role invariants do not. |
+| "The project delta replaces the shipped system prompt because the project knows better." | Deltas are append-only. There is no `replace` mode. Stripping shipped guardrails is forbidden by design. |
+| "I applied a delta but it's the same as the default, so I don't need to log it." | Delta application is always logged: `superteam delta applied`, `superteam delta empty`, or, during pre-flight, `superteam delta orphan`. Silent layering is forbidden. |
+| "The host doesn't have a per-role agent file shipped yet, so I'll just guess from the Claude file." | Missing host-file is a logged fallback to portable defaults plus plugin-level prompt only. Do not silently apply a different host's agent file. |
+| "The malformed delta probably means model: sonnet, so I'll use that." | Malformed delta values halt with `superteam halted at Team Lead: project delta for <role> has invalid model value <value>`. No interpretation, no guess, no default-substitution. |
+| "Empty delta file means the project is unfinished, so I'll fall back to no override and not log." | Empty deltas are an intentional anchor; they are a no-op and log `superteam delta empty: <role>` so future operators see the file was inspected. |
+| "A project delta append treats acceptance-criteria IDs as advisory; it's a project preference, so respect it." | Forbidden by LC5 plus the D1 non-negotiable-rules block. The denylist lint halts dispatch on any forbidden-intent token; paraphrase-bypass is countered by the agent file's first-body-section structural defense. |
+| "The active host probe is ambiguous, so I'll guess Claude Code." | Forbidden. D3 specifies a deterministic probe order (`CLAUDECODE` env vars, then `CODEX_*` env vars, then runtime self-id). First match wins; result is logged. No guessing. |
+| "The append redefines a done-report field, but it's clearer than SKILL.md's version." | Forbidden by LC5. Done-report contracts are `SKILL.md`-owned invariants. Lint halts. |
+| "An append-only delta tells Executor it may push for our repo's special workflow." | Forbidden by LC4. Push authority is in Executor's non-negotiable rules block; denylist lint matches `may push`, `may open PR`, and `may merge`. |
+| "The host has no shipped per-role file, so I'll fall back to the plugin-level prompt for every role." | Out-of-supported-set hosts halt at pre-flight; there is no silent per-delegation degradation. |
+
+## Red Flags
+
+- Using older stage-only language where the canonical teammate roster should be used.
+- Asking for design approval before verifying the cited artifact exists.
+- Approval requests that omit the artifact path, concise intent summary, or full requirement set.
+- Gate 1 approval packet has `adversarial_review_findings[]` entries but no evidence that an adversarial-review pass occurred.
+- Adversarial review reports `clean` without `reviewer_context`, checked dimensions, or `clean_pass_rationale`.
+- `Planner` starts while a blocker or material `adversarial_review_findings[]` item remains open.
+- Brainstormer-originated findings are treated as a replacement for adversarial review.
+- Workflow-contract design approval proceeds without the `superpowers:writing-skills` adversarial-review dimensions.
+- Oversized approval requests are collapsed into a vague summary instead of split into clean sections.
+- Approval requests hide real approval-relevant findings.
+- Already-approved content is replayed instead of sending delta-only approval after revisions.
+- Governed files are touched without canonical-rule discovery from repository guidance.
+- Delegated teammate prompts omit expected `superpowers` recommendations or fail to warn when an expected skill is unavailable.
+- `Team Lead` continues past contradictory branch, artifact, or PR state without halting.
+- Execution-mode capability is resolved without running the deterministic probe order in `pre-flight.md`.
+- An ambiguous prompt during an open gate is classified as approval rather than feedback.
+- A repeated `/superteam` invocation restarts without an explicit operator restart token or an unambiguous new-issue signal.
+- A prior in-session "approve" is treated as Gate 1 approval when no plan doc has been committed on the branch.
+- Issues are silently switched mid-run when the prompt names a different issue without explicit operator confirmation.
+- Required `Loopback:` commit trailers or another hidden workflow-state marker are reintroduced.
+- Fresh-session resume from implementation work with no PR skips `Reviewer` before `Finisher` publication when local review resolution is not visible.
+- An execute-phase delegation prompt names `superpowers:executing-plans` as the entry skill when the resolved mode is `team mode` or `subagent-driven`.
+- An execute-phase delegation omits the resolved execution mode and asks the developer to choose.
+- Ambiguous "faster", "inline-ish", or "forever" framing is treated as an inline override.
+- A non-execute route halts solely because execution-mode capability is unavailable.
+- `Team Lead` proceeds to committed-artifact inspection while the current branch is the repository default branch and the active issue was resolved from an explicit `#<n>` in the prompt.
+- `Team Lead` performs `git stash` or any auto-stash variant as part of the auto-switch path.
+- `Team Lead` runs `git rebase --abort` after a rebase conflict on the existing issue branch.
+- `pre-flight.md` depends on an external branch workflow instead of the self-contained issue-branch procedure.
+- `Team Lead` silently continues on the default branch after `gh repo view` fails to resolve the default branch.
+- A `superteam` run authors `docs/superpowers/specs/...` on the default branch.
+- A teammate delegation omits a resolved `model` value, or omits the host's model-override parameter on the dispatch surface, when the per-role default is not `inherit`.
+- "Go faster", "use the cheap model", "use the better model", or similar fuzzy framing is treated as an operator model override.
+- An execute-phase delegation resolves `{model}` to the parent session model by default rather than to the per-role `Executor` default (`gpt-5.3-codex` on Codex; `sonnet` on Claude).
+- A per-role procedural rule appears in `SKILL.md` after the refactor instead of in the role's agent file.
+- A delta is applied silently with no `superteam delta applied`, `delta empty`, or `delta orphan` audit line.
+- A project delta uses a section heading outside the documented set `{ ## Model, ## Tools, ## System prompt append }`.
+- A malformed delta is interpreted instead of halting.
+- Team Lead delegates without first probing and logging the active host.
+- The active host is outside the supported set `{ claude-code, codex }` and Team Lead delegates anyway instead of halting at pre-flight.
+- The plugin-level `agents/openai.yaml` is treated as a per-role config surface.
+- An orphan `docs/superpowers/<unknown>.md` file is silently used to override an unintended role.
+- A dispatch audit line is missing the `non-negotiable-rules-sha=<prefix>` field.
+- A delta append textually contains a denylist token and dispatch does not halt.


### PR DESCRIPTION
## Summary

- Update Codex per-role Superteam defaults to `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, and `gpt-5.4-mini` as appropriate.
- Make model-selection docs host-aware while preserving Claude model aliases.
- Document Spark as an exact, transient Executor/Finisher downshift only, and split long quality guard catalogs out of `SKILL.md`.

## Linked issue

- Closes #77

## Acceptance criteria

### AC-77-1

Codex host model resolution now uses Codex-native role defaults rather than Claude aliases.

- [x] Local evidence — Codex role YAML `rg` default check | local | @tlmader | 2026-05-05T07:31:14Z

### AC-77-2

Brainstormer, Planner, Executor, Reviewer, and Finisher Codex role files match the agreed issue table.

- [x] Local evidence — inspected `skills/superteam/agents/*.openai.yaml` model fields | local | @tlmader | 2026-05-05T07:31:14Z

### AC-77-3

Codex override grammar is host-aware, exact-token based, and remains one delegation only.

- [x] Local evidence — reviewed `SKILL.md` and `project-deltas.md` override grammar | local | @tlmader | 2026-05-05T07:31:14Z

### AC-77-4

`gpt-5.3-codex-spark` is documented only as an optional, availability-gated downshift for trivial Executor/Finisher delegations.

- [x] Local evidence — targeted `rg` confirmed Spark exclusion from defaults/project deltas and constrained override prose | local | @tlmader | 2026-05-05T07:31:14Z

### AC-77-5

Claude guidance remains valid and is separated from Codex guidance.

- [x] Local evidence — Claude role metadata preserved and `docs/project-overrides.md` examples split by host | local | @tlmader | 2026-05-05T07:31:14Z

## Validation

- `pnpm lint:md`
- `git diff --check`
- Targeted `rg` checks for Codex defaults, absence of Claude aliases in Codex YAML, Spark constraints, host-aware model enums, and `quality-guards.md` references
- Fresh Reviewer pass: no findings
- `skill-improver` loop: pass; no critical or major issues remain

## Docs updated

- [x] Updated in this PR