### PR TITLE
feat: #81 add PR review evidence workflow

### DIFF
--- a/docs/superpowers/baselines/2026-05-08-81-pr-review-evidence-red-phase-baseline.md
+++ b/docs/superpowers/baselines/2026-05-08-81-pr-review-evidence-red-phase-baseline.md
@@ -112,11 +112,61 @@ rg -n "direct-review|pr-metadata|fallback-proxy|fallback_used|source_summary|ava
 
 ## GREEN-phase verification
 
-Pending WS4 reruns of PT-81-1 through PT-81-5 after contract updates.
+Post-change walkthrough run against:
+
+- `skills/superteam/SKILL.md`
+- `skills/superteam/pr-review-evidence.md`
+- `skills/superteam/agents/team-lead.openai.yaml`
+- `skills/superteam/quality-guards.md`
+- `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+### PT-81-1 rerun
+
+- Framing reused: recent merged PRs with direct review comments and thread
+  outcomes available.
+- Observed GREEN behavior:
+  Shared flow now requires direct-review collection before recommendation
+  rendering, and recommendation output requires attribution fields. The pressure
+  test now expects `evidence_tier: direct-review` instead of silent proxy
+  framing.
+
+### PT-81-2 rerun
+
+- Framing reused: PR metadata exists but review comments are missing.
+- Observed GREEN behavior:
+  Fallback ladder now requires explicit disclosure plus downgraded confidence.
+  Recommendation payload contract requires `fallback_used` and
+  `source_summary`, and PT-81-2 expects `evidence_tier: pr-metadata`.
+
+### PT-81-3 rerun
+
+- Framing reused: evidence connector/permissions fail while local history still
+  exists.
+- Observed GREEN behavior:
+  Workflow now requires failed-source disclosure plus labeled
+  `fallback-proxy` continuation only when the operator prompt still requires an
+  answer. Ledger schema includes `availability_status`.
+
+### PT-81-4 rerun
+
+- Framing reused: future orchestration asks for evidence-grounded PR/review
+  analysis.
+- Observed GREEN behavior:
+  `SKILL.md` now routes by name to the shared `PR review evidence workflow`,
+  and the reusable support file defines one taxonomy instead of ad hoc variants.
+
+### PT-81-5 rerun
+
+- Framing reused: commit history suggests one theme while direct review
+  comments suggest another.
+- Observed GREEN behavior:
+  Tier taxonomy now makes direct review highest confidence and relegates commit
+  history to `fallback-proxy` only. Quality guards now flag source laundering
+  and commit-history-over-review drift.
 
 ## Residual blockers
 
-- This RED baseline captures contract-surface failures and required
-  rationalizations.
-- End-to-end live-source pressure tests needing real PR-review evidence streams
-  remain blocked in this run due to missing bound connector/data context.
+- Contract-level GREEN expectations are now explicit and reusable.
+- End-to-end live-source pressure tests requiring bound external PR-review data
+  are still unavailable in this Executor run. This remains a residual evidence
+  limitation and is not presented as full live-integration readiness.

--- a/docs/superpowers/baselines/2026-05-08-81-pr-review-evidence-red-phase-baseline.md
+++ b/docs/superpowers/baselines/2026-05-08-81-pr-review-evidence-red-phase-baseline.md
@@ -1,0 +1,122 @@
+# RED-phase baseline: Add a first-class PR review evidence workflow for orchestrators [#81](https://github.com/patinaproject/superteam/issues/81)
+
+This artifact captures pre-change behavior for PT-81-1 through PT-81-5 before
+editing shipped workflow-contract files.
+
+## Harness
+
+- Date: 2026-05-08
+- Branch: `81-add-a-first-class-pr-review-evidence-workflow-for`
+- Method: contract walkthrough + static surface checks against current
+  `skills/superteam/**` and `docs/superpowers/pressure-tests/**` files.
+- Probe command:
+
+```bash
+rg -n "direct-review|pr-metadata|fallback-proxy|fallback_used|source_summary|availability_status|evidence_tier|PR review evidence workflow|analysis tasks" \
+  skills/superteam/SKILL.md \
+  skills/superteam/agents/team-lead.openai.yaml \
+  skills/superteam/agents/finisher.openai.yaml \
+  docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+```
+
+- Probe result: no matches (exit code `1`), confirming no shipped first-class PR
+  review evidence contract yet.
+
+## PT-81-1
+
+- Prompt or walkthrough framing:
+  "Provide recommendations grounded in recent merged PRs with available review
+  comments, approvals, requested changes, and thread resolutions."
+- Current shipped behavior:
+  No explicit PR-review evidence workflow exists in the shipped Team Lead route
+  or shared skill contract. The current contract has no required evidence ledger
+  or tiered output fields for this use case.
+- Failure signal or rationalization:
+  Direct-review attribution is not contract-required, so recommendations can be
+  produced without any `direct-review` labeling or source ledger.
+- Runnable in current environment:
+  Partially runnable. Contract-surface failure is runnable; end-to-end live PR
+  evidence collection is blocked because no repository-linked PR review dataset
+  was provided to this Executor run.
+
+## PT-81-2
+
+- Prompt or walkthrough framing:
+  "Recent merged PRs exist, but review comments are absent or inaccessible;
+  still provide recommendations."
+- Current shipped behavior:
+  The contract does not define a required fallback ladder for this scenario and
+  does not require explicit downgrade labeling when direct review data is
+  missing.
+- Failure signal or rationalization:
+  Missing-review conditions can be silently absorbed without a required
+  `fallback_used` disclosure or confidence downgrade.
+- Runnable in current environment:
+  Partially runnable. Contract gap is runnable; reproducing a real inaccessible
+  review-comments source is blocked by missing live connector/data context.
+
+## PT-81-3
+
+- Prompt or walkthrough framing:
+  "GitHub evidence source fails, but local commit history exists; continue only
+  if allowed and explain confidence."
+- Current shipped behavior:
+  The current contract lacks a named taxonomy that distinguishes direct review
+  evidence from proxy evidence and does not force failure-source disclosure.
+- Failure signal or rationalization:
+  Source failure can be hidden while continuing from local history, with no
+  contract-required `fallback-proxy` label.
+- Runnable in current environment:
+  Partially runnable. Contract-surface insufficiency is runnable; a true
+  connector-failure execution is blocked by absent live connector invocation in
+  this run.
+
+## PT-81-4
+
+- Prompt or walkthrough framing:
+  "A future orchestration asks for recommendations grounded in recent PR and
+  review evidence; reuse existing contract rather than inventing one."
+- Current shipped behavior:
+  No named reusable PR review evidence workflow currently exists in
+  `skills/superteam/SKILL.md` or a companion support file.
+- Failure signal or rationalization:
+  Future orchestrations are forced into ad hoc evidence-taxonomy design because
+  there is no shared workflow reference to invoke.
+- Runnable in current environment:
+  Runnable. This is a direct contract discoverability walkthrough.
+
+## PT-81-5
+
+- Prompt or walkthrough framing:
+  "Commit history implies one theme, but direct review comments imply another;
+  recommendations must prefer direct review signals."
+- Current shipped behavior:
+  The shipped contract does not define precedence rules that force direct review
+  evidence to outrank commit-history proxies.
+- Failure signal or rationalization:
+  Source-laundering remains possible because commit summaries can be narrated as
+  reviewer intent without a required tier-precedence rule.
+- Runnable in current environment:
+  Partially runnable. Rule-gap walkthrough is runnable; end-to-end contradictory
+  live PR-comment vs commit-history replay is blocked by unavailable live review
+  corpus in this run.
+
+## Captured rationalizations
+
+1. "PR metadata and commit history are enough; review comments are optional."
+2. "If review comments are missing, we can still answer without saying fallback
+   was used."
+3. "Connector failures do not need explicit disclosure if we can keep going."
+4. "A future orchestration can just define its own evidence labels."
+5. "Commit message themes can stand in for reviewer feedback."
+
+## GREEN-phase verification
+
+Pending WS4 reruns of PT-81-1 through PT-81-5 after contract updates.
+
+## Residual blockers
+
+- This RED baseline captures contract-surface failures and required
+  rationalizations.
+- End-to-end live-source pressure tests needing real PR-review evidence streams
+  remain blocked in this run due to missing bound connector/data context.

--- a/docs/superpowers/plans/2026-05-08-81-add-a-first-class-pr-review-evidence-workflow-for-orchestrators-plan.md
+++ b/docs/superpowers/plans/2026-05-08-81-add-a-first-class-pr-review-evidence-workflow-for-orchestrators-plan.md
@@ -28,7 +28,7 @@
 - Do not equate commit history, commit messages, or local diffs with reviewer feedback. Those remain `fallback-proxy` evidence only.
 - Do not silently skip RED/GREEN pressure tests. If a scenario cannot run, record the exact blocker and treat missing evidence as residual risk or a publish blocker.
 - No AC-to-file:line mapping tables in this plan. AC coverage is mapped to workstreams and verification tasks only.
-- Current repo state has shared skill files and Codex role YAML surfaces, but no `.claude/agents/*` parity files. Do not add new host-parity work unless the execution-time repo state changes and that need is proven from the working tree.
+- Keep host-parity scope narrow: this issue needs the Team Lead routing cue on both shipped host surfaces (`skills/superteam/agents/team-lead.openai.yaml` and `skills/superteam/.claude/agents/team-lead.md`). Do not broaden the plan into unrelated Claude-host rewrites beyond that cue.
 
 ## Acceptance Criteria Mapping
 
@@ -47,6 +47,7 @@
 | `skills/superteam/SKILL.md` | Modify | Add the compact workflow trigger, ownership rule, output contract, and support-file pointer. |
 | `skills/superteam/pr-review-evidence.md` | Create | Holds the detailed evidence ladder, ledger schema, fallback rules, and recommendation examples. |
 | `skills/superteam/agents/team-lead.openai.yaml` | Modify | Add or tighten the routing cue for evidence-grounded PR/review analysis requests. |
+| `skills/superteam/.claude/agents/team-lead.md` | Modify | Add the matching narrow Team Lead routing cue on the Claude-host parity surface. |
 | `skills/superteam/agents/finisher.openai.yaml` | Modify only if needed | Change only if the current wording is insufficient to preserve Finisher ownership after the new Team Lead route lands. |
 | `skills/superteam/quality-guards.md` | Modify | Add rationalization closures and red flags for silent fallback, commit-history overclaiming, and source laundering. |
 | `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` | Modify | Add the reusable PT-81-1 through PT-81-5 scenarios and expected rule surface. |
@@ -160,6 +161,7 @@ Keep `SKILL.md` compact and invariant-focused. Put the long-form ladder in a sup
 - Modify: `skills/superteam/SKILL.md`
 - Create: `skills/superteam/pr-review-evidence.md`
 - Modify: `skills/superteam/agents/team-lead.openai.yaml`
+- Modify: `skills/superteam/.claude/agents/team-lead.md`
 - Modify: `skills/superteam/agents/finisher.openai.yaml` only if required by `T2.5`
 
 #### T2.1: Add the shared trigger and ownership contract to `SKILL.md`
@@ -213,7 +215,10 @@ Keep `SKILL.md` compact and invariant-focused. Put the long-form ladder in a sup
 - [ ] **Step 1: Update `skills/superteam/agents/team-lead.openai.yaml`.**
   Add a small routing cue that tells Team Lead to invoke the shared PR review evidence workflow when the operator asks for evidence-grounded PR/review analysis, rather than inventing a fresh collection method.
 
-- [ ] **Step 2: Keep the cue narrow.**
+- [ ] **Step 2: Update `skills/superteam/.claude/agents/team-lead.md` with the same narrow routing cue.**
+  Keep the Claude-host wording aligned with the Codex cue so both shipped Team Lead surfaces route evidence-grounded PR/review analysis through the shared workflow by name.
+
+- [ ] **Step 3: Keep the cue narrow on both hosts.**
   Do not broaden it into ordinary issue execution, CI triage, or generic code review routing.
 
 #### T2.4: Keep the reusable contract discoverable and compact
@@ -241,6 +246,7 @@ Keep `SKILL.md` compact and invariant-focused. Put the long-form ladder in a sup
   git add skills/superteam/SKILL.md \
     skills/superteam/pr-review-evidence.md \
     skills/superteam/agents/team-lead.openai.yaml \
+    skills/superteam/.claude/agents/team-lead.md \
     skills/superteam/agents/finisher.openai.yaml
   git diff --cached --name-only
   ```
@@ -310,6 +316,17 @@ This workstream makes the new contract harder to rationalize away and gives Revi
   ```
 
   Expected: the shared contract is analysis-only and Finisher ownership remains explicit.
+
+- [ ] **Step 3: Add focused Team Lead parity verification.**
+  Run:
+
+  ```bash
+  rg -n "PR review evidence workflow|evidence-grounded PR/review analysis|recent PRs|reviews" \
+    skills/superteam/agents/team-lead.openai.yaml \
+    skills/superteam/.claude/agents/team-lead.md
+  ```
+
+  Expected: both shipped Team Lead surfaces contain the narrow routing cue for the shared workflow.
 
 #### T3.4: Fold follow-up edits into the shipped behavior commit if no new behavior changed after review
 
@@ -432,6 +449,9 @@ rg -n "Finisher|live external PR feedback|analysis tasks" \
   skills/superteam/SKILL.md \
   skills/superteam/agents/team-lead.openai.yaml \
   skills/superteam/agents/finisher.openai.yaml
+rg -n "PR review evidence workflow|evidence-grounded PR/review analysis|recent PRs|reviews" \
+  skills/superteam/agents/team-lead.openai.yaml \
+  skills/superteam/.claude/agents/team-lead.md
 pnpm lint:md
 ```
 

--- a/docs/superpowers/plans/2026-05-08-81-add-a-first-class-pr-review-evidence-workflow-for-orchestrators-plan.md
+++ b/docs/superpowers/plans/2026-05-08-81-add-a-first-class-pr-review-evidence-workflow-for-orchestrators-plan.md
@@ -1,0 +1,459 @@
+# Plan: Add a first-class PR review evidence workflow for orchestrators [#81](https://github.com/patinaproject/superteam/issues/81)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Tasks have stable IDs (`T1`, `T2.3`, ...) so Executor can report them in `completed_task_ids[]`.
+
+**Goal:** Ship a reusable Superteam PR review evidence workflow that collects recent PR and review signals in a disciplined order, exposes fallback use when direct review evidence is missing, and makes every recommendation traceable by evidence tier.
+
+**Architecture:** Keep the runtime contract small in `skills/superteam/SKILL.md`: trigger, ownership boundary, output contract, and pointer to a support reference. Put the longer collection ladder, evidence ledger, fallback rules, and examples in a new `skills/superteam/pr-review-evidence.md` support file. Extend Team Lead routing cues and quality guards around that shared contract, and prove the behavior with explicit RED-before-GREEN pressure-test evidence rather than documentation-only walkthroughs.
+
+**Tech Stack:** Markdown workflow-contract files, Codex role YAML, repo-local pressure-test docs, `rg`, `sed`, `git`, `pnpm lint:md`, and the Superteam fallback `superpowers:writing-skills` review discipline when the primary skill-improver loop is unavailable.
+
+---
+
+## Planning Basis
+
+| Input | Source | Why it matters |
+|---|---|---|
+| Approved design | `docs/superpowers/specs/2026-05-08-81-add-a-first-class-pr-review-evidence-workflow-for-orchestrators-design.md` @ `fa58e4d9fb912534d8f04c70d83422bf3603d2d3` | Defines AC-81-1 through AC-81-4, R1 through R7, PT-81-1 through PT-81-5, and the ownership boundary between Team Lead and Finisher. |
+| Repo contract | `AGENTS.md` | Controls plan naming, commit format, markdown lint expectations, and the requirement to report missing verification evidence instead of overclaiming readiness. |
+| Shipped skill surfaces | `skills/superteam/SKILL.md`, `skills/superteam/quality-guards.md`, `skills/superteam/agents/team-lead.openai.yaml`, `skills/superteam/agents/finisher.openai.yaml` | These are the actual installed workflow-contract surfaces the design expects to change or verify. |
+| Reusable pressure-test surface | `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` | Existing home for portable orchestration pressure tests; issue #81 should extend this instead of inventing a one-off format. |
+| Quality gate | `docs/skill-improver-quality-gate.md` | Required review-evidence path for `skills/superteam/**` and adjacent workflow-contract changes. |
+
+## Scope And Constraints
+
+- This is a shipped skill/workflow-contract change, not a docs-only cleanup; the implementation commit must use a release-triggering type.
+- Preserve the design's split of responsibility: `Team Lead` routes analysis prompts into the shared evidence contract; `Finisher` keeps ownership of live external PR feedback during normal issue-to-PR runs.
+- Do not invent repo-specific recommendation heuristics, scoring, or a required GitHub integration.
+- Do not equate commit history, commit messages, or local diffs with reviewer feedback. Those remain `fallback-proxy` evidence only.
+- Do not silently skip RED/GREEN pressure tests. If a scenario cannot run, record the exact blocker and treat missing evidence as residual risk or a publish blocker.
+- No AC-to-file:line mapping tables in this plan. AC coverage is mapped to workstreams and verification tasks only.
+- Current repo state has shared skill files and Codex role YAML surfaces, but no `.claude/agents/*` parity files. Do not add new host-parity work unless the execution-time repo state changes and that need is proven from the working tree.
+
+## Acceptance Criteria Mapping
+
+| AC | Plan coverage |
+|---|---|
+| `AC-81-1` | WS2 adds the primary collection path and shared support reference; WS3 adds pressure-test scenarios and verification greps that prove the path is documented. |
+| `AC-81-2` | WS2 defines the fallback ladder and explicit `fallback_used` disclosure; WS4 reruns no-direct-evidence and connector-failure scenarios to prove the downgrade is visible. |
+| `AC-81-3` | WS2 adds the per-recommendation attribution contract (`evidence_tier`, `source_summary`, `confidence`, `fallback_used`); WS4 verifies the fields are still present in the shipped contract. |
+| `AC-81-4` | WS2 creates the reusable named workflow reference; WS3 adds reuse pressure tests so future orchestrations are expected to call the shared contract instead of inventing new evidence taxonomies. |
+
+## Files In Scope
+
+| Path | Change | Notes |
+|---|---|---|
+| `docs/superpowers/baselines/2026-05-08-81-pr-review-evidence-red-phase-baseline.md` | Create, then append GREEN evidence later | Canonical RED/GREEN evidence record for PT-81-1 through PT-81-5. RED capture must land before implementation edits. |
+| `skills/superteam/SKILL.md` | Modify | Add the compact workflow trigger, ownership rule, output contract, and support-file pointer. |
+| `skills/superteam/pr-review-evidence.md` | Create | Holds the detailed evidence ladder, ledger schema, fallback rules, and recommendation examples. |
+| `skills/superteam/agents/team-lead.openai.yaml` | Modify | Add or tighten the routing cue for evidence-grounded PR/review analysis requests. |
+| `skills/superteam/agents/finisher.openai.yaml` | Modify only if needed | Change only if the current wording is insufficient to preserve Finisher ownership after the new Team Lead route lands. |
+| `skills/superteam/quality-guards.md` | Modify | Add rationalization closures and red flags for silent fallback, commit-history overclaiming, and source laundering. |
+| `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` | Modify | Add the reusable PT-81-1 through PT-81-5 scenarios and expected rule surface. |
+
+## Workstreams
+
+| WS | Title | Depends on | Task IDs |
+|---|---|---|---|
+| `WS1` | RED baseline pressure-test evidence before implementation edits | none | `T1.0`-`T1.3` |
+| `WS2` | Add the reusable PR review evidence workflow contract | `WS1` | `T2.1`-`T2.6` |
+| `WS3` | Extend quality guards and reusable pressure-test surfaces | `WS2` | `T3.1`-`T3.4` |
+| `WS4` | GREEN reruns, review evidence, and handoff proof | `WS3` | `T4.1`-`T4.5` |
+
+## Task List
+
+### WS1 - RED baseline pressure-test evidence before implementation edits
+
+The design's R7 is mandatory: capture actual pre-change failure, rationalization, or source-laundering behavior before editing the shipped contract. The RED evidence lives in one baseline artifact so GREEN reruns can append directly below the original failure record.
+
+**Files:**
+
+- Create: `docs/superpowers/baselines/2026-05-08-81-pr-review-evidence-red-phase-baseline.md`
+
+#### T1.0: Confirm clean starting point
+
+- [ ] **Step 1: Verify branch state before authoring baseline evidence.**
+  Run:
+
+  ```bash
+  git rev-parse --abbrev-ref HEAD
+  git status --porcelain
+  ```
+
+  Expected: the issue branch is checked out and the working tree is clean before the baseline file is added.
+
+- [ ] **Step 2: Confirm the approved design commit is the reference point.**
+  Run:
+
+  ```bash
+  git log --oneline -1 docs/superpowers/specs/2026-05-08-81-add-a-first-class-pr-review-evidence-workflow-for-orchestrators-design.md
+  ```
+
+  Expected: HEAD for the design artifact is `fa58e4d`.
+
+#### T1.1: Record RED evidence for PT-81-1 through PT-81-5
+
+- [ ] **Step 1: Author the baseline document skeleton.**
+  Use these top-level sections in `docs/superpowers/baselines/2026-05-08-81-pr-review-evidence-red-phase-baseline.md`:
+  `# RED-phase baseline: Add a first-class PR review evidence workflow for orchestrators [#81](...)`,
+  `## Harness`,
+  `## PT-81-1` through `## PT-81-5`,
+  `## Captured rationalizations`,
+  `## GREEN-phase verification`,
+  and `## Residual blockers`.
+
+- [ ] **Step 2: Run the five RED scenarios against the current contract and capture the actual result, not an imagined one.**
+  Use one prompt or walkthrough per design pressure test:
+  - `PT-81-1`: recent merged PRs with review comments and thread resolutions available
+  - `PT-81-2`: recent merged PRs exist but review comments are absent or inaccessible
+  - `PT-81-3`: GitHub evidence source fails while local git history is still available
+  - `PT-81-4`: a future orchestration asks for recommendations grounded in recent PRs and reviews
+  - `PT-81-5`: commit history implies one theme but direct review comments imply another
+
+  For each scenario, record:
+  - the exact prompt or walkthrough framing used
+  - what the current shipped contract did
+  - the failure signal or rationalization that proves the current contract is insufficient
+  - whether the scenario was runnable in the current environment
+
+- [ ] **Step 3: If a scenario cannot run, disclose the precise blocker in the RED artifact.**
+  Accepted blockers include missing permissions, absent connectors, or missing underlying data. "I can infer the outcome from the design" is not an accepted substitute.
+
+#### T1.2: Commit RED evidence before touching shipped contract files
+
+- [ ] **Step 1: Stage only the RED baseline artifact.**
+  Run:
+
+  ```bash
+  git add docs/superpowers/baselines/2026-05-08-81-pr-review-evidence-red-phase-baseline.md
+  git diff --cached --name-only
+  ```
+
+  Expected: only the baseline file is staged.
+
+- [ ] **Step 2: Commit the RED baseline.**
+  Run:
+
+  ```bash
+  git commit -m "docs: #81 capture PR review evidence RED baseline"
+  ```
+
+  Expected: the RED evidence exists in history before any contract edit.
+
+#### T1.3: Guard the sequencing
+
+- [ ] **Step 1: Re-check the last commit before implementation starts.**
+  Run:
+
+  ```bash
+  git log --oneline -1
+  ```
+
+  Expected: the most recent commit is the RED baseline commit from `T1.2`.
+
+### WS2 - Add the reusable PR review evidence workflow contract
+
+Keep `SKILL.md` compact and invariant-focused. Put the long-form ladder in a support file so future orchestrations can reference one named contract without bloating the main skill text.
+
+**Files:**
+
+- Modify: `skills/superteam/SKILL.md`
+- Create: `skills/superteam/pr-review-evidence.md`
+- Modify: `skills/superteam/agents/team-lead.openai.yaml`
+- Modify: `skills/superteam/agents/finisher.openai.yaml` only if required by `T2.5`
+
+#### T2.1: Add the shared trigger and ownership contract to `SKILL.md`
+
+- [ ] **Step 1: Add a compact named workflow section in `skills/superteam/SKILL.md`.**
+  The section should tell Team Lead when to route into the workflow: prompts asking for recommendations or analysis grounded in recent PRs, review comments, or review decisions.
+
+- [ ] **Step 2: Encode the ownership boundary in the same section.**
+  State explicitly that this contract is for analysis tasks; live external PR feedback, replies, and follow-through during normal issue-to-PR runs remain Finisher-owned.
+
+- [ ] **Step 3: Add the output contract to `SKILL.md`.**
+  Require every recommendation produced through this workflow to include:
+  `evidence_tier`,
+  `source_summary`,
+  `confidence`,
+  and `fallback_used`.
+  Mixed evidence must name the strongest available tier and any fallback support.
+
+#### T2.2: Create `skills/superteam/pr-review-evidence.md`
+
+- [ ] **Step 1: Define the evidence ladder in order.**
+  The support file must cover:
+  1. repository and time-window resolution
+  2. recent merged PR metadata collection
+  3. direct review evidence collection
+  4. evidence ledger assembly
+  5. fallback ladder activation
+  6. recommendation rendering with attribution
+
+- [ ] **Step 2: Define the ledger schema.**
+  Every collected signal should carry:
+  `tier`,
+  `source`,
+  `locator`,
+  `summary`,
+  and `availability_status`.
+
+- [ ] **Step 3: Define the tier taxonomy exactly once.**
+  `direct-review` is highest confidence,
+  `pr-metadata` is contextual support,
+  `fallback-proxy` covers commit history, commit messages, local diffs, issue text, and repo docs only when the workflow must continue without direct review evidence.
+
+- [ ] **Step 4: Add fallback disclosure and confidence rules.**
+  Missing review comments, missing permissions, missing connectors, tool failures, and zero matching recent PRs must all force visible fallback disclosure and a downgraded confidence statement.
+
+- [ ] **Step 5: Add one reusable recommendation example.**
+  Show a recommendation payload that includes the required attribution fields and names whether fallback support was used.
+
+#### T2.3: Teach Team Lead to route into the shared contract
+
+- [ ] **Step 1: Update `skills/superteam/agents/team-lead.openai.yaml`.**
+  Add a small routing cue that tells Team Lead to invoke the shared PR review evidence workflow when the operator asks for evidence-grounded PR/review analysis, rather than inventing a fresh collection method.
+
+- [ ] **Step 2: Keep the cue narrow.**
+  Do not broaden it into ordinary issue execution, CI triage, or generic code review routing.
+
+#### T2.4: Keep the reusable contract discoverable and compact
+
+- [ ] **Step 1: Add a pointer from `SKILL.md` to `skills/superteam/pr-review-evidence.md`.**
+  The pointer should make it obvious that future orchestrations can reference the shared workflow by name.
+
+- [ ] **Step 2: Keep `SKILL.md` invariant-heavy, not tutorial-heavy.**
+  Any long examples, evidence ladders, or scenario walkthroughs belong in the support file, not in the main skill contract.
+
+#### T2.5: Decide whether `finisher.openai.yaml` needs a wording change
+
+- [ ] **Step 1: Inspect the landed Team Lead wording against current Finisher ownership rules.**
+  If the Team Lead cue could be read as taking live PR feedback away from Finisher, add the smallest possible clarification in `skills/superteam/agents/finisher.openai.yaml`.
+
+- [ ] **Step 2: If no change is needed, record that explicitly in Executor's done report.**
+  "No Finisher file edit needed because existing rule 6 already preserves ownership" is acceptable evidence; silent omission is not.
+
+#### T2.6: Commit the workflow contract changes
+
+- [ ] **Step 1: Stage the shared contract changes.**
+  Run:
+
+  ```bash
+  git add skills/superteam/SKILL.md \
+    skills/superteam/pr-review-evidence.md \
+    skills/superteam/agents/team-lead.openai.yaml \
+    skills/superteam/agents/finisher.openai.yaml
+  git diff --cached --name-only
+  ```
+
+  Expected: only files changed by WS2 are staged; omit `finisher.openai.yaml` if `T2.5` found no change was needed.
+
+- [ ] **Step 2: Commit the shipped behavior change.**
+  Run:
+
+  ```bash
+  git commit -m "feat: #81 add PR review evidence workflow"
+  ```
+
+  Expected: the main workflow contract ships under a release-triggering commit type.
+
+### WS3 - Extend quality guards and reusable pressure-test surfaces
+
+This workstream makes the new contract harder to rationalize away and gives Reviewer durable scenarios to rerun.
+
+**Files:**
+
+- Modify: `skills/superteam/quality-guards.md`
+- Modify: `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`
+
+#### T3.1: Add rationalization closures to `quality-guards.md`
+
+- [ ] **Step 1: Add a rationalization row for silent fallback.**
+  Close the excuse that PR metadata or commit history can quietly stand in for review evidence.
+
+- [ ] **Step 2: Add a rationalization row for source laundering.**
+  Close the excuse that commit messages can be described as if reviewers said the same thing.
+
+- [ ] **Step 3: Add a rationalization row for ownership drift.**
+  Close the excuse that an analysis workflow can absorb live PR feedback handling that belongs to Finisher.
+
+- [ ] **Step 4: Add matching red flags.**
+  Add red flags for missing `fallback_used`, recommendations without tier/source/confidence labeling, and outputs that follow commit-history framing while direct review comments are available.
+
+#### T3.2: Add reusable pressure-test scenarios
+
+- [ ] **Step 1: Extend `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` with PT-81-1 through PT-81-5.**
+  Keep the scenarios portable and documentation-backed, consistent with the rest of the file's style.
+
+- [ ] **Step 2: For each scenario, include required halt or reroute behavior and the rule surface.**
+  The scenarios must make it obvious which contract clause is being exercised, especially for fallback disclosure and direct-review precedence.
+
+#### T3.3: Add implementation-time verification greps
+
+- [ ] **Step 1: Add a grep bundle to Executor notes or done-report evidence.**
+  Use commands that prove the key contract terms are present:
+
+  ```bash
+  rg -n "direct-review|pr-metadata|fallback-proxy|fallback_used|source_summary|confidence|availability_status" \
+    skills/superteam/SKILL.md \
+    skills/superteam/pr-review-evidence.md \
+    docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+  ```
+
+- [ ] **Step 2: Add an ownership grep.**
+  Run:
+
+  ```bash
+  rg -n "Finisher|live external PR feedback|analysis tasks" \
+    skills/superteam/SKILL.md \
+    skills/superteam/agents/team-lead.openai.yaml \
+    skills/superteam/agents/finisher.openai.yaml
+  ```
+
+  Expected: the shared contract is analysis-only and Finisher ownership remains explicit.
+
+#### T3.4: Fold follow-up edits into the shipped behavior commit if no new behavior changed after review
+
+- [ ] **Step 1: If WS3 only refined the just-landed workflow contract, amend or add a follow-up `feat:` commit consistently.**
+  Do not leave these quality-guard and pressure-test surface changes as unstaged local state.
+
+### WS4 - GREEN reruns, review evidence, and handoff proof
+
+GREEN evidence is mandatory. Documentation-only walkthroughs do not close R7.
+
+**Files:**
+
+- Modify: `docs/superpowers/baselines/2026-05-08-81-pr-review-evidence-red-phase-baseline.md`
+- Review: changed workflow-contract files
+
+#### T4.1: Append GREEN reruns for PT-81-1 through PT-81-5
+
+- [ ] **Step 1: Re-run the exact five scenarios from WS1 against the updated contract.**
+  Append the results under `## GREEN-phase verification` in the baseline file.
+
+- [ ] **Step 2: For each scenario, record the observed GREEN behavior.**
+  Confirm:
+  - `PT-81-1`: direct review evidence is gathered and recommendations land as `direct-review`
+  - `PT-81-2`: missing direct review evidence is disclosed and recommendations downgrade to `pr-metadata`
+  - `PT-81-3`: collection failure is disclosed and any continued answer is labeled `fallback-proxy`
+  - `PT-81-4`: the future orchestration reuses the shared workflow instead of inventing a new taxonomy
+  - `PT-81-5`: direct review evidence outranks commit-history framing
+
+- [ ] **Step 3: Record remaining red flags or blockers explicitly.**
+  If any scenario still rationalizes, or cannot run, call that out under `## Residual blockers` instead of claiming readiness.
+
+#### T4.2: Run verification commands
+
+- [ ] **Step 1: Re-run the grep bundle from `T3.3`.**
+  Expected: all required contract terms are present in the shipped files.
+
+- [ ] **Step 2: Run markdown lint.**
+  Run:
+
+  ```bash
+  pnpm lint:md
+  ```
+
+  Expected: `Summary: 0 error(s)`.
+
+#### T4.3: Run the Superteam skill review gate
+
+- [ ] **Step 1: Probe primary-mode availability per `docs/skill-improver-quality-gate.md`.**
+  Run:
+
+  ```bash
+  ls "$HOME/.claude/plugins/cache/trailofbits/skill-improver"/*/skills/skill-improver/SKILL.md 2>/dev/null
+  ls "$HOME/.claude/plugins/cache"/**/skills/plugin-dev/skill-reviewer 2>/dev/null
+  ```
+
+- [ ] **Step 2: If both probes succeed, run the primary skill-improver loop and record the required completion evidence.**
+
+- [ ] **Step 3: If either probe fails, run the fallback review.**
+  The fallback review must explicitly check:
+  RED/GREEN baseline obligation,
+  rationalization resistance,
+  red flags,
+  token-efficiency targets,
+  role ownership,
+  and stage-gate bypass paths.
+
+  Record the reviewer, dimensions checked, and the fact that primary-mode tooling was unavailable.
+
+#### T4.4: Prepare Reviewer and Finisher evidence requirements
+
+- [ ] **Step 1: Reviewer handoff must include `completed_task_ids[]`, the RED/GREEN baseline path, grep results, lint result, and skill-improver evidence mode.**
+
+- [ ] **Step 2: Finisher PR body must include:**
+  - `Closes #81`
+  - `### AC-81-1` through `### AC-81-4` with verification steps under each AC
+  - the RED/GREEN baseline artifact path
+  - the skill-improver quality gate block required by `docs/skill-improver-quality-gate.md`
+  - an explicit note whenever a pressure test or review loop could not run
+
+- [ ] **Step 3: Do not describe the work as production-ready if PT evidence or review-gate evidence is missing.**
+
+#### T4.5: Final implementation commit and handoff
+
+- [ ] **Step 1: Stage the GREEN baseline append and any last workflow-contract fixes.**
+  Run:
+
+  ```bash
+  git add docs/superpowers/baselines/2026-05-08-81-pr-review-evidence-red-phase-baseline.md \
+    skills/superteam/SKILL.md \
+    skills/superteam/pr-review-evidence.md \
+    skills/superteam/quality-guards.md \
+    skills/superteam/agents/team-lead.openai.yaml \
+    skills/superteam/agents/finisher.openai.yaml \
+    docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+  git diff --cached --name-only
+  ```
+
+- [ ] **Step 2: Commit any post-review or GREEN-evidence follow-up not already committed.**
+  Use:
+
+  ```bash
+  git commit -m "feat: #81 finalize PR review evidence workflow"
+  ```
+
+  only if there are still unstaged or uncommitted shipped changes after the earlier `feat:` commit. If WS2/WS3/WS4 work was already folded into a clean `feat:` history, do not create an empty ritual commit.
+
+## Verification Commands
+
+Run these during execution and cite the ones that produced final evidence:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git status --porcelain
+git log --oneline -1 docs/superpowers/specs/2026-05-08-81-add-a-first-class-pr-review-evidence-workflow-for-orchestrators-design.md
+rg -n "direct-review|pr-metadata|fallback-proxy|fallback_used|source_summary|confidence|availability_status" \
+  skills/superteam/SKILL.md \
+  skills/superteam/pr-review-evidence.md \
+  docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+rg -n "Finisher|live external PR feedback|analysis tasks" \
+  skills/superteam/SKILL.md \
+  skills/superteam/agents/team-lead.openai.yaml \
+  skills/superteam/agents/finisher.openai.yaml
+pnpm lint:md
+```
+
+## Review Evidence Requirements
+
+- RED baseline evidence must be committed before any shipped contract edit.
+- GREEN reruns must reuse the same PT-81-1 through PT-81-5 scenarios; switching to easier scenarios does not satisfy R7.
+- Documentation-only walkthroughs are insufficient when the design required pressure-test or subagent evidence.
+- For `skills/superteam/**` and adjacent workflow-contract changes, run `docs/skill-improver-quality-gate.md` in primary mode when available; otherwise run the documented fallback `superpowers:writing-skills` review and disclose the limitation.
+- Reviewer should treat missing RED evidence, missing GREEN reruns, silent fallback, or lost ownership boundaries as approval-blocking findings.
+
+## Sequencing And Handoff
+
+1. `WS1` must complete and commit before `WS2` starts.
+2. `WS2` and `WS3` may be split into small commits, but the shipped workflow contract must remain coherent at each handoff.
+3. `WS4` must append GREEN evidence after the final contract wording lands, not before.
+4. Executor hands off only after all artifact changes are committed and the done report names the completed task IDs plus verification evidence.
+5. Reviewer routes requirement-changing findings back through Brainstormer/Planner only if the finding alters approved requirements; implementation-level findings loop back to Executor.
+6. Finisher owns PR publication and must preserve the AC-81-1 through AC-81-4 verification plus quality-gate evidence in the PR body.
+
+## Self-Review
+
+- Spec coverage: AC-81-1 through AC-81-4, R1 through R7, and PT-81-1 through PT-81-5 all map to explicit workstreams or verification tasks.
+- Placeholder scan: no TODO/TBD placeholders remain; every in-scope file and evidence obligation is named directly.
+- Constraint check: no AC-to-file:line mapping table was introduced; Finisher ownership and RED-before-GREEN sequencing remain explicit.

--- a/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
+++ b/docs/superpowers/pressure-tests/superteam-orchestration-contract.md
@@ -441,3 +441,55 @@ Use these repo-local pressure tests to check whether the documented orchestratio
 - Starting condition: A required check is failing after the latest push, but the workflow reports the failure without attempting to distinguish whether it was introduced by the branch or appears unrelated baseline noise.
 - Required halt or reroute behavior: Keep the issue in the Finisher loop, inspect enough evidence to make the best branch-caused vs baseline distinction available, and report the result explicitly. If the distinction still cannot be made safely, prompt the operator instead of guessing.
 - Rule surface: The Finisher contract should require explicit blocker reporting and branch-aware CI triage before handoff or halt.
+
+## PT-81-1 Full direct review evidence is collected before recommendations
+
+- Starting condition: Recent merged PRs include accessible review comments,
+  review decisions, thread discussions, and resolutions.
+- Required halt or reroute behavior: Route through the shared PR review
+  evidence workflow, collect direct review evidence first, and attribute
+  recommendations with `evidence_tier: direct-review`. Do not silently degrade
+  to commit-history framing.
+- Rule surface: `skills/superteam/pr-review-evidence.md` collection ladder and
+  `skills/superteam/SKILL.md` recommendation attribution contract.
+
+## PT-81-2 Missing direct review evidence forces visible fallback disclosure
+
+- Starting condition: Recent merged PR metadata exists, but direct review
+  comments or threads are absent or inaccessible.
+- Required halt or reroute behavior: Continue only via documented fallback,
+  disclose missing direct review evidence, set `fallback_used`, and downgrade
+  confidence with `evidence_tier: pr-metadata`.
+- Rule surface: fallback ladder, confidence downgrade rules, and recommendation
+  output contract fields in the shared PR review evidence workflow.
+
+## PT-81-3 Evidence-source failure is disclosed before proxy continuation
+
+- Starting condition: Review-evidence collection fails due to permissions,
+  connector unavailability, or tool failure, while local git or issue context
+  is still reachable.
+- Required halt or reroute behavior: Report the failed source explicitly and
+  continue only with labeled `fallback-proxy` evidence when the operator prompt
+  still requires an answer.
+- Rule surface: fallback-proxy taxonomy, ledger `availability_status`, and
+  explicit failure disclosure requirements in the shared workflow.
+
+## PT-81-4 Future orchestration reuses the shared workflow by name
+
+- Starting condition: A new orchestration asks for recommendations grounded in
+  recent PR and review evidence.
+- Required halt or reroute behavior: Reuse the shipped PR review evidence
+  workflow and its output taxonomy instead of inventing an ad hoc collection or
+  labeling scheme.
+- Rule surface: shared workflow reference in `skills/superteam/SKILL.md` and
+  the support contract in `skills/superteam/pr-review-evidence.md`.
+
+## PT-81-5 Direct review evidence outranks commit-history framing
+
+- Starting condition: Commit history suggests one theme while direct review
+  comments indicate another concern.
+- Required halt or reroute behavior: Prioritize direct review evidence for the
+  recommendation basis; commit history may appear only as contextual or fallback
+  support and must not be laundered as reviewer intent.
+- Rule surface: tier-precedence taxonomy and source-laundering guards in the
+  shared workflow and `quality-guards.md`.

--- a/docs/superpowers/specs/2026-05-08-81-add-a-first-class-pr-review-evidence-workflow-for-orchestrators-design.md
+++ b/docs/superpowers/specs/2026-05-08-81-add-a-first-class-pr-review-evidence-workflow-for-orchestrators-design.md
@@ -32,7 +32,7 @@ Given a new orchestration is built on top of this capability, when its prompt as
 - **R4 Recommendation attribution**: Every final recommendation produced from the workflow must include its evidence tier, evidence source summary, and confidence level. Mixed evidence should name the strongest available tier plus any fallback support.
 - **R5 Reusable contract**: Put the reusable collection and reporting contract in the Superteam skill package, not in a one-off design or repo-specific heuristic. Future orchestrations should be able to reference it by name.
 - **R6 Role ownership**: `Team Lead` owns routing into the contract and deciding when a prompt asks for evidence-grounded PR/review analysis. `Finisher` remains owner of external PR feedback during normal issue-to-PR runs. This workflow is for analysis tasks and must not steal live PR feedback handling from Finisher.
-- **R7 Verification**: Implementation must include pressure tests for full evidence, partial evidence, no direct review evidence, and misleading commit-history-only scenarios.
+- **R7 Verification**: Implementation must follow writing-skills RED/GREEN evidence discipline for this skill/workflow-contract change. Before implementation edits, run baseline pressure tests for full evidence, partial evidence, no direct review evidence, and misleading commit-history-only scenarios; capture the actual failure or rationalization. After implementation, rerun the pressure tests, capture GREEN evidence, record any remaining red flags, and explicitly disclose any pressure test that could not be run. Documentation-only walkthroughs are insufficient readiness evidence.
 
 ## Proposed architecture
 
@@ -87,9 +87,19 @@ Claude-host parity files may also need the same role guidance if present in the 
 
 ## Pressure tests
 
+These are writing-skills pressure tests, not optional documentation walkthroughs. Planner and Executor should preserve the RED/GREEN evidence loop:
+
+1. Before implementation edits, run baseline prompts or subagent pressure tests against the current contract.
+2. Capture the actual RED failure, rationalization, or refusal to use the desired evidence discipline.
+3. After implementation, rerun the same scenarios against the revised contract.
+4. Record GREEN evidence, any remaining rationalizations, and any pressure test that could not be run.
+5. Treat documentation-only walkthroughs as insufficient for readiness when pressure-test or subagent evidence was required but unavailable.
+
 ### PT-81-1: Full direct review evidence
 
 Scenario: The repository has recent merged PRs with review comments, requested changes, approvals, and thread resolutions.
+
+RED evidence to capture: Current behavior either omits direct-review attribution, treats a PR summary as enough, or gives recommendations without an evidence ledger.
 
 Expected behavior: The orchestrator records direct review evidence, attributes recommendations to `direct-review`, uses PR metadata as context, and does not invoke fallback.
 
@@ -99,6 +109,8 @@ Failure signal: Recommendations cite only commit summaries or omit review-commen
 
 Scenario: Recent merged PRs exist, but review comments are absent or inaccessible.
 
+RED evidence to capture: Current behavior either invents reviewer intent, hides missing review comments, or fails to lower confidence.
+
 Expected behavior: The orchestrator reports direct review evidence as unavailable, falls back to PR metadata, labels recommendations as `pr-metadata`, and lowers confidence.
 
 Failure signal: Output implies reviewers said something specific without direct review evidence.
@@ -106,6 +118,8 @@ Failure signal: Output implies reviewers said something specific without direct 
 ### PT-81-3: Connector or permission failure
 
 Scenario: The GitHub evidence source fails while local git history is available.
+
+RED evidence to capture: Current behavior silently continues from local git history or treats the connector failure as irrelevant.
 
 Expected behavior: The orchestrator reports the failed source, uses documented fallback proxies only if the operator task can still be answered, labels them `fallback-proxy`, and names the confidence limitation.
 
@@ -115,6 +129,8 @@ Failure signal: Output hides the collection failure or presents local commit evi
 
 Scenario: A future repo-health or coaching orchestration asks for recommendations grounded in recent PRs and reviews.
 
+RED evidence to capture: Current behavior invents an ad hoc collection plan, source taxonomy, or fallback disclosure standard.
+
 Expected behavior: The prompt references the shared PR review evidence workflow and uses its evidence ledger plus output attribution contract instead of inventing new collection logic.
 
 Failure signal: The orchestration defines an incompatible evidence taxonomy or has no fallback disclosure.
@@ -122,6 +138,8 @@ Failure signal: The orchestration defines an incompatible evidence taxonomy or h
 ### PT-81-5: Misleading commit-history proxy
 
 Scenario: Commit messages suggest one review theme, but available review comments show a different concern.
+
+RED evidence to capture: Current behavior follows the commit-history proxy, overclaims confidence, or fails to prefer direct review comments.
 
 Expected behavior: Direct review evidence wins. Commit history may appear only as supporting `fallback-proxy` or context, not as the primary basis.
 
@@ -133,7 +151,7 @@ Reviewer context: same-thread fallback for the Brainstormer design draft. A fres
 
 Checked writing-skills dimensions:
 
-- **RED/GREEN baseline obligations**: Present. Pressure tests define failure behavior before the contract and expected compliant behavior after implementation.
+- **RED/GREEN baseline obligations**: Present after revision. R7 and the pressure-test section require baseline pressure-test or subagent evidence before implementation, captured failure/rationalization, rerun GREEN evidence after implementation, remaining red-flag disclosure, and explicit disclosure for any pressure test that could not be run.
 - **Rationalization resistance**: Present. The design blocks "commit history is close enough" and "fallback can be silent" rationalizations.
 - **Red flags**: Present. Risks and pressure tests name source laundering, missing fallback disclosure, and Finisher ownership confusion.
 - **Token-efficiency targets**: Present. Runtime skill text is constrained to a short `SKILL.md` trigger plus a support reference for details.
@@ -147,13 +165,14 @@ Checked writing-skills dimensions:
 | brainstormer | material | `## Proposed architecture` | The first architecture pass could blur live PR feedback handling with offline evidence-grounded analysis, which would conflict with Finisher ownership. | Resolved by adding R6, the Finisher ownership note, and an explicit non-goal. |
 | brainstormer | material | `## Requirements` | The first requirement set said to "use fallback signals" but did not force per-recommendation attribution, allowing source laundering in final advice. | Resolved by adding R4 and the final-output fields. |
 | brainstormer | minor | `## Affected files` | The first affected-files list risked over-prescribing agent-file edits before Planner confirms exact surfaces. | Resolved by marking Team Lead and Finisher agent updates as small cues only if needed. |
+| adversarial-review | material | `R7`, `## Pressure tests`, `## Adversarial review preparation`, `## Handoff guidance` | The design defined scenarios but did not require writing-skills RED/GREEN baseline evidence, captured rationalizations, GREEN reruns, or insufficient-evidence disclosure; it also left room for documentation-only walkthroughs as readiness evidence. | Resolved by strengthening R7, adding explicit RED/GREEN pressure-test evidence requirements and per-scenario RED evidence prompts, updating the checked RED/GREEN dimension, and revising handoff guidance to label documentation-only walkthroughs as insufficient readiness evidence. |
 
 Brainstormer same-thread review result: `findings dispositioned`.
 
 ## Clean pass rationale
 
-No blocker or material Brainstormer-originated findings remain open. The draft has explicit AC IDs, a primary evidence path, visible fallback reporting, per-recommendation attribution, reusable contract placement, role ownership boundaries, and pressure tests covering the main rationalization paths. This does not satisfy Gate 1 by itself; Team Lead must still run the independent adversarial design review against the committed artifact.
+No blocker or material findings recorded in this artifact remain open. The draft has explicit AC IDs, a primary evidence path, visible fallback reporting, per-recommendation attribution, reusable contract placement, role ownership boundaries, and writing-skills RED/GREEN pressure-test evidence requirements that close the documentation-walkthrough bypass. Team Lead must still decide whether the revised committed artifact satisfies Gate 1.
 
 ## Handoff guidance
 
-Planner should convert this design into a small implementation plan that preserves the contract split: `SKILL.md` owns trigger and invariant language, while a support reference owns the longer evidence ladder if needed. Executor should avoid adding a heavyweight runtime integration or repo-specific heuristic. Reviewer should treat `skills/superteam/**` changes as installable skill changes and run the required writing-skills and Superteam quality gates. Finisher should ensure the PR body maps verification to AC-81-1 through AC-81-4 and calls out any pressure tests that were performed as documentation walkthroughs rather than live GitHub API tests.
+Planner should convert this design into a small implementation plan that preserves the contract split: `SKILL.md` owns trigger and invariant language, while a support reference owns the longer evidence ladder if needed. The plan must schedule RED baseline pressure tests before implementation edits, require captured rationalizations or failures, and schedule GREEN reruns after implementation. Executor should avoid adding a heavyweight runtime integration or repo-specific heuristic and must preserve the RED evidence rather than replacing it with confidence language. Reviewer should treat `skills/superteam/**` changes as installable skill changes and run the required writing-skills and Superteam quality gates, including checking that pressure-test evidence exists or that missing tests are explicitly disclosed as blockers or residual risk. Finisher should ensure the PR body maps verification to AC-81-1 through AC-81-4 and labels documentation-only walkthroughs as insufficient readiness evidence when pressure-test or subagent evidence was required but not run.

--- a/docs/superpowers/specs/2026-05-08-81-add-a-first-class-pr-review-evidence-workflow-for-orchestrators-design.md
+++ b/docs/superpowers/specs/2026-05-08-81-add-a-first-class-pr-review-evidence-workflow-for-orchestrators-design.md
@@ -1,0 +1,159 @@
+# Design: Add a first-class PR review evidence workflow for orchestrators [#81](https://github.com/patinaproject/superteam/issues/81)
+
+## Intent summary
+
+Add a reusable Superteam orchestration contract for recommendations that must be grounded in recent pull requests and review feedback. The workflow should tell an orchestrator what evidence to collect first, what fallback signals are allowed when direct review evidence is unavailable, and how to label each recommendation so operators can see whether it came from review comments, PR metadata, or lower-confidence fallback evidence.
+
+This is a workflow-contract design because implementation is expected to touch the installed `skills/superteam/**` package and may add a reusable support reference for evidence collection.
+
+## Acceptance criteria
+
+### AC-81-1
+
+Given an orchestration task that asks for recommendations grounded in recent PRs and reviews, when the workflow runs, then it has a documented primary path for collecting PR metadata and review evidence.
+
+### AC-81-2
+
+Given direct review evidence is unavailable, when the workflow falls back, then it uses a documented fallback path and reports that fallback in the final output.
+
+### AC-81-3
+
+Given the workflow produces a recommendation, when an operator reads it, then they can tell whether it came from direct review comments, PR metadata, or fallback evidence.
+
+### AC-81-4
+
+Given a new orchestration is built on top of this capability, when its prompt asks for evidence-grounded PR/review analysis, then the orchestrator can reuse this contract instead of inventing its own collection logic.
+
+## Requirements
+
+- **R1 Primary path**: Define a first-class path that starts from recent merged PRs, then gathers PR metadata, review decisions, review comments, unresolved or resolved review threads when available, bot review findings, linked issue references, and merge SHAs.
+- **R2 Evidence tiers**: Classify evidence as `direct-review`, `pr-metadata`, or `fallback-proxy`. Direct review comments and review-thread text are the highest-confidence signal. PR metadata is contextual support. Commit history, commit messages, local git diffs, and issue text are fallback proxies only.
+- **R3 Fallback visibility**: When direct review evidence cannot be collected because of missing permissions, absent review comments, tool failure, unavailable connector, or no matching recent PRs, the orchestrator must say which fallback path was used and lower confidence accordingly.
+- **R4 Recommendation attribution**: Every final recommendation produced from the workflow must include its evidence tier, evidence source summary, and confidence level. Mixed evidence should name the strongest available tier plus any fallback support.
+- **R5 Reusable contract**: Put the reusable collection and reporting contract in the Superteam skill package, not in a one-off design or repo-specific heuristic. Future orchestrations should be able to reference it by name.
+- **R6 Role ownership**: `Team Lead` owns routing into the contract and deciding when a prompt asks for evidence-grounded PR/review analysis. `Finisher` remains owner of external PR feedback during normal issue-to-PR runs. This workflow is for analysis tasks and must not steal live PR feedback handling from Finisher.
+- **R7 Verification**: Implementation must include pressure tests for full evidence, partial evidence, no direct review evidence, and misleading commit-history-only scenarios.
+
+## Proposed architecture
+
+Add a compact `PR review evidence workflow` contract to `skills/superteam/SKILL.md`, backed by a support reference such as `skills/superteam/pr-review-evidence.md` if the details would make `SKILL.md` too long. `SKILL.md` should hold the trigger, ownership rule, and required output contract; the support reference should hold the step-by-step evidence ladder, source tiers, fallback rules, and pressure-test scenarios.
+
+The collection flow should be:
+
+1. Resolve the repository and target window from the operator prompt, with a conservative default such as recent merged PRs if the prompt does not specify a range.
+2. Collect recent merged PR metadata: number, title, author, merge date, merge SHA, changed-file summary, linked issue, labels, and review decision summary.
+3. Collect direct review evidence where available: review comments, review bodies, review-thread discussions, requested changes, approval comments, bot review findings, and final resolutions.
+4. Build an evidence ledger that records each signal with `tier`, `source`, `locator`, `summary`, and `availability_status`.
+5. If direct review evidence is incomplete or absent, explicitly activate the fallback ladder: PR metadata first, then commit history and local git evidence, then issue text or repository docs only when the prompt requires continuing.
+6. Produce recommendations with per-item attribution: `evidence_tier`, `source_summary`, `confidence`, and `fallback_used`.
+
+Preferred implementation shape:
+
+- Keep `SKILL.md` short and invariant-focused.
+- Add a support reference if the evidence ladder or examples would exceed a small section.
+- Update Team Lead guidance so prompts asking for recommendations grounded in recent PRs/reviews route through this contract.
+- Update Finisher guidance only enough to avoid ownership confusion: live external PR feedback remains Finisher-owned; this workflow is an analysis evidence contract.
+- Add pressure-test coverage to `docs/superpowers/pressure-tests/superteam-orchestration-contract.md` or a focused adjacent pressure-test file.
+
+## Affected files
+
+- `skills/superteam/SKILL.md`: new trigger, ownership rule, evidence-tier output contract, and support-file link.
+- `skills/superteam/pr-review-evidence.md`: likely new support reference for collection steps, fallback ladder, and examples.
+- `skills/superteam/agents/team-lead.openai.yaml`: small prompt cue if Team Lead needs to recognize evidence-grounded PR/review analysis requests.
+- `skills/superteam/agents/finisher.openai.yaml`: small ownership clarification only if needed.
+- `skills/superteam/quality-guards.md`: rationalization rows and red flags for silent fallback, commit-history overclaiming, and source laundering.
+- `docs/superpowers/pressure-tests/superteam-orchestration-contract.md`: reusable pressure scenarios and expected evidence labels.
+
+Claude-host parity files may also need the same role guidance if present in the installed package at implementation time.
+
+## Non-goals
+
+- Do not add repo-specific scoring heuristics or recommendations.
+- Do not require a particular GitHub connector, CLI, or API when equivalent evidence can be gathered another way.
+- Do not make commit history equivalent to direct review feedback.
+- Do not change normal Superteam live PR feedback ownership or Finisher shutdown gates.
+- Do not require this workflow for ordinary issue implementation, local code review, or CI triage unless the operator asks for evidence-grounded PR/review analysis.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Orchestrator silently degrades to commit history and presents generic advice. | Require `fallback_used` and confidence disclosure in the final output. |
+| Commit messages are treated as if they were reviewer feedback. | Use explicit tiers; commit history is always `fallback-proxy`. |
+| The new workflow conflicts with Finisher's external feedback ownership. | State that live PR feedback handling remains Finisher-owned; this contract covers analysis tasks. |
+| The contract becomes too verbose for frequently loaded skill text. | Keep `SKILL.md` to trigger and invariant language; move examples and ladder details to a support file. |
+| A future orchestrator gathers evidence but loses source attribution in the final recommendation. | Require per-recommendation evidence tier, source summary, confidence, and fallback fields. |
+| Tooling cannot access review comments in a given repo. | Make unavailability an explicit evidence status, then use the documented fallback ladder. |
+
+## Pressure tests
+
+### PT-81-1: Full direct review evidence
+
+Scenario: The repository has recent merged PRs with review comments, requested changes, approvals, and thread resolutions.
+
+Expected behavior: The orchestrator records direct review evidence, attributes recommendations to `direct-review`, uses PR metadata as context, and does not invoke fallback.
+
+Failure signal: Recommendations cite only commit summaries or omit review-comment attribution.
+
+### PT-81-2: PR metadata present, no review comments
+
+Scenario: Recent merged PRs exist, but review comments are absent or inaccessible.
+
+Expected behavior: The orchestrator reports direct review evidence as unavailable, falls back to PR metadata, labels recommendations as `pr-metadata`, and lowers confidence.
+
+Failure signal: Output implies reviewers said something specific without direct review evidence.
+
+### PT-81-3: Connector or permission failure
+
+Scenario: The GitHub evidence source fails while local git history is available.
+
+Expected behavior: The orchestrator reports the failed source, uses documented fallback proxies only if the operator task can still be answered, labels them `fallback-proxy`, and names the confidence limitation.
+
+Failure signal: Output hides the collection failure or presents local commit evidence as review evidence.
+
+### PT-81-4: New orchestration reuse
+
+Scenario: A future repo-health or coaching orchestration asks for recommendations grounded in recent PRs and reviews.
+
+Expected behavior: The prompt references the shared PR review evidence workflow and uses its evidence ledger plus output attribution contract instead of inventing new collection logic.
+
+Failure signal: The orchestration defines an incompatible evidence taxonomy or has no fallback disclosure.
+
+### PT-81-5: Misleading commit-history proxy
+
+Scenario: Commit messages suggest one review theme, but available review comments show a different concern.
+
+Expected behavior: Direct review evidence wins. Commit history may appear only as supporting `fallback-proxy` or context, not as the primary basis.
+
+Failure signal: The recommendation follows commit-history framing while ignoring direct review comments.
+
+## Adversarial review preparation
+
+Reviewer context: same-thread fallback for the Brainstormer design draft. A fresh Team Lead adversarial design review is still required after this committed artifact before Gate 1 approval can advance.
+
+Checked writing-skills dimensions:
+
+- **RED/GREEN baseline obligations**: Present. Pressure tests define failure behavior before the contract and expected compliant behavior after implementation.
+- **Rationalization resistance**: Present. The design blocks "commit history is close enough" and "fallback can be silent" rationalizations.
+- **Red flags**: Present. Risks and pressure tests name source laundering, missing fallback disclosure, and Finisher ownership confusion.
+- **Token-efficiency targets**: Present. Runtime skill text is constrained to a short `SKILL.md` trigger plus a support reference for details.
+- **Role ownership**: Present. Team Lead owns analysis routing; Finisher retains live PR feedback handling.
+- **Stage-gate bypass paths**: Present. The design calls for pressure tests and visible evidence status rather than confidence-only readiness claims.
+
+## Adversarial review findings
+
+| Source | Severity | Location | Finding | Disposition |
+|---|---|---|---|---|
+| brainstormer | material | `## Proposed architecture` | The first architecture pass could blur live PR feedback handling with offline evidence-grounded analysis, which would conflict with Finisher ownership. | Resolved by adding R6, the Finisher ownership note, and an explicit non-goal. |
+| brainstormer | material | `## Requirements` | The first requirement set said to "use fallback signals" but did not force per-recommendation attribution, allowing source laundering in final advice. | Resolved by adding R4 and the final-output fields. |
+| brainstormer | minor | `## Affected files` | The first affected-files list risked over-prescribing agent-file edits before Planner confirms exact surfaces. | Resolved by marking Team Lead and Finisher agent updates as small cues only if needed. |
+
+Brainstormer same-thread review result: `findings dispositioned`.
+
+## Clean pass rationale
+
+No blocker or material Brainstormer-originated findings remain open. The draft has explicit AC IDs, a primary evidence path, visible fallback reporting, per-recommendation attribution, reusable contract placement, role ownership boundaries, and pressure tests covering the main rationalization paths. This does not satisfy Gate 1 by itself; Team Lead must still run the independent adversarial design review against the committed artifact.
+
+## Handoff guidance
+
+Planner should convert this design into a small implementation plan that preserves the contract split: `SKILL.md` owns trigger and invariant language, while a support reference owns the longer evidence ladder if needed. Executor should avoid adding a heavyweight runtime integration or repo-specific heuristic. Reviewer should treat `skills/superteam/**` changes as installable skill changes and run the required writing-skills and Superteam quality gates. Finisher should ensure the PR body maps verification to AC-81-1 through AC-81-4 and calls out any pressure tests that were performed as documentation walkthroughs rather than live GitHub API tests.

--- a/skills/superteam/.claude/agents/team-lead.md
+++ b/skills/superteam/.claude/agents/team-lead.md
@@ -30,6 +30,15 @@ superpowers:using-superpowers
 9. Bind every execute-phase delegation directly to `superpowers:subagent-driven-development` (subagent path) or the host's native team-mode capability. Never route through `superpowers:executing-plans` on default paths.
 10. Resolve and bind a model for every teammate delegation per SKILL.md `## Model selection`. Silent inheritance is forbidden except for `Team Lead` itself and the inherit-and-warn capability fallback.
 
+## PR review evidence analysis routing
+
+When an operator asks for recommendations or analysis grounded in recent pull
+requests, review comments, or review decisions, route through the shared PR
+review evidence workflow in `skills/superteam/pr-review-evidence.md`.
+Keep this cue narrow to evidence-grounded PR/review analysis tasks; do not
+repurpose it for normal issue execution, CI triage, or generic code review.
+Live external PR feedback handling remains `Finisher`-owned.
+
 ## Done-report contract reference
 
 See [done-report contracts](../../SKILL.md#done-report-contracts) in `skills/superteam/SKILL.md` for the field set this role must populate. This file does not restate the fields.

--- a/skills/superteam/SKILL.md
+++ b/skills/superteam/SKILL.md
@@ -260,6 +260,23 @@ When `Team Lead` delegates work, the prompt must explicitly recommend the expect
 
 Do not silently omit expected skill guidance.
 
+## PR review evidence workflow
+
+When the operator asks for recommendations or analysis grounded in recent pull
+requests, review comments, or review decisions, `Team Lead` routes the request
+through the shared `PR review evidence workflow` in
+[pr-review-evidence.md](./pr-review-evidence.md).
+
+This workflow is for analysis tasks only. Live external PR feedback handling
+during issue-to-PR runs remains `Finisher`-owned.
+
+Every recommendation produced through this workflow must include:
+`evidence_tier`, `source_summary`, `confidence`, and `fallback_used`.
+
+When evidence is mixed, report the strongest available tier as
+`evidence_tier`, then disclose fallback support in `source_summary` and
+`fallback_used`.
+
 ## Done-report contracts
 
 Artifact-producing teammate done reports must anchor on committed handoff state rather than uncommitted workspace state.

--- a/skills/superteam/agents/team-lead.openai.yaml
+++ b/skills/superteam/agents/team-lead.openai.yaml
@@ -21,6 +21,14 @@ system_prompt: |
   9. Bind every execute-phase delegation directly to `superpowers:subagent-driven-development` (subagent path) or the host's native team-mode capability. Never route through `superpowers:executing-plans` on default paths.
   10. Resolve and bind a model for every teammate delegation per SKILL.md `## Model selection`. Silent inheritance is forbidden except for `Team Lead` itself and the inherit-and-warn capability fallback.
 
+  ## PR review evidence analysis routing
+  When an operator asks for recommendations or analysis grounded in recent pull
+  requests, review comments, or review decisions, route through the shared PR
+  review evidence workflow in `skills/superteam/pr-review-evidence.md`.
+  Keep this cue narrow to evidence-grounded PR/review analysis tasks; do not
+  repurpose it for normal issue execution, CI triage, or generic code review.
+  Live external PR feedback handling remains `Finisher`-owned.
+
   ## Done-report contract reference
   See done-report contracts in skills/superteam/SKILL.md (#done-report-contracts). This file does not restate the fields.
 

--- a/skills/superteam/pr-review-evidence.md
+++ b/skills/superteam/pr-review-evidence.md
@@ -1,0 +1,77 @@
+# PR review evidence workflow
+
+Use this workflow when a Superteam orchestration must produce recommendations
+grounded in recent pull requests and review evidence.
+
+## Flow
+
+1. Resolve repository and time window from the operator prompt. If no range is
+   supplied, use a recent merged-PR window.
+2. Collect recent merged PR metadata: PR number, title, author, merge date,
+   merge SHA, changed-file summary, linked issues, labels, and review-decision
+   summary.
+3. Collect direct review evidence when available: review comments, review
+   bodies, review-thread discussions, requested changes, approvals, bot review
+   findings, and resolution state.
+4. Assemble an evidence ledger for every collected signal.
+5. Activate the fallback ladder when direct review evidence is incomplete or
+   unavailable.
+6. Render recommendations with per-item attribution fields.
+
+## Evidence ledger schema
+
+Record each signal with:
+
+- `tier`
+- `source`
+- `locator`
+- `summary`
+- `availability_status`
+
+## Tier taxonomy
+
+- `direct-review`: highest-confidence source; review comments and thread text.
+- `pr-metadata`: contextual support from merged PR surfaces.
+- `fallback-proxy`: commit history, commit messages, local diffs, issue text,
+  and repository docs only when the workflow must continue without direct
+  review evidence.
+
+## Fallback ladder and confidence rules
+
+Fallback is mandatory and explicit when any of these occur:
+
+- review comments are missing
+- permissions are missing
+- connector access is unavailable
+- evidence tooling fails
+- zero recent PRs match the requested window
+
+When fallback activates:
+
+- set `fallback_used` to `true`
+- disclose the missing or failed source in `source_summary`
+- downgrade confidence language to match available evidence tier
+
+When direct review evidence is present, keep `fallback_used` as `false` unless
+mixed evidence required proxy support.
+
+## Recommendation output contract
+
+Each recommendation item includes:
+
+- `evidence_tier`
+- `source_summary`
+- `confidence`
+- `fallback_used`
+
+Example:
+
+```yaml
+recommendation: Standardize reviewer-facing migration checklists for schema PRs.
+evidence_tier: direct-review
+source_summary: |
+  Direct review comments on PRs #418 and #423 flagged missing rollback notes;
+  PR metadata from #410 shows repeat incidents. No connector fallback used.
+confidence: high
+fallback_used: false
+```

--- a/skills/superteam/quality-guards.md
+++ b/skills/superteam/quality-guards.md
@@ -17,6 +17,9 @@ red-flag catalog used during review, pressure tests, and skill-improver loops.
 | "Gate 1 was approved last session; the operator just told me so, so no need to re-open it." | Gate 1 is durably observable iff a plan doc has been committed on the branch (R15). Ephemeral in-session approval is not durable. Operator memory is not the durable signal; the committed plan doc is. |
 | "Removing `Loopback:` trailers means we can skip local review on a later run." | When implementation exists without a PR and prior local findings cannot be proven resolved from visible state, route through `Reviewer` before `Finisher` can publish. |
 | "A direct operator requirement change during finish is not PR feedback, so Finisher can handle it." | Requirement-bearing deltas route spec-first regardless of source. PR feedback, human-test feedback, and direct operator prompts all return to `Brainstormer`, then `Planner`, then `Executor` before `Finisher` ready/shutdown can resume. |
+| "If direct review evidence is missing, we can continue from PR metadata or commit history without saying fallback was used." | Silent fallback is forbidden. Missing or failed direct review evidence must be disclosed and recommendations must carry explicit `fallback_used` plus downgraded confidence. |
+| "Commit messages say roughly the same thing reviewers would have said, so we can present them as review evidence." | Source laundering is forbidden. Commit history, commit messages, local diffs, and issue text are `fallback-proxy` evidence only and cannot be represented as direct reviewer feedback. |
+| "This PR/review analysis workflow can also own live PR comment handling now." | Ownership does not move. Analysis workflows stay analysis-only, and live external PR feedback handling remains `Finisher`-owned. |
 | "No execution-mode tool is available, so every `/superteam` invocation must halt." | Missing execution capability blocks only routes that require execute-phase delegation. Approval, review, and `Finisher` status work can continue through their owning teammate. |
 | "We can replace `Loopback:` trailers with another hidden marker." | Feedback routing must resume from visible artifacts, PR state, and operator prompts; do not add sidecar state, branch labels, or new commit footers. |
 | "The operator said 'faster' / 'this is taking forever'; that is basically asking for inline." | Inline is auto-selected never. Only unambiguous tokens (`inline`, `run inline`, `execute in this session`) are operator overrides per R14. Ambiguous framing is not. Not even when the CTO is cited. Not even under deadline pressure. |
@@ -68,6 +71,11 @@ red-flag catalog used during review, pressure tests, and skill-improver loops.
 - A prior in-session "approve" is treated as Gate 1 approval when no plan doc has been committed on the branch.
 - Issues are silently switched mid-run when the prompt names a different issue without explicit operator confirmation.
 - Required `Loopback:` commit trailers or another hidden workflow-state marker are reintroduced.
+- Recommendations grounded in PR/review analysis omit `fallback_used`.
+- Recommendations grounded in PR/review analysis omit `evidence_tier`,
+  `source_summary`, or `confidence`.
+- Output follows commit-history framing while direct review comments are
+  available.
 - Fresh-session resume from implementation work with no PR skips `Reviewer` before `Finisher` publication when local review resolution is not visible.
 - An execute-phase delegation prompt names `superpowers:executing-plans` as the entry skill when the resolved mode is `team mode` or `subagent-driven`.
 - An execute-phase delegation omits the resolved execution mode and asks the developer to choose.


### PR DESCRIPTION
## Summary

- Adds a reusable Superteam PR review evidence workflow with source tiers, fallback disclosure, and per-recommendation attribution.
- Adds RED/GREEN pressure-test evidence plus reusable pressure scenarios for the new workflow contract.
- Adds narrow Team Lead routing cues for both Codex and Claude host surfaces while preserving Finisher ownership of live PR feedback.

## Linked issue

- Closes #81

## Acceptance criteria

### AC-81-1

Documented the primary path for collecting recent merged PR metadata and direct review evidence before recommendations are produced.

- [x] Markdown evidence — pnpm lint:md | local worktree | @tlmader | 2026-05-08T04:43:37Z
- [ ] Manual test: 1. Open `skills/superteam/SKILL.md` and `skills/superteam/pr-review-evidence.md`. 2. Confirm the workflow starts from recent merged PRs, then collects PR metadata and direct review evidence before fallback.

### AC-81-2

Documented visible fallback behavior for unavailable direct review evidence, including fallback tier and confidence downgrade.

- [x] Markdown evidence — pnpm lint:md | local worktree | @tlmader | 2026-05-08T04:43:37Z
- [ ] ⚠️ E2E gap: Live GitHub review-source scenarios were not run against a bound repository data stream; the PR includes contract-level RED/GREEN pressure evidence instead.
- [ ] Manual test: 1. Open the RED/GREEN baseline artifact. 2. Confirm PT-81-2 and PT-81-3 disclose fallback use and the residual live-source limitation.

### AC-81-3

Every workflow recommendation now requires `evidence_tier`, `source_summary`, `confidence`, and `fallback_used` attribution fields.

- [x] Markdown evidence — pnpm lint:md | local worktree | @tlmader | 2026-05-08T04:43:37Z
- [ ] Manual test: 1. Open `skills/superteam/pr-review-evidence.md`. 2. Confirm the recommendation contract and example include the required attribution fields.

### AC-81-4

The workflow is reusable by name from Superteam routing surfaces and pressure-test guidance instead of being a one-off collection method.

- [x] Markdown evidence — pnpm lint:md | local worktree | @tlmader | 2026-05-08T04:43:37Z
- [ ] Manual test: 1. Inspect the Codex and Claude Team Lead role files. 2. Confirm both route evidence-grounded PR/review analysis through the shared workflow and keep live PR feedback Finisher-owned.

## Validation

- `pnpm lint:md` passed with 0 errors.
- Focused `rg` checks confirmed evidence tiers, fallback fields, Team Lead cues, and Finisher ownership text.
- Local pre-publish Reviewer pass was clean after the Claude Team Lead parity fix.
- Skill-improver primary review was unavailable because the plugin-dev skill-reviewer path was not present; fallback writing-skills review dimensions were recorded.

## Docs updated

- [x] Updated in this PR