### PR TITLE
docs: #84 link archived repo to skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Superteam
 
+> **Archive notice:** Superteam now lives in
+> [`patinaproject/skills`](https://github.com/patinaproject/skills). Use that
+> repository for the current plugin, issues, and updates.
+
 Build with a team of agents using Superpowers.
 
 `superteam` is a Claude Code + Codex plugin. It ships an installable orchestration skill under `skills/superteam/` and is distributed through the [`patinaproject/skills`](https://github.com/patinaproject/skills) marketplace.


### PR DESCRIPTION
## Summary

- Add an archive notice at the top of the README.
- Point visitors to `patinaproject/skills` for the current plugin, issues, and updates.

## Linked issue

- Related to #84. This PR completes the README handoff; repository archival must happen through the GitHub repository setting after merge.

## Acceptance criteria

### AC-84-1

Visitors can clearly navigate from this repository to the maintained `patinaproject/skills` repository.

- [x] Local evidence — pnpm lint:md | local worktree | @tlmader | 2026-05-12T15:03:50Z
- [ ] Manual test: 1. Open the README on GitHub. 2. Confirm the archive notice appears at the top. 3. Confirm the `patinaproject/skills` link opens https://github.com/patinaproject/skills.

### AC-84-2

Deferred until after this PR merges because archiving is a repository setting, not a file change.

## Validation

- `pnpm lint:md`
- Commit hook ran `markdownlint-cli2` on the staged README and `pnpm check:versions`.

## Docs updated

- [x] Updated in this PR